### PR TITLE
improve log messages for DHEC key exchange

### DIFF
--- a/src/main/java/com/jcraft/jsch/DHECN.java
+++ b/src/main/java/com/jcraft/jsch/DHECN.java
@@ -52,7 +52,8 @@ public abstract class DHECN extends KeyExchange{
   protected String sha_name; 
   protected int key_size;
 
-  public void init(Session session,
+  @Override
+public void init(Session session,
 		   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
     this.session=session;
     this.V_S=V_S;      
@@ -104,11 +105,16 @@ public abstract class DHECN extends KeyExchange{
     state=SSH_MSG_KEX_ECDH_REPLY;
   }
 
-  public boolean next(Buffer _buf) throws Exception{
+  @Override
+public boolean next(Buffer _buf) throws Exception{
     int i,j;
     switch(state){
+
     case SSH_MSG_KEX_ECDH_REPLY:
+        if( JSch.getLogger().isEnabled( Logger.INFO ) )
+        {
                 JSch.getLogger().log( Logger.INFO, "Received SSH_MSG_KEX_ECDH_REPLY" );
+        }
       // The server responds with:
       // byte     SSH_MSG_KEX_ECDH_REPLY
       // string   K_S, server's public host key
@@ -183,5 +189,6 @@ public abstract class DHECN extends KeyExchange{
     return false;
   }
 
-  public int getState(){return state; }
+  @Override
+public int getState(){return state; }
 }

--- a/src/main/java/com/jcraft/jsch/DHECN.java
+++ b/src/main/java/com/jcraft/jsch/DHECN.java
@@ -96,8 +96,7 @@ public abstract class DHECN extends KeyExchange{
     session.write(packet);
 
     if(JSch.getLogger().isEnabled(Logger.INFO)){
-      JSch.getLogger().log(Logger.INFO, 
-                           "SSH_MSG_KEX_ECDH_INIT sent");
+            JSch.getLogger().log( Logger.INFO, "SSH_MSG_KEX_ECDH_INIT sent with EC nistp" + key_size );
       JSch.getLogger().log(Logger.INFO, 
                            "expecting SSH_MSG_KEX_ECDH_REPLY");
     }
@@ -109,6 +108,7 @@ public abstract class DHECN extends KeyExchange{
     int i,j;
     switch(state){
     case SSH_MSG_KEX_ECDH_REPLY:
+                JSch.getLogger().log( Logger.INFO, "Received SSH_MSG_KEX_ECDH_REPLY" );
       // The server responds with:
       // byte     SSH_MSG_KEX_ECDH_REPLY
       // string   K_S, server's public host key

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -1090,7 +1090,7 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
 	int reason_id=buf.getInt();
         if(JSch.getLogger().isEnabled(Logger.INFO)){
           JSch.getLogger().log(Logger.INFO,
-                               "Received SSH_MSG_UNIMPLEMENTED for "+reason_id);
+                        "Received SSH_MSG_UNIMPLEMENTED to message sequence number " + reason_id );
         }
       }
       else if(type==SSH_MSG_DEBUG){

--- a/src/main/java/com/jcraft/jsch/SftpException.java
+++ b/src/main/java/com/jcraft/jsch/SftpException.java
@@ -30,22 +30,17 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.jcraft.jsch;
 
 public class SftpException extends Exception{
-  //private static final long serialVersionUID=-5616888495583253811L;
-  public int id;
-  private Throwable cause=null;
+    private static final long serialVersionUID = 1786321820685541562L;
+    public int id;
   public SftpException (int id, String message) {
     super(message);
     this.id=id;
   }
   public SftpException (int id, String message, Throwable e) {
-    super(message);
+    super(message,e);
     this.id=id;
-    this.cause=e;
   }
   public String toString(){
     return id+": "+getMessage();
-  }
-  public Throwable getCause(){
-    return this.cause;
   }
 }


### PR DESCRIPTION
The log message upon receiving SSH_MSG_UNIMPLEMENTED after a DHEC key exchange is a bit confusing. Many users think that the exchange has failed. These changes should make the process of kex more clear.