### PR TITLE
Fix bug with AEAD ciphers when compression is used.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/jcraft/jsch/DH25519.java
+++ b/src/main/java/com/jcraft/jsch/DH25519.java
@@ -33,5 +33,6 @@ public class DH25519 extends DHXEC {
   public DH25519(){
     sha_name="sha-256";
     curve_name="X25519";
+    key_len=32;
   }
 }

--- a/src/main/java/com/jcraft/jsch/DHECN.java
+++ b/src/main/java/com/jcraft/jsch/DHECN.java
@@ -117,8 +117,8 @@ public abstract class DHECN extends KeyExchange{
       j=_buf.getInt();
       j=_buf.getByte();
       j=_buf.getByte();
-      if(j!=31){
-	System.err.println("type: must be 31 "+j);
+      if(j!=SSH_MSG_KEX_ECDH_REPLY){
+	System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY "+j);
 	return false;
       }
 

--- a/src/main/java/com/jcraft/jsch/DHXEC.java
+++ b/src/main/java/com/jcraft/jsch/DHXEC.java
@@ -55,6 +55,7 @@ public abstract class DHXEC extends KeyExchange{
 
   protected String sha_name;
   protected String curve_name;
+  protected int key_len;
 
   public void init(Session session,
 		   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
@@ -82,7 +83,7 @@ public abstract class DHXEC extends KeyExchange{
     try{
       Class c=Class.forName(session.getConfig("xdh"));
       xdh=(XDH)(c.newInstance());
-      xdh.init(curve_name);
+      xdh.init(curve_name, key_len);
 
       Q_C = xdh.getQ();
       buf.putString(Q_C);
@@ -121,8 +122,8 @@ public abstract class DHXEC extends KeyExchange{
       j=_buf.getInt();
       j=_buf.getByte();
       j=_buf.getByte();
-      if(j!=31){
-	System.err.println("type: must be 31 "+j);
+      if(j!=SSH_MSG_KEX_ECDH_REPLY){
+	System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY "+j);
 	return false;
       }
 
@@ -167,6 +168,11 @@ public abstract class DHXEC extends KeyExchange{
       //   key and the local private key scalar.  The 32 or 56 bytes of X are
       //   converted into K by interpreting the octets as an unsigned fixed-
       //   length integer encoded in network byte order.
+      //
+      //   The mpint K is then encoded using the process described in Section 5
+      //   of [RFC4251], and the resulting bytes are fed as described in
+      //   [RFC4253] to the key exchange method's hash function to generate
+      //   encryption keys.
       buf.reset();
       buf.putString(V_C); buf.putString(V_S);
       buf.putString(I_C); buf.putString(I_S);

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -148,7 +148,7 @@ public class JSch{
     config.put("PubkeyAcceptedKeyTypes", "ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256,rsa-sha2-512,ssh-rsa");
 
     config.put("CheckCiphers", "aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-ctr,arcfour,arcfour128,arcfour256");
-    config.put("CheckMacs", "hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,,hmac-sha2-256,hmac-sha2-512");
+    config.put("CheckMacs", "hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512");
     config.put("CheckKexes", "curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha1,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521");
     config.put("CheckSignatures", "rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521");
     config.put("FingerprintHash", "sha256");

--- a/src/main/java/com/jcraft/jsch/JSchException.java
+++ b/src/main/java/com/jcraft/jsch/JSchException.java
@@ -31,7 +31,6 @@ package com.jcraft.jsch;
 
 public class JSchException extends Exception{
   //private static final long serialVersionUID=-1319309923966731989L;
-  private Throwable cause=null;
   public JSchException () {
     super();
   }
@@ -39,10 +38,6 @@ public class JSchException extends Exception{
     super(s);
   }
   public JSchException (String s, Throwable e) {
-    super(s);
-    this.cause=e;
-  }
-  public Throwable getCause(){
-    return this.cause;
+    super(s, e);
   }
 }

--- a/src/main/java/com/jcraft/jsch/KeyExchange.java
+++ b/src/main/java/com/jcraft/jsch/KeyExchange.java
@@ -248,7 +248,7 @@ public abstract class KeyExchange{
 
       if(JSch.getLogger().isEnabled(Logger.INFO)){
         JSch.getLogger().log(Logger.INFO, 
-                             "ssh_rsa_verify: signature "+result);
+                             "ssh_rsa_verify: "+foo+" signature "+result);
       }
     }
     else if(alg.equals("ssh-dss")){
@@ -335,6 +335,11 @@ public abstract class KeyExchange{
       sig.update(H);
 
       result=sig.verify(sig_of_H);
+
+      if(JSch.getLogger().isEnabled(Logger.INFO)){
+        JSch.getLogger().log(Logger.INFO, 
+                             "ssh_ecdsa_verify: "+alg+" signature "+result);
+      }
     }
     else{
       System.err.println("unknown alg");

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -565,7 +565,7 @@ public class Session implements Runnable{
       //e.printStackTrace();
       if(e instanceof RuntimeException) throw (RuntimeException)e;
       if(e instanceof JSchException) throw (JSchException)e;
-      throw new JSchException("Session.connect: "+e);
+      throw new JSchException("Session.connect: "+e, e);
     }
     finally{
       Util.bzero(this.password);

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -982,6 +982,8 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
         if(isAEAD){
           s2ccipher.updateAAD(buf.buffer, 0, 4);
           s2ccipher.doFinal(buf.buffer, 4, j, buf.buffer, 4);
+          // don't include AEAD tag size in buf so that decompression works below
+          buf.index -= s2ccipher.getTagSize();
         }
         else{
           s2cmac.update(seqi);

--- a/src/main/java/com/jcraft/jsch/XDH.java
+++ b/src/main/java/com/jcraft/jsch/XDH.java
@@ -30,7 +30,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.jcraft.jsch;
 
 public interface XDH {
-  void init(String name) throws Exception;
+  void init(String name, int keylen) throws Exception;
   byte[] getSecret(byte[] u) throws Exception;
   byte[] getQ() throws Exception;
   boolean validate(byte[] u) throws Exception;

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -204,27 +205,42 @@ public class AlgorithmsIT {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "aes256-gcm@openssh.com",
-        "aes128-gcm@openssh.com",
-        "aes256-ctr",
-        "aes192-ctr",
-        "aes128-ctr",
-        "aes256-cbc",
-        "aes192-cbc",
-        "aes128-cbc",
-        "3des-cbc",
-        "blowfish-cbc",
-        "arcfour",
-        "arcfour256",
-        "arcfour128"
+  @CsvSource(
+      value = {
+        "aes256-gcm@openssh.com,none",
+        "aes256-gcm@openssh.com,zlib@openssh.com",
+        "aes128-gcm@openssh.com,none",
+        "aes128-gcm@openssh.com,zlib@openssh.com",
+        "aes256-ctr,none",
+        "aes256-ctr,zlib@openssh.com",
+        "aes192-ctr,none",
+        "aes192-ctr,zlib@openssh.com",
+        "aes128-ctr,none",
+        "aes128-ctr,zlib@openssh.com",
+        "aes256-cbc,none",
+        "aes256-cbc,zlib@openssh.com",
+        "aes192-cbc,none",
+        "aes192-cbc,zlib@openssh.com",
+        "aes128-cbc,none",
+        "aes128-cbc,zlib@openssh.com",
+        "3des-cbc,none",
+        "3des-cbc,zlib@openssh.com",
+        "blowfish-cbc,none",
+        "blowfish-cbc,zlib@openssh.com",
+        "arcfour,none",
+        "arcfour,zlib@openssh.com",
+        "arcfour256,none",
+        "arcfour256,zlib@openssh.com",
+        "arcfour128,none",
+        "arcfour128,zlib@openssh.com"
       })
-  public void testCiphers(String cipher) throws Exception {
+  public void testCiphers(String cipher, String compression) throws Exception {
     JSch ssh = createRSAIdentity();
     Session session = createSession(ssh);
     session.setConfig("cipher.s2c", cipher);
     session.setConfig("cipher.c2s", cipher);
+    session.setConfig("compression.s2c", compression);
+    session.setConfig("compression.c2s", compression);
     doSftp(session);
 
     String expectedS2C = String.format("kex: server->client cipher: %s.*", cipher);
@@ -234,26 +250,40 @@ public class AlgorithmsIT {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "hmac-sha2-512-etm@openssh.com",
-        "hmac-sha2-256-etm@openssh.com",
-        "hmac-sha1-etm@openssh.com",
-        "hmac-sha1-96-etm@openssh.com",
-        "hmac-md5-etm@openssh.com",
-        "hmac-md5-96-etm@openssh.com",
-        "hmac-sha2-512",
-        "hmac-sha2-256",
-        "hmac-sha1",
-        "hmac-sha1-96",
-        "hmac-md5",
-        "hmac-md5-96"
+  @CsvSource(
+      value = {
+        "hmac-sha2-512-etm@openssh.com,none",
+        "hmac-sha2-512-etm@openssh.com,zlib@openssh.com",
+        "hmac-sha2-256-etm@openssh.com,none",
+        "hmac-sha2-256-etm@openssh.com,zlib@openssh.com",
+        "hmac-sha1-etm@openssh.com,none",
+        "hmac-sha1-etm@openssh.com,zlib@openssh.com",
+        "hmac-sha1-96-etm@openssh.com,none",
+        "hmac-sha1-96-etm@openssh.com,zlib@openssh.com",
+        "hmac-md5-etm@openssh.com,none",
+        "hmac-md5-etm@openssh.com,zlib@openssh.com",
+        "hmac-md5-96-etm@openssh.com,none",
+        "hmac-md5-96-etm@openssh.com,zlib@openssh.com",
+        "hmac-sha2-512,none",
+        "hmac-sha2-512,zlib@openssh.com",
+        "hmac-sha2-256,none",
+        "hmac-sha2-256,zlib@openssh.com",
+        "hmac-sha1,none",
+        "hmac-sha1,zlib@openssh.com",
+        "hmac-sha1-96,none",
+        "hmac-sha1-96,zlib@openssh.com",
+        "hmac-md5,none",
+        "hmac-md5,zlib@openssh.com",
+        "hmac-md5-96,none",
+        "hmac-md5-96,zlib@openssh.com"
       })
-  public void testMACs(String mac) throws Exception {
+  public void testMACs(String mac, String compression) throws Exception {
     JSch ssh = createRSAIdentity();
     Session session = createSession(ssh);
     session.setConfig("mac.s2c", mac);
     session.setConfig("mac.c2s", mac);
+    session.setConfig("compression.s2c", compression);
+    session.setConfig("compression.c2s", compression);
     // Make sure a non-AEAD cipher is used
     session.setConfig("cipher.s2c", "aes128-ctr");
     session.setConfig("cipher.c2s", "aes128-ctr");

--- a/src/test/resources/docker/sshd_config
+++ b/src/test/resources/docker/sshd_config
@@ -17,4 +17,4 @@ KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,
 HostKeyAlgorithms ecdsa-sha2-nistp521,ecdsa-sha2-nistp384,ecdsa-sha2-nistp256,rsa-sha2-512,rsa-sha2-256,ssh-rsa,ssh-dss
 Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc,blowfish-cbc,arcfour,arcfour256,arcfour128
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-96-etm@openssh.com,hmac-sha1-96,hmac-md5-etm@openssh.com,hmac-md5,hmac-md5-96-etm@openssh.com,hmac-md5-96
-LogLevel DEBUG1
+LogLevel DEBUG3


### PR DESCRIPTION
The inflater code expects the end of buffer to not include the AEAD tag.

I updated the integration tests to always test every cipher & mac both with and without compression enabled to hopefully catch issues like this in the future.