### PR TITLE
Try to fix intermittent test failures while checking log messages.

### DIFF
--- a/src/test/java/com/jcraft/jsch/Algorithms2IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms2IT.java
@@ -230,7 +230,7 @@ public class Algorithms2IT {
 
   private static ListAppender<ILoggingEvent> getListAppender(Class<?> clazz) {
     Logger logger = (Logger) LoggerFactory.getLogger(clazz);
-    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    ListAppender<ILoggingEvent> listAppender = new ListAppender2<>();
     logger.addAppender(listAppender);
     return listAppender;
   }

--- a/src/test/java/com/jcraft/jsch/Algorithms3IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms3IT.java
@@ -165,7 +165,7 @@ public class Algorithms3IT {
 
   private static ListAppender<ILoggingEvent> getListAppender(Class<?> clazz) {
     Logger logger = (Logger) LoggerFactory.getLogger(clazz);
-    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    ListAppender<ILoggingEvent> listAppender = new ListAppender2<>();
     logger.addAppender(listAppender);
     return listAppender;
   }

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -493,7 +493,7 @@ public class AlgorithmsIT {
 
   private static ListAppender<ILoggingEvent> getListAppender(Class<?> clazz) {
     Logger logger = (Logger) LoggerFactory.getLogger(clazz);
-    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    ListAppender<ILoggingEvent> listAppender = new ListAppender2<>();
     logger.addAppender(listAppender);
     return listAppender;
   }

--- a/src/test/java/com/jcraft/jsch/ListAppender2.java
+++ b/src/test/java/com/jcraft/jsch/ListAppender2.java
@@ -1,0 +1,15 @@
+package com.jcraft.jsch;
+
+import ch.qos.logback.core.read.ListAppender;
+
+public class ListAppender2<E> extends ListAppender<E> {
+
+  @Override
+  protected void append(E e) {
+    // Avoid append messages after appender is stopped to avoid ConcurrentModificationException's
+    // when examining the List of events.
+    if (super.started) {
+      super.append(e);
+    }
+  }
+}


### PR DESCRIPTION
This manifests as unexpected ConcurrentModificationException's being
thrown because the TestContainer is still emitting log messages while
the tests are actively examining the list of previously captured log
messages.