### PR TITLE
.decrypt(null) should return `true` on decrypted keys (deferred) #42

### DIFF
--- a/src/test/java/com/jcraft/jsch/KeyPairTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairTest.java
@@ -98,4 +98,22 @@ class KeyPairTest {
         });
     }
 
+    @Test
+    void decryptEncryptedOpensshKey() throws URISyntaxException, JSchException {
+        final JSch jSch = new JSch();
+        final String prvkey = Paths.get(ClassLoader.getSystemResource("encrypted_openssh_private_key_dsa").toURI()).toFile().getAbsolutePath();
+        assertTrue(new File(prvkey).exists());
+        IdentityFile identity = IdentityFile.newInstance(prvkey, null, jSch);
+
+        // Decrypt the key file
+        assertTrue(identity.getKeyPair().decrypt("secret123"));
+
+        // From now on, the pair now longer counts as encrypted
+        assertFalse(identity.getKeyPair().isEncrypted());
+
+        // An unencrypted key pair should allow #decrypt(null)
+        // com.jcraft.jsch.UserAuthPublicKey relies on this
+        assertTrue(identity.getKeyPair().decrypt((byte[])null));
+    }
+
 }


### PR DESCRIPTION
Add new test `KeyPairTest#decryptEncryptedOpensshKey` which
 1. creates an identity based on an encrypted key in OpenSSH format.
 2. decrypts the key
 3. checks whether the key stil counts as "encrypted" (shouldn't)
 4. calls decrypt without passphrase (which is what `com.jcraft.jsch.UserAuthPublicKey` does).
 
This is a reproduction for #42 

