### PR TITLE
Make it possible to run tests on Windows

### DIFF
--- a/src/test/java/com/jcraft/jsch/Algorithms2IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms2IT.java
@@ -244,7 +244,7 @@ public class Algorithms2IT {
   }
 
   private String getResourceFile(String fileName) {
-    return this.getClass().getClassLoader().getResource(fileName).getPath();
+    return ResourceUtil.getResourceFile(getClass(), fileName);
   }
 
   private static ListAppender<ILoggingEvent> getListAppender(Class<?> clazz) {

--- a/src/test/java/com/jcraft/jsch/Algorithms3IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms3IT.java
@@ -179,7 +179,7 @@ public class Algorithms3IT {
   }
 
   private String getResourceFile(String fileName) {
-    return this.getClass().getClassLoader().getResource(fileName).getPath();
+    return ResourceUtil.getResourceFile(getClass(), fileName);
   }
 
   private static ListAppender<ILoggingEvent> getListAppender(Class<?> clazz) {

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -517,7 +517,7 @@ public class AlgorithmsIT {
   }
 
   private String getResourceFile(String fileName) {
-    return this.getClass().getClassLoader().getResource(fileName).getPath();
+    return ResourceUtil.getResourceFile(getClass(), fileName);
   }
 
   private static ListAppender<ILoggingEvent> getListAppender(Class<?> clazz) {

--- a/src/test/java/com/jcraft/jsch/ResourceUtil.java
+++ b/src/test/java/com/jcraft/jsch/ResourceUtil.java
@@ -1,0 +1,13 @@
+package com.jcraft.jsch;
+
+import java.io.File;
+
+public class ResourceUtil {
+  public static String getResourceFile(Class<?> clazz, String fileName) {
+    String path = clazz.getClassLoader().getResource(fileName).getFile();
+    // Note: on Windows the returned path can be in the form: /C:/<path>
+    // to strip the initial / in a platform independent way we need to
+    // create a java.io.File and take it's absolute path
+    return new File(path).getAbsolutePath();
+  }
+}


### PR DESCRIPTION
Paths to resources on Windows have a form: /<drive letter>:/<path>, so the initial / should be stripped out before a File instance is created.