### PR TITLE
Allow ssh-agent keys that are unsupported

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,7 @@ As I explained in a [blog post](http://www.matez.de/index.php/2020/06/22/the-fut
   * This library is a Multi-Release-jar, which means that you can only use certain features when a more recent Java version is used.
     * In order to use ssh-ed25519 & ssh-ed448, you must use at least Java 15.
     * In order to use curve25519-sha256, curve448-sha512 & chacha20-poly1305@<!-- -->openssh.com, you must use at least Java 11.
+  * As of the [0.1.66](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.66) release, these algorithms can now be used with older Java releases if [Bouncy Castle](https://www.bouncycastle.org/) (bcprov-jdk15on) is added to the classpath.
 
 ## Changes since fork:
 * [0.1.66](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.66)
@@ -99,6 +100,13 @@ As I explained in a [blog post](http://www.matez.de/index.php/2020/06/22/the-fut
     * See `examples/JSchWithAgentProxy.java` for simple example
     * ssh-agent support requires either [Java 16's JEP 380](https://openjdk.java.net/jeps/380) or the addition of [junixsocket](https://github.com/kohlschutter/junixsocket) to classpath
     * Pageant support is untested & requires the addition of [JNA](https://github.com/java-native-access/jna) to classpath
+  * Added support for the following algorithms with older Java releases by using [Bouncy Castle](https://www.bouncycastle.org/):
+    * ssh-ed25519
+    * ssh-ed448
+    * curve25519-sha256
+    * curve25519-sha256@<!-- -->libssh.org
+    * curve448-sha512
+    * chacha20-poly1305@<!-- -->openssh.com
 * [0.1.65](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.65)
   * Added system properties to allow manipulation of various crypto algorithms used by default
   * Integrated JZlib, allowing use of zlib@<!-- -->openssh.com & zlib compressions without the need to provide the JZlib jar-file

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.69</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-common</artifactId>
             <version>${junixsocket.version}</version>
@@ -335,6 +341,7 @@
                         <version>0.8.7</version>
                         <configuration>
                             <excludes>
+                                <exclude>com/jcraft/jsch/JavaVersion.class</exclude>
                                 <exclude>com/jcraft/jsch/UnixDomainSocketFactory.class</exclude>
                             </excludes>
                         </configuration>

--- a/src/main/java/com/jcraft/jsch/DHXEC.java
+++ b/src/main/java/com/jcraft/jsch/DHXEC.java
@@ -89,7 +89,7 @@ public abstract class DHXEC extends KeyExchange{
       Q_C = xdh.getQ();
       buf.putString(Q_C);
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
       throw new JSchException(e.toString(), e);
     }
 

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -106,13 +106,9 @@ public class JSch{
 
     config.put("ecdh-sha2-nistp", "com.jcraft.jsch.jce.ECDHN");
 
-    config.put("ssh-ed25519", "com.jcraft.jsch.jce.SignatureEd25519");
-    config.put("ssh-ed448",   "com.jcraft.jsch.jce.SignatureEd448");
-
     config.put("curve25519-sha256",            "com.jcraft.jsch.DH25519");
     config.put("curve25519-sha256@libssh.org", "com.jcraft.jsch.DH25519");
     config.put("curve448-sha512",              "com.jcraft.jsch.DH448");
-    config.put("xdh", "com.jcraft.jsch.jce.XDH");
 
     config.put("dh",            "com.jcraft.jsch.jce.DH");
     config.put("3des-cbc",      "com.jcraft.jsch.jce.TripleDESCBC");
@@ -156,12 +152,10 @@ public class JSch{
     config.put("keypairgen.dsa",   "com.jcraft.jsch.jce.KeyPairGenDSA");
     config.put("keypairgen.rsa",   "com.jcraft.jsch.jce.KeyPairGenRSA");
     config.put("keypairgen.ecdsa", "com.jcraft.jsch.jce.KeyPairGenECDSA");
-    config.put("keypairgen.eddsa", "com.jcraft.jsch.jce.KeyPairGenEdDSA");
     config.put("random",        "com.jcraft.jsch.jce.Random");
 
     config.put("none",           "com.jcraft.jsch.CipherNone");
 
-    config.put("chacha20-poly1305@openssh.com",    "com.jcraft.jsch.jce.ChaCha20Poly1305");
     config.put("aes128-gcm@openssh.com",    "com.jcraft.jsch.jce.AES128GCM");
     config.put("aes256-gcm@openssh.com",    "com.jcraft.jsch.jce.AES256GCM");
 
@@ -188,6 +182,26 @@ public class JSch{
     config.put("zlib@openssh.com", "com.jcraft.jsch.jzlib.Compression");
 
     config.put("pbkdf", "com.jcraft.jsch.jce.PBKDF");
+
+    if(JavaVersion.getVersion()>=11){
+      config.put("chacha20-poly1305@openssh.com", "com.jcraft.jsch.jce.ChaCha20Poly1305");
+      config.put("xdh", "com.jcraft.jsch.jce.XDH");
+    }
+    else{
+      config.put("chacha20-poly1305@openssh.com", "com.jcraft.jsch.bc.ChaCha20Poly1305");
+      config.put("xdh", "com.jcraft.jsch.bc.XDH");
+    }
+
+    if(JavaVersion.getVersion()>=15){
+      config.put("keypairgen.eddsa", "com.jcraft.jsch.jce.KeyPairGenEdDSA");
+      config.put("ssh-ed25519", "com.jcraft.jsch.jce.SignatureEd25519");
+      config.put("ssh-ed448", "com.jcraft.jsch.jce.SignatureEd448");
+    }
+    else{
+      config.put("keypairgen.eddsa", "com.jcraft.jsch.bc.KeyPairGenEdDSA");
+      config.put("ssh-ed25519", "com.jcraft.jsch.bc.SignatureEd25519");
+      config.put("ssh-ed448", "com.jcraft.jsch.bc.SignatureEd448");
+    }
 
     config.put("StrictHostKeyChecking",  "ask");
     config.put("HashKnownHosts",  "no");

--- a/src/main/java/com/jcraft/jsch/JavaVersion.java
+++ b/src/main/java/com/jcraft/jsch/JavaVersion.java
@@ -1,0 +1,8 @@
+package com.jcraft.jsch;
+
+final class JavaVersion {
+
+  static int getVersion() {
+    return 8;
+  }
+}

--- a/src/main/java/com/jcraft/jsch/KeyExchange.java
+++ b/src/main/java/com/jcraft/jsch/KeyExchange.java
@@ -143,18 +143,25 @@ public abstract class KeyExchange{
       }
     }
 
-    Class<?> _s2cclazz=Class.forName(session.getConfig(guess[PROPOSAL_ENC_ALGS_STOC]));
-    Cipher _s2ccipher=(Cipher)(_s2cclazz.getDeclaredConstructor().newInstance());
-    boolean _s2cAEAD=_s2ccipher.isAEAD();
-    if(_s2cAEAD){
-      guess[PROPOSAL_MAC_ALGS_STOC]=null;
-    }
+    boolean _s2cAEAD=false;
+    boolean _c2sAEAD=false;
+    try{
+      Class<?> _s2cclazz=Class.forName(session.getConfig(guess[PROPOSAL_ENC_ALGS_STOC]));
+      Cipher _s2ccipher=(Cipher)(_s2cclazz.getDeclaredConstructor().newInstance());
+      _s2cAEAD=_s2ccipher.isAEAD();
+      if(_s2cAEAD){
+        guess[PROPOSAL_MAC_ALGS_STOC]=null;
+      }
 
-    Class<?> _c2sclazz=Class.forName(session.getConfig(guess[PROPOSAL_ENC_ALGS_CTOS]));
-    Cipher _c2scipher=(Cipher)(_c2sclazz.getDeclaredConstructor().newInstance());
-    boolean _c2sAEAD=_c2scipher.isAEAD();
-    if(_c2sAEAD){
-      guess[PROPOSAL_MAC_ALGS_CTOS]=null;
+      Class<?> _c2sclazz=Class.forName(session.getConfig(guess[PROPOSAL_ENC_ALGS_CTOS]));
+      Cipher _c2scipher=(Cipher)(_c2sclazz.getDeclaredConstructor().newInstance());
+      _c2sAEAD=_c2scipher.isAEAD();
+      if(_c2sAEAD){
+        guess[PROPOSAL_MAC_ALGS_CTOS]=null;
+      }
+    }
+    catch(Exception | NoClassDefFoundError e){
+      throw new JSchException(e.toString(), e);
     }
 
     if(JSch.getLogger().isEnabled(Logger.INFO)){
@@ -361,7 +368,7 @@ public abstract class KeyExchange{
         sig=(SignatureEdDSA)(c.getDeclaredConstructor().newInstance());
         sig.init();
       }
-      catch(Exception e){
+      catch(Exception | NoClassDefFoundError e){
         System.err.println(e);
       }
 

--- a/src/main/java/com/jcraft/jsch/KeyPairEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairEdDSA.java
@@ -57,7 +57,7 @@ public abstract class KeyPairEdDSA extends KeyPair{
 
       keypairgen=null;
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
       //System.err.println("KeyPairEdDSA: "+e);
       throw new JSchException(e.toString(), e);
     }
@@ -134,7 +134,7 @@ public abstract class KeyPairEdDSA extends KeyPair{
       tmp[1] = sig;
       return Buffer.fromBytes(tmp).buffer;
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
     }
     return null;
   }
@@ -160,7 +160,7 @@ public abstract class KeyPairEdDSA extends KeyPair{
       eddsa.setPubKey(pub_array);
       return eddsa;
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
     }
     return null;
   }

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -610,7 +610,7 @@ public class Session implements Runnable{
       Class<?> c=Class.forName(getConfig(guess[KeyExchange.PROPOSAL_KEX_ALGS]));
       kex=(KeyExchange)(c.getDeclaredConstructor().newInstance());
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
       throw new JSchException(e.toString(), e);
     }
 
@@ -1528,7 +1528,7 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
       method=guess[KeyExchange.PROPOSAL_COMP_ALGS_STOC];
       initInflater(method);
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
       if(e instanceof JSchException)
         throw e;
       throw new JSchException(e.toString(), e);
@@ -2574,9 +2574,6 @@ break;
           catch(Exception ee){ }
           deflater.init(Compression.DEFLATER, level);
         }
-        catch(NoClassDefFoundError ee){
-          throw new JSchException(ee.toString(), ee);
-        }
         catch(Exception ee){
           throw new JSchException(ee.toString(), ee);
           //System.err.println(foo+" isn't accessible.");
@@ -2855,7 +2852,7 @@ break;
               new byte[_c.getIVSize()]);
       return true;
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
       return false;
     }
   }
@@ -2904,7 +2901,7 @@ break;
       _c.init(new byte[_c.getBlockSize()]);
       return true;
     }
-    catch(Exception e){
+    catch(Exception | NoClassDefFoundError e){
       return false;
     }
   }
@@ -2947,7 +2944,7 @@ break;
       _c.init(s ,null, null, null, null);
       return true;
     }
-    catch(Exception e){ return false; }
+    catch(Exception | NoClassDefFoundError e){ return false; }
   }
 
   private String[] checkSignatures(String sigs){
@@ -2967,7 +2964,7 @@ break;
         final Signature sig=(Signature)(c.getDeclaredConstructor().newInstance());
         sig.init();
       }
-      catch(Exception e){
+      catch(Exception | NoClassDefFoundError e){
         result.addElement(_sigs[i]);
       }
    }

--- a/src/main/java/com/jcraft/jsch/bc/KeyPairGenEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/bc/KeyPairGenEdDSA.java
@@ -1,6 +1,6 @@
 /* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
 /*
-Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+Copyright (c) 2002-2018 ymnk, JCraft,Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -27,24 +27,38 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-package com.jcraft.jsch.jce;
+package com.jcraft.jsch.bc;
 
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.params.*;
 
-public class KeyPairGenXEC implements com.jcraft.jsch.KeyPairGenXEC {
-  XECPublicKey pubKey;
-  XECPrivateKey prvKey;
+public class KeyPairGenEdDSA implements com.jcraft.jsch.KeyPairGenEdDSA{
+  byte[] prv;  // private
+  byte[] pub;  // public
+  int keylen;
+  String name;
+
   @Override
-  public void init(String name) throws Exception {
-    KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
-    NamedParameterSpec paramSpec = new NamedParameterSpec(name);
-    kpg.initialize(paramSpec);
-    KeyPair kp = kpg.genKeyPair();
-    prvKey = (XECPrivateKey)kp.getPrivate();
-    pubKey = (XECPublicKey)kp.getPublic();
+  public void init(String name, int keylen) throws Exception{
+    if(!name.equals("Ed25519") && !name.equals("Ed448")){
+      throw new IllegalArgumentException("invalid curve");
+    }
+    this.keylen = keylen;
+    this.name = name;
+
+    if(name.equals("Ed25519")){
+      Ed25519PrivateKeyParameters privateKey = new Ed25519PrivateKeyParameters(new SecureRandom());
+      pub = privateKey.generatePublicKey().getEncoded();
+      prv = privateKey.getEncoded();
+    }
+    else{
+      Ed448PrivateKeyParameters privateKey = new Ed448PrivateKeyParameters(new SecureRandom());
+      pub = privateKey.generatePublicKey().getEncoded();
+      prv = privateKey.getEncoded();
+    }
   }
-  XECPublicKey getPublicKey(){ return pubKey; }
-  XECPrivateKey getPrivateKey(){ return prvKey; }
+  @Override
+  public byte[] getPrv(){return pub;}
+  @Override
+  public byte[] getPub(){return prv;}
 }

--- a/src/main/java/com/jcraft/jsch/bc/SignatureEd25519.java
+++ b/src/main/java/com/jcraft/jsch/bc/SignatureEd25519.java
@@ -27,24 +27,21 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-package com.jcraft.jsch.jce;
+package com.jcraft.jsch.bc;
 
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
-
-public class KeyPairGenXEC implements com.jcraft.jsch.KeyPairGenXEC {
-  XECPublicKey pubKey;
-  XECPrivateKey prvKey;
+public class SignatureEd25519 extends SignatureEdDSA {
   @Override
-  public void init(String name) throws Exception {
-    KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
-    NamedParameterSpec paramSpec = new NamedParameterSpec(name);
-    kpg.initialize(paramSpec);
-    KeyPair kp = kpg.genKeyPair();
-    prvKey = (XECPrivateKey)kp.getPrivate();
-    pubKey = (XECPublicKey)kp.getPublic();
+  String getName() {
+    return "ssh-ed25519";
   }
-  XECPublicKey getPublicKey(){ return pubKey; }
-  XECPrivateKey getPrivateKey(){ return prvKey; }
+
+  @Override
+  String getAlgo() {
+    return "Ed25519";
+  }
+
+  @Override
+  int getKeylen() {
+    return 32;
+  }
 }

--- a/src/main/java/com/jcraft/jsch/bc/SignatureEd448.java
+++ b/src/main/java/com/jcraft/jsch/bc/SignatureEd448.java
@@ -27,24 +27,21 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-package com.jcraft.jsch.jce;
+package com.jcraft.jsch.bc;
 
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
-
-public class KeyPairGenXEC implements com.jcraft.jsch.KeyPairGenXEC {
-  XECPublicKey pubKey;
-  XECPrivateKey prvKey;
+public class SignatureEd448 extends SignatureEdDSA {
   @Override
-  public void init(String name) throws Exception {
-    KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
-    NamedParameterSpec paramSpec = new NamedParameterSpec(name);
-    kpg.initialize(paramSpec);
-    KeyPair kp = kpg.genKeyPair();
-    prvKey = (XECPrivateKey)kp.getPrivate();
-    pubKey = (XECPublicKey)kp.getPublic();
+  String getName() {
+    return "ssh-ed448";
   }
-  XECPublicKey getPublicKey(){ return pubKey; }
-  XECPrivateKey getPrivateKey(){ return prvKey; }
+
+  @Override
+  String getAlgo() {
+    return "Ed448";
+  }
+
+  @Override
+  int getKeylen() {
+    return 57;
+  }
 }

--- a/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
@@ -1,0 +1,114 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.bouncycastle.crypto.Signer;
+import org.bouncycastle.crypto.params.*;
+import org.bouncycastle.crypto.signers.*;
+import com.jcraft.jsch.Buffer;
+
+public abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
+
+  Signer signature;
+
+  abstract String getName();
+  abstract String getAlgo();
+  abstract int getKeylen();
+
+  @Override
+  public void init() throws Exception{
+    if(!getAlgo().equals("Ed25519") && !getAlgo().equals("Ed448")){
+      throw new IllegalArgumentException("invalid curve");
+    }
+
+    if(getAlgo().equals("Ed25519")){
+      signature = new Ed25519Signer();
+    }
+    else{
+      signature = new Ed448Signer(new byte[0]);
+    }
+  }
+
+  @Override
+  public void setPubKey(byte[] y_arr) throws Exception{
+    if(getAlgo().equals("Ed25519")){
+      Ed25519PublicKeyParameters pubKey = new Ed25519PublicKeyParameters(y_arr);
+      signature.init(false, pubKey);
+    }
+    else{
+      Ed448PublicKeyParameters pubKey = new Ed448PublicKeyParameters(y_arr);
+      signature.init(false, pubKey);
+    }
+  }
+
+  @Override
+  public void setPrvKey(byte[] bytes) throws Exception{
+    if(getAlgo().equals("Ed25519")){
+      Ed25519PrivateKeyParameters prvKey = new Ed25519PrivateKeyParameters(bytes);
+      signature.init(true, prvKey);
+    }
+    else{
+      Ed448PrivateKeyParameters prvKey = new Ed448PrivateKeyParameters(bytes);
+      signature.init(true, prvKey);
+    }
+  }
+
+  @Override
+  public byte[] sign() throws Exception{
+    byte[] sig = signature.generateSignature();
+    return sig;
+  }
+
+  @Override
+  public void update(byte[] foo) throws Exception{
+    signature.update(foo, 0, foo.length);
+  }
+
+  @Override
+  public boolean verify(byte[] sig) throws Exception{
+    int i = 0;
+    int j = 0;
+    byte[] tmp;
+    Buffer buf = new Buffer(sig);
+
+    String foo = new String(buf.getString(), StandardCharsets.UTF_8);
+    if(foo.equals(getName())){
+      j = buf.getInt();
+      i = buf.getOffSet();
+      tmp = new byte[j];
+      System.arraycopy(sig, i, tmp, 0, j);
+      sig = tmp;
+    }
+
+    return signature.verifySignature(sig);
+  }
+}

--- a/src/main/java/com/jcraft/jsch/bc/XDH.java
+++ b/src/main/java/com/jcraft/jsch/bc/XDH.java
@@ -1,0 +1,94 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import org.bouncycastle.crypto.params.*;
+
+public class XDH implements com.jcraft.jsch.XDH {
+  byte[] Q_array;
+  Object privateKey;
+  int keylen;
+  String name;
+
+  @Override
+  public void init(String name, int keylen) throws Exception{
+    if(!name.equals("X25519") && !name.equals("X448")){
+      throw new IllegalArgumentException("invalid curve");
+    }
+    this.keylen = keylen;
+    this.name = name;
+    if(name.equals("X25519")){
+      X25519PrivateKeyParameters privateKey = new X25519PrivateKeyParameters(new SecureRandom());
+      Q_array = privateKey.generatePublicKey().getEncoded();
+      this.privateKey = privateKey;
+    }
+    else{
+      X448PrivateKeyParameters privateKey = new X448PrivateKeyParameters(new SecureRandom());
+      Q_array = privateKey.generatePublicKey().getEncoded();
+      this.privateKey = privateKey;
+    }
+  }
+
+  @Override
+  public byte[] getQ() throws Exception{
+    return Q_array;
+  }
+
+  @Override
+  public byte[] getSecret(byte[] Q) throws Exception{
+    byte[] secret = new byte[keylen];
+    if(name.equals("X25519")){
+      X25519PrivateKeyParameters privateKey = (X25519PrivateKeyParameters) this.privateKey;
+      privateKey.generateSecret(new X25519PublicKeyParameters(Q), secret, 0);
+    }
+    else{
+      X448PrivateKeyParameters privateKey = (X448PrivateKeyParameters) this.privateKey;
+      privateKey.generateSecret(new X448PublicKeyParameters(Q), secret, 0);
+    }
+    return secret;
+  }
+
+  // https://cr.yp.to/ecdh.html#validate
+  // RFC 8731,
+  // 3. Key Exchange Methods
+  //   Clients and servers MUST
+  //   also abort if the length of the received public keys are not the
+  //   expected lengths.  An abort for these purposes is defined as a
+  //   disconnect (SSH_MSG_DISCONNECT) of the session and SHOULD use the
+  //   SSH_DISCONNECT_KEY_EXCHANGE_FAILED reason for the message
+  //   [IANA-REASON].  No further validation is required beyond what is
+  //   described in [RFC7748].
+  @Override
+  public boolean validate(byte[] u) throws Exception{
+    return u.length == keylen;
+  }
+}

--- a/src/main/java9/com/jcraft/jsch/JavaVersion.java
+++ b/src/main/java9/com/jcraft/jsch/JavaVersion.java
@@ -1,0 +1,8 @@
+package com.jcraft.jsch;
+
+final class JavaVersion {
+
+  static int getVersion() {
+    return Runtime.version().major();
+  }
+}

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -2,6 +2,7 @@ module com.jcraft.jsch {
     exports com.jcraft.jsch;
 
     requires java.security.jgss;
+    requires static org.bouncycastle.provider;
     requires static org.newsclub.net.unix;
     requires static com.kohlschutter.junixsocket.nativecommon;
     requires static com.sun.jna;

--- a/src/test/java/com/jcraft/jsch/Algorithms2IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms2IT.java
@@ -121,6 +121,19 @@ public class Algorithms2IT {
   public void testJava11KEXs() throws Exception {
     JSch ssh = createRSAIdentity();
     Session session = createSession(ssh);
+    session.setConfig("xdh", "com.jcraft.jsch.jce.XDH");
+    session.setConfig("kex", "curve448-sha512");
+    doSftp(session, true);
+
+    String expected = "kex: algorithm: curve448-sha512.*";
+    checkLogs(expected);
+  }
+
+  @Test
+  public void testBCKEXs() throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+    session.setConfig("xdh", "com.jcraft.jsch.bc.XDH");
     session.setConfig("kex", "curve448-sha512");
     doSftp(session, true);
 
@@ -131,6 +144,7 @@ public class Algorithms2IT {
   @ParameterizedTest
   @ValueSource(
       strings = {
+        "curve448-sha512",
         "diffie-hellman-group17-sha512",
         "diffie-hellman-group15-sha512",
         "diffie-hellman-group18-sha512@ssh.com",
@@ -192,6 +206,34 @@ public class Algorithms2IT {
 
   @Test
   @EnabledForJreRange(min = JAVA_15)
+  public void testJava15Ed448() throws Exception {
+    JSch ssh = createEd448Identity();
+    Session session = createSession(ssh);
+    session.setConfig("keypairgen.eddsa", "com.jcraft.jsch.jce.KeyPairGenEdDSA");
+    session.setConfig("ssh-ed448", "com.jcraft.jsch.jce.SignatureEd448");
+    session.setConfig("PubkeyAcceptedAlgorithms", "ssh-ed448");
+    session.setConfig("server_host_key", "ssh-ed448");
+    doSftp(session, true);
+
+    String expected = "kex: host key algorithm: ssh-ed448.*";
+    checkLogs(expected);
+  }
+
+  @Test
+  public void testBCEd448() throws Exception {
+    JSch ssh = createEd448Identity();
+    Session session = createSession(ssh);
+    session.setConfig("keypairgen.eddsa", "com.jcraft.jsch.bc.KeyPairGenEdDSA");
+    session.setConfig("ssh-ed448", "com.jcraft.jsch.bc.SignatureEd448");
+    session.setConfig("PubkeyAcceptedAlgorithms", "ssh-ed448");
+    session.setConfig("server_host_key", "ssh-ed448");
+    doSftp(session, true);
+
+    String expected = "kex: host key algorithm: ssh-ed448.*";
+    checkLogs(expected);
+  }
+
+  @Test
   public void testEd448() throws Exception {
     JSch ssh = createEd448Identity();
     Session session = createSession(ssh);

--- a/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
@@ -120,16 +120,14 @@ public class OpenSSH74ServerSigAlgsIT {
     String expectedExtInfo = "SSH_MSG_EXT_INFO received";
     String expectedServerSigAlgs = "server-sig-algs=<ssh-ed25519,ssh-rsa,ssh-dss,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521>";
     String expectedOpenSSH74Bug = "OpenSSH 7.4 detected: adding rsa-sha2-256 & rsa-sha2-512 to server-sig-algs";
-    String expectedPubkeysBefore = String.format("After getUnavailableSignatures PubkeyAcceptedAlgorithms = %s", algos);
-    String expectedPubkeysKnown = "PubkeyAcceptedAlgorithms in server-sig-algs = rsa-sha2-512,rsa-sha2-256,ssh-rsa";
-    String expectedPubkeysUnknown = "PubkeyAcceptedAlgorithms not in server-sig-algs = ssh-rsa-sha512@ssh.com,ssh-rsa-sha384@ssh.com,ssh-rsa-sha256@ssh.com,ssh-rsa-sha224@ssh.com";
+    String expectedPubkeysKnown = "PubkeyAcceptedAlgorithms in server-sig-algs = \\[rsa-sha2-512, rsa-sha2-256, ssh-rsa\\]";
+    String expectedPubkeysUnknown = "PubkeyAcceptedAlgorithms not in server-sig-algs = \\[ssh-rsa-sha512@ssh.com, ssh-rsa-sha384@ssh.com, ssh-rsa-sha256@ssh.com, ssh-rsa-sha224@ssh.com\\]";
     String expectedPreauth = "rsa-sha2-512 preauth success";
     String expectedAuth = "rsa-sha2-512 auth success";
     checkLogs(expectedKex);
     checkLogs(expectedExtInfo);
     checkLogs(expectedServerSigAlgs);
     checkLogs(expectedOpenSSH74Bug);
-    checkLogs(expectedPubkeysBefore);
     checkLogs(expectedPubkeysKnown);
     checkLogs(expectedPubkeysUnknown);
     checkLogs(expectedPreauth);

--- a/src/test/java/com/jcraft/jsch/SSHAgentIT.java
+++ b/src/test/java/com/jcraft/jsch/SSHAgentIT.java
@@ -1,0 +1,420 @@
+package com.jcraft.jsch;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.codec.binary.Base64.decodeBase64;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.condition.JRE.JAVA_16;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.testcontainers.containers.BindMode.READ_WRITE;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sun.jna.platform.unix.LibC;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Random;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@EnabledOnOs(LINUX)
+@Testcontainers
+public class SSHAgentIT {
+
+  private static final int timeout = 2000;
+  private static final DigestUtils sha256sum = new DigestUtils(DigestUtils.getSha256Digest());
+  private static final ListAppender<ILoggingEvent> jschAppender = getListAppender(JSch.class);
+  private static final ListAppender<ILoggingEvent> sshdAppender = getListAppender(SSHAgentIT.class);
+  private static final ListAppender<ILoggingEvent> sshAgentAppender = getListAppender(AgentProxy.class);
+  @TempDir public static Path tmpDir;
+  private static String testuid;
+  private static String testgid;
+  private static Path sshAgentSock;
+
+  private Path in;
+  private Path out;
+  private String hash;
+  private Slf4jLogConsumer sshdLogConsumer;
+  private Slf4jLogConsumer sshAgentLogConsumer;
+
+  @Container
+  public GenericContainer<?> sshd =
+      new GenericContainer<>(
+              new ImageFromDockerfile()
+                  .withFileFromClasspath("ssh_host_rsa_key", "docker/ssh_host_rsa_key")
+                  .withFileFromClasspath("ssh_host_rsa_key.pub", "docker/ssh_host_rsa_key.pub")
+                  .withFileFromClasspath("ssh_host_ecdsa256_key", "docker/ssh_host_ecdsa256_key")
+                  .withFileFromClasspath(
+                      "ssh_host_ecdsa256_key.pub", "docker/ssh_host_ecdsa256_key.pub")
+                  .withFileFromClasspath("ssh_host_ecdsa384_key", "docker/ssh_host_ecdsa384_key")
+                  .withFileFromClasspath(
+                      "ssh_host_ecdsa384_key.pub", "docker/ssh_host_ecdsa384_key.pub")
+                  .withFileFromClasspath("ssh_host_ecdsa521_key", "docker/ssh_host_ecdsa521_key")
+                  .withFileFromClasspath(
+                      "ssh_host_ecdsa521_key.pub", "docker/ssh_host_ecdsa521_key.pub")
+                  .withFileFromClasspath("ssh_host_ed25519_key", "docker/ssh_host_ed25519_key")
+                  .withFileFromClasspath(
+                      "ssh_host_ed25519_key.pub", "docker/ssh_host_ed25519_key.pub")
+                  .withFileFromClasspath("ssh_host_dsa_key", "docker/ssh_host_dsa_key")
+                  .withFileFromClasspath("ssh_host_dsa_key.pub", "docker/ssh_host_dsa_key.pub")
+                  .withFileFromClasspath("sshd_config", "docker/sshd_config")
+                  .withFileFromClasspath("authorized_keys", "docker/authorized_keys")
+                  .withFileFromClasspath("Dockerfile", "docker/Dockerfile"))
+          .withExposedPorts(22);
+
+  @Container
+  public GenericContainer<?> sshAgent =
+      new GenericContainer<>(
+              new ImageFromDockerfile()
+                  .withBuildArg("testuid", testuid)
+                  .withBuildArg("testgid", testgid)
+                  .withFileFromClasspath("Dockerfile", "docker/Dockerfile.sshagent"))
+          .withFileSystemBind(sshAgentSock.getParent().toString(), "/testuser", READ_WRITE);
+
+  @BeforeAll
+  public static void beforeAll() throws IOException {
+    JSch.setLogger(Slf4jLogger.getInstance());
+    LibC libc = LibC.INSTANCE;
+    testuid = Integer.toString(libc.getuid());
+    testgid = Integer.toString(libc.getgid());
+    Path temp = Files.createTempDirectory(tmpDir, "sshagent");
+    sshAgentSock = temp.resolve("sock");
+  }
+
+  @BeforeEach
+  public void beforeEach() throws IOException {
+    if (sshdLogConsumer == null) {
+      sshdLogConsumer = new Slf4jLogConsumer(LoggerFactory.getLogger(SSHAgentIT.class));
+      sshd.followOutput(sshdLogConsumer);
+    }
+
+    if (sshAgentLogConsumer == null) {
+      sshAgentLogConsumer = new Slf4jLogConsumer(LoggerFactory.getLogger(AgentProxy.class));
+      sshAgent.followOutput(sshAgentLogConsumer);
+    }
+
+    Path temp = Files.createTempDirectory(tmpDir, "sshd");
+    in = temp.resolve("in");
+    out = temp.resolve("out");
+    Files.createFile(in);
+    try (OutputStream os = Files.newOutputStream(in)) {
+      byte[] data = new byte[1024];
+      for (int i = 0; i < 1024 * 100; i += 1024) {
+        new Random().nextBytes(data);
+        os.write(data);
+      }
+    }
+    hash = sha256sum.digestAsHex(in);
+
+    jschAppender.list.clear();
+    sshdAppender.list.clear();
+    sshAgentAppender.list.clear();
+    jschAppender.start();
+    sshdAppender.start();
+    sshAgentAppender.start();
+  }
+
+  @AfterEach
+  public void afterEach() {
+    jschAppender.stop();
+    sshdAppender.stop();
+    sshAgentAppender.stop();
+    jschAppender.list.clear();
+    sshdAppender.list.clear();
+    sshAgentAppender.list.clear();
+
+    try {
+      Files.deleteIfExists(sshAgentSock);
+    } catch (IOException ignore) {
+    }
+
+    try {
+      Files.deleteIfExists(out);
+    } catch (IOException ignore) {
+    }
+
+    try {
+      Files.deleteIfExists(in);
+    } catch (IOException ignore) {
+    }
+
+    try {
+      Files.deleteIfExists(in.getParent());
+    } catch (IOException ignore) {
+    }
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    try {
+      Files.deleteIfExists(sshAgentSock.getParent());
+    } catch (IOException ignore) {
+    }
+  }
+
+  @Test
+  public void testEd25519JUnixSocketFactory() throws Exception {
+    JSch ssh = createEd25519Identity(new JUnixSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ssh-ed25519");
+    doSftp(session, true);
+  }
+
+  @Test
+  public void testECDSA521JUnixSocketFactory() throws Exception {
+    JSch ssh = createECDSA521Identity(new JUnixSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ecdsa-sha2-nistp521");
+    doSftp(session, true);
+  }
+
+  @Test
+  public void testECDSA384JUnixSocketFactory() throws Exception {
+    JSch ssh = createECDSA384Identity(new JUnixSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ecdsa-sha2-nistp384");
+    doSftp(session, true);
+  }
+
+  @Test
+  public void testECDSA256JUnixSocketFactory() throws Exception {
+    JSch ssh = createECDSA256Identity(new JUnixSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ecdsa-sha2-nistp256");
+    doSftp(session, true);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"})
+  public void testRSAJUnixSocketFactory(String keyType) throws Exception {
+    JSch ssh = createRSAIdentity(new JUnixSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", keyType);
+    doSftp(session, true);
+  }
+
+  @Test
+  public void testDSAJUnixSocketFactory() throws Exception {
+    JSch ssh = createDSAIdentity(new JUnixSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ssh-dss");
+    doSftp(session, true);
+  }
+
+  @Test
+  @EnabledForJreRange(min = JAVA_16)
+  public void testEd25519UnixDomainSocketFactory() throws Exception {
+    JSch ssh = createEd25519Identity(new UnixDomainSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ssh-ed25519");
+    doSftp(session, true);
+  }
+
+  @Test
+  @EnabledForJreRange(min = JAVA_16)
+  public void testECDSA521UnixDomainSocketFactory() throws Exception {
+    JSch ssh = createECDSA521Identity(new UnixDomainSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ecdsa-sha2-nistp521");
+    doSftp(session, true);
+  }
+
+  @Test
+  @EnabledForJreRange(min = JAVA_16)
+  public void testECDSA384UnixDomainSocketFactory() throws Exception {
+    JSch ssh = createECDSA384Identity(new UnixDomainSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ecdsa-sha2-nistp384");
+    doSftp(session, true);
+  }
+
+  @Test
+  @EnabledForJreRange(min = JAVA_16)
+  public void testECDSA256UnixDomainSocketFactory() throws Exception {
+    JSch ssh = createECDSA256Identity(new UnixDomainSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ecdsa-sha2-nistp256");
+    doSftp(session, true);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"})
+  @EnabledForJreRange(min = JAVA_16)
+  public void testRSAUnixDomainSocketFactory(String keyType) throws Exception {
+    JSch ssh = createRSAIdentity(new UnixDomainSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", keyType);
+    doSftp(session, true);
+  }
+
+  @Test
+  @EnabledForJreRange(min = JAVA_16)
+  public void testDSAUnixDomainSocketFactory() throws Exception {
+    JSch ssh = createDSAIdentity(new UnixDomainSocketFactory());
+    Session session = createSession(ssh);
+    session.setConfig("PubkeyAcceptedAlgorithms", "ssh-dss");
+    doSftp(session, true);
+  }
+
+  private JSch createRSAIdentity(USocketFactory factory) throws Exception {
+    IdentityRepository ir = new AgentIdentityRepository(new SSHAgentConnector(factory, sshAgentSock));
+    assertTrue(ir.getIdentities().isEmpty(), "ssh-agent empty");
+
+    HostKey hostKey = readHostKey(getResourceFile("docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.setIdentityRepository(ir);
+    ssh.addIdentity(getResourceFile("docker/id_rsa"), getResourceFile("docker/id_rsa.pub"), null);
+    assertEquals(1, ir.getIdentities().size());
+    ssh.getHostKeyRepository().add(hostKey, null);
+    return ssh;
+  }
+
+  private JSch createECDSA256Identity(USocketFactory factory) throws Exception {
+    IdentityRepository ir = new AgentIdentityRepository(new SSHAgentConnector(factory, sshAgentSock));
+    assertTrue(ir.getIdentities().isEmpty(), "ssh-agent empty");
+
+    HostKey hostKey = readHostKey(getResourceFile("docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.setIdentityRepository(ir);
+    ssh.addIdentity(
+        getResourceFile("docker/id_ecdsa256"), getResourceFile("docker/id_ecdsa256.pub"), null);
+    ssh.getHostKeyRepository().add(hostKey, null);
+    return ssh;
+  }
+
+  private JSch createECDSA384Identity(USocketFactory factory) throws Exception {
+    IdentityRepository ir = new AgentIdentityRepository(new SSHAgentConnector(factory, sshAgentSock));
+    assertTrue(ir.getIdentities().isEmpty(), "ssh-agent empty");
+
+    HostKey hostKey = readHostKey(getResourceFile("docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.setIdentityRepository(ir);
+    ssh.addIdentity(
+        getResourceFile("docker/id_ecdsa384"), getResourceFile("docker/id_ecdsa384.pub"), null);
+    assertEquals(1, ir.getIdentities().size());
+    ssh.getHostKeyRepository().add(hostKey, null);
+    return ssh;
+  }
+
+  private JSch createECDSA521Identity(USocketFactory factory) throws Exception {
+    IdentityRepository ir = new AgentIdentityRepository(new SSHAgentConnector(factory, sshAgentSock));
+    assertTrue(ir.getIdentities().isEmpty(), "ssh-agent empty");
+
+    HostKey hostKey = readHostKey(getResourceFile("docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.setIdentityRepository(ir);
+    ssh.addIdentity(
+        getResourceFile("docker/id_ecdsa521"), getResourceFile("docker/id_ecdsa521.pub"), null);
+    assertEquals(1, ir.getIdentities().size());
+    ssh.getHostKeyRepository().add(hostKey, null);
+    return ssh;
+  }
+
+  private JSch createDSAIdentity(USocketFactory factory) throws Exception {
+    IdentityRepository ir = new AgentIdentityRepository(new SSHAgentConnector(factory, sshAgentSock));
+    assertTrue(ir.getIdentities().isEmpty(), "ssh-agent empty");
+
+    HostKey hostKey = readHostKey(getResourceFile("docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.setIdentityRepository(ir);
+    ssh.addIdentity(getResourceFile("docker/id_dsa"), getResourceFile("docker/id_dsa.pub"), null);
+    assertEquals(1, ir.getIdentities().size());
+    ssh.getHostKeyRepository().add(hostKey, null);
+    return ssh;
+  }
+
+  private JSch createEd25519Identity(USocketFactory factory) throws Exception {
+    IdentityRepository ir = new AgentIdentityRepository(new SSHAgentConnector(factory, sshAgentSock));
+    assertTrue(ir.getIdentities().isEmpty(), "ssh-agent empty");
+
+    HostKey hostKey = readHostKey(getResourceFile("docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.setIdentityRepository(ir);
+    ssh.addIdentity(
+        getResourceFile("docker/id_ed25519"), getResourceFile("docker/id_ed25519.pub"), null);
+    assertEquals(1, ir.getIdentities().size());
+    ssh.getHostKeyRepository().add(hostKey, null);
+    return ssh;
+  }
+
+  private HostKey readHostKey(String fileName) throws Exception {
+    List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
+    String[] split = lines.get(0).split("\\s+");
+    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    return new HostKey(hostname, decodeBase64(split[1]));
+  }
+
+  private Session createSession(JSch ssh) throws Exception {
+    Session session = ssh.getSession("root", sshd.getHost(), sshd.getFirstMappedPort());
+    session.setConfig("StrictHostKeyChecking", "yes");
+    session.setConfig("PreferredAuthentications", "publickey");
+    return session;
+  }
+
+  private void doSftp(Session session, boolean debugException) throws Exception {
+    try {
+      session.setTimeout(timeout);
+      session.connect();
+      ChannelSftp sftp = (ChannelSftp) session.openChannel("sftp");
+      sftp.connect(timeout);
+      sftp.put(in.toString(), "/root/test");
+      sftp.get("/root/test", out.toString());
+      sftp.disconnect();
+      session.disconnect();
+      jschAppender.stop();
+      sshdAppender.stop();
+      sshAgentAppender.stop();
+    } catch (Exception e) {
+      if (debugException) {
+        printInfo();
+      }
+      throw e;
+    }
+
+    assertEquals(1024L * 100L, Files.size(out));
+    assertEquals(hash, sha256sum.digestAsHex(out));
+  }
+
+  private static void printInfo() {
+    jschAppender.stop();
+    sshdAppender.stop();
+    sshAgentAppender.stop();
+    jschAppender.list.stream().map(ILoggingEvent::getFormattedMessage).forEach(System.out::println);
+    sshdAppender.list.stream().map(ILoggingEvent::getFormattedMessage).forEach(System.out::println);
+    sshAgentAppender.list.stream().map(ILoggingEvent::getFormattedMessage).forEach(System.out::println);
+    System.out.println("");
+    System.out.println("");
+    System.out.println("");
+  }
+
+  private String getResourceFile(String fileName) {
+    return ResourceUtil.getResourceFile(getClass(), fileName);
+  }
+
+  private static ListAppender<ILoggingEvent> getListAppender(Class<?> clazz) {
+    Logger logger = (Logger) LoggerFactory.getLogger(clazz);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender2<>();
+    logger.addAppender(listAppender);
+    return listAppender;
+  }
+}

--- a/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
@@ -119,15 +119,13 @@ public class ServerSigAlgsIT {
     String expectedKex = "kex: host key algorithm: rsa-sha2-512";
     String expectedExtInfo = "SSH_MSG_EXT_INFO received";
     String expectedServerSigAlgs = "server-sig-algs=<ssh-ed25519,ssh-rsa,rsa-sha2-256,rsa-sha2-512,ssh-dss,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521>";
-    String expectedPubkeysBefore = String.format("After getUnavailableSignatures PubkeyAcceptedAlgorithms = %s", algos);
-    String expectedPubkeysKnown = "PubkeyAcceptedAlgorithms in server-sig-algs = rsa-sha2-512,rsa-sha2-256,ssh-rsa";
-    String expectedPubkeysUnknown = "PubkeyAcceptedAlgorithms not in server-sig-algs = ssh-rsa-sha512@ssh.com,ssh-rsa-sha384@ssh.com,ssh-rsa-sha256@ssh.com,ssh-rsa-sha224@ssh.com";
+    String expectedPubkeysKnown = "PubkeyAcceptedAlgorithms in server-sig-algs = \\[rsa-sha2-512, rsa-sha2-256, ssh-rsa\\]";
+    String expectedPubkeysUnknown = "PubkeyAcceptedAlgorithms not in server-sig-algs = \\[ssh-rsa-sha512@ssh.com, ssh-rsa-sha384@ssh.com, ssh-rsa-sha256@ssh.com, ssh-rsa-sha224@ssh.com\\]";
     String expectedPreauth = "rsa-sha2-512 preauth success";
     String expectedAuth = "rsa-sha2-512 auth success";
     checkLogs(expectedKex);
     checkLogs(expectedExtInfo);
     checkLogs(expectedServerSigAlgs);
-    checkLogs(expectedPubkeysBefore);
     checkLogs(expectedPubkeysKnown);
     checkLogs(expectedPubkeysUnknown);
     checkLogs(expectedPreauth);
@@ -145,7 +143,6 @@ public class ServerSigAlgsIT {
     doSftp(session, true);
 
     String expectedKex = "kex: host key algorithm: rsa-sha2-512";
-    String expectedPubkeysBefore = String.format("After getUnavailableSignatures PubkeyAcceptedAlgorithms = %s", algos);
     String expectedPubkeysNoServerSigs = String.format("No server-sig-algs found, using PubkeyAcceptedAlgorithms = %s", algos);
     String expectedPreauthFail1 = "ssh-rsa-sha512@ssh.com preauth failure";
     String expectedPreauthFail2 = "ssh-rsa-sha384@ssh.com preauth failure";
@@ -154,7 +151,6 @@ public class ServerSigAlgsIT {
     String expectedPreauth = "rsa-sha2-512 preauth success";
     String expectedAuth = "rsa-sha2-512 auth success";
     checkLogs(expectedKex);
-    checkLogs(expectedPubkeysBefore);
     checkLogs(expectedPreauthFail1);
     checkLogs(expectedPreauthFail2);
     checkLogs(expectedPreauthFail3);

--- a/src/test/resources/docker/Dockerfile.sshagent
+++ b/src/test/resources/docker/Dockerfile.sshagent
@@ -1,0 +1,14 @@
+FROM alpine:3.7
+ARG testuid
+ARG testgid
+RUN apk update && \
+    apk upgrade && \
+    apk add openssh su-exec && \
+    rm /var/cache/apk/* && \
+    addgroup -g $testgid testuser && \
+    adduser -Du $testuid -G testuser -Hh /testuser -s /bin/sh -g testuser testuser && \
+    mkdir /testuser && \
+    chown testuser:testuser /testuser && \
+    chmod 700 /testuser && \
+    passwd -u testuser
+ENTRYPOINT ["/sbin/su-exec", "testuser:testuser", "/usr/bin/ssh-agent", "-d", "-a", "/testuser/sock"]


### PR DESCRIPTION
* Allow usage of keys from ssh-agent that would otherwise not work because of missing support for the signature algorithm.
* Add integration tests for ssh-agent support.
* Added support for the following algorithms with older Java releases by using [Bouncy Castle](https://www.bouncycastle.org/):
  * ssh-ed25519
  * ssh-ed448
  * curve25519-sha256
  * curve25519-sha256@<!-- -->libssh.org
  * curve448-sha512
  * chacha20-poly1305@<!-- -->openssh.com

FYI, allowing usage of ssh-agent keys allows using ssh-ed25519 from Java versions < 15, since the signature generation process is delegated to the ssh-agent process and does not rely upon Ed25519 support within Java itself.

Also, the ssh-agent integration tests can only be run from Linux, since it relies on sharing a bind mount between the host and container running the ssh-agent process, and it doesn't seem possible to share the ssh-agent's unix domain socket through this bind mount on macOS (and I assume Windows as well).

FYI, the Bouncy Castle addition is completely optional: JSch will still function without it being present in the classpath, albeit without supporting the above mentioned algorithms on older Java releases. This should help address some issues that have been raised by users asking why we don't support these algorithms on older Java releases: all the user has to do is add the `bcprov-jdk15on` jar-file to their classpath to gain support.