### PR TITLE
More legacy algorithm support and bugfixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 * [0.1.68](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.68)
   * Added support for the rijndael-cbc@<!-- -->lysator.liu.se algorithm
   * Added support for the hmac-ripemd160, hmac-ripemd160@<!-- -->openssh.com and hmac-ripemd160-etm@<!-- -->openssh.com algorithms using [Bouncy Castle](https://www.bouncycastle.org/)
+  * Added support for the cast128-cbc and cast128-ctr algorithms from [RFC 4253](https://datatracker.ietf.org/doc/html/rfc4253) and [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344) using [Bouncy Castle](https://www.bouncycastle.org/)
 * [0.1.67](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.67)
   * Added support for the blowfish-ctr algorithm from [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344)
   * Fix bug where ext-info-c was incorrectly advertised during rekeying

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
   * Added support for the rijndael-cbc@<!-- -->lysator.liu.se algorithm
   * Added support for the hmac-ripemd160, hmac-ripemd160@<!-- -->openssh.com and hmac-ripemd160-etm@<!-- -->openssh.com algorithms using [Bouncy Castle](https://www.bouncycastle.org/)
   * Added support for the cast128-cbc and cast128-ctr algorithms from [RFC 4253](https://datatracker.ietf.org/doc/html/rfc4253) and [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344) using [Bouncy Castle](https://www.bouncycastle.org/)
+  * Added support for the seed-cbc@<!-- -->ssh.com algorithm using [Bouncy Castle](https://www.bouncycastle.org/)
 * [0.1.67](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.67)
   * Added support for the blowfish-ctr algorithm from [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344)
   * Fix bug where ext-info-c was incorrectly advertised during rekeying

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+* [0.1.68](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.68)
+  * Added support for the rijndael-cbc@<!-- -->lysator.liu.se algorithm
 * [0.1.67](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.67)
   * Added support for the blowfish-ctr algorithm from [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344)
   * Fix bug where ext-info-c was incorrectly advertised during rekeying

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
     * twofish256-cbc
     * twofish256-ctr
   * Added support for the seed-cbc@<!-- -->ssh.com algorithm using [Bouncy Castle](https://www.bouncycastle.org/)
+  * Address [#76](https://github.com/mwiede/jsch/issues/76) by making the "Host" keyword case-insensitive
 * [0.1.67](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.67)
   * Added support for the blowfish-ctr algorithm from [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344)
   * Fix bug where ext-info-c was incorrectly advertised during rekeying

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 * [0.1.68](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.68)
   * Added support for the rijndael-cbc@<!-- -->lysator.liu.se algorithm
+  * Added support for the hmac-ripemd160, hmac-ripemd160@<!-- -->openssh.com and hmac-ripemd160-etm@<!-- -->openssh.com algorithms using [Bouncy Castle](https://www.bouncycastle.org/)
 * [0.1.67](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.67)
   * Added support for the blowfish-ctr algorithm from [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344)
   * Fix bug where ext-info-c was incorrectly advertised during rekeying

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 * [0.1.68](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.68)
   * Added support for the rijndael-cbc@<!-- -->lysator.liu.se algorithm
-  * Added support for the hmac-ripemd160, hmac-ripemd160@<!-- -->openssh.com and hmac-ripemd160-etm@<!-- -->openssh.com algorithms using [Bouncy Castle](https://www.bouncycastle.org/)
-  * Added support for various algorithms from [RFC 4253](https://datatracker.ietf.org/doc/html/rfc4253) and [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344) using [Bouncy Castle](https://www.bouncycastle.org/)
+  * Added support for the hmac-ripemd160, hmac-ripemd160@<!-- -->openssh.com and hmac-ripemd160-etm@<!-- -->openssh.com algorithms using [Bouncy Castle](https://www.bouncycastle.org/java.html)
+  * Added support for various algorithms from [RFC 4253](https://datatracker.ietf.org/doc/html/rfc4253) and [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344) using [Bouncy Castle](https://www.bouncycastle.org/java.html)
     * cast128-cbc
     * cast128-ctr
     * twofish-cbc
@@ -11,13 +11,13 @@
     * twofish192-ctr
     * twofish256-cbc
     * twofish256-ctr
-  * Added support for the seed-cbc@<!-- -->ssh.com algorithm using [Bouncy Castle](https://www.bouncycastle.org/)
+  * Added support for the seed-cbc@<!-- -->ssh.com algorithm using [Bouncy Castle](https://www.bouncycastle.org/java.html)
   * Address [#76](https://github.com/mwiede/jsch/issues/76) by making the "Host" keyword case-insensitive
 * [0.1.67](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.67)
   * Added support for the blowfish-ctr algorithm from [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344)
   * Fix bug where ext-info-c was incorrectly advertised during rekeying
     * According to [RFC 8308 section 2.1](https://datatracker.ietf.org/doc/html/rfc8308#section-2.1), ext-info-c should only advertised during the first key exchange
-  * Address [#77](https://github.com/mwiede/jsch/issues/77) by attempting to add compatibility with older [Bouncy Castle](https://www.bouncycastle.org/) releases
+  * Address [#77](https://github.com/mwiede/jsch/issues/77) by attempting to add compatibility with older [Bouncy Castle](https://www.bouncycastle.org/java.html) releases
 * [0.1.66](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.66)
   * Added support for [RFC 8308](https://datatracker.ietf.org/doc/html/rfc8308) extension negotiation and server-sig-algs extension
     * This support is enabled by default, but can be controlled via the enable_server_sig_algs config option (or `jsch.enable_server_sig_algs` system property)
@@ -51,7 +51,7 @@
     * See `examples/JSchWithAgentProxy.java` for simple example
     * ssh-agent support requires either [Java 16's JEP 380](https://openjdk.java.net/jeps/380) or the addition of [junixsocket](https://github.com/kohlschutter/junixsocket) to classpath
     * Pageant support is untested & requires the addition of [JNA](https://github.com/java-native-access/jna) to classpath
-  * Added support for the following algorithms with older Java releases by using [Bouncy Castle](https://www.bouncycastle.org/):
+  * Added support for the following algorithms with older Java releases by using [Bouncy Castle](https://www.bouncycastle.org/java.html):
     * ssh-ed25519
     * ssh-ed448
     * curve25519-sha256

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,16 @@
 * [0.1.68](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.68)
   * Added support for the rijndael-cbc@<!-- -->lysator.liu.se algorithm
   * Added support for the hmac-ripemd160, hmac-ripemd160@<!-- -->openssh.com and hmac-ripemd160-etm@<!-- -->openssh.com algorithms using [Bouncy Castle](https://www.bouncycastle.org/)
-  * Added support for the cast128-cbc and cast128-ctr algorithms from [RFC 4253](https://datatracker.ietf.org/doc/html/rfc4253) and [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344) using [Bouncy Castle](https://www.bouncycastle.org/)
+  * Added support for various algorithms from [RFC 4253](https://datatracker.ietf.org/doc/html/rfc4253) and [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344) using [Bouncy Castle](https://www.bouncycastle.org/)
+    * cast128-cbc
+    * cast128-ctr
+    * twofish-cbc
+    * twofish128-cbc
+    * twofish128-ctr
+    * twofish192-cbc
+    * twofish192-ctr
+    * twofish256-cbc
+    * twofish256-ctr
   * Added support for the seed-cbc@<!-- -->ssh.com algorithm using [Bouncy Castle](https://www.bouncycastle.org/)
 * [0.1.67](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.67)
   * Added support for the blowfish-ctr algorithm from [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344)

--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,7 @@ As I explained in a [blog post](http://www.matez.de/index.php/2020/06/22/the-fut
   * This library is a Multi-Release-jar, which means that you can only use certain features when a more recent Java version is used.
     * In order to use ssh-ed25519 & ssh-ed448, you must use at least Java 15.
     * In order to use curve25519-sha256, curve448-sha512 & chacha20-poly1305@<!-- -->openssh.com, you must use at least Java 11.
-  * As of the [0.1.66](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.66) release, these algorithms can now be used with older Java releases if [Bouncy Castle](https://www.bouncycastle.org/) (bcprov-jdk15on) is added to the classpath.
+  * As of the [0.1.66](https://github.com/mwiede/jsch/releases/tag/jsch-0.1.66) release, these algorithms can now be used with older Java releases if [Bouncy Castle](https://www.bouncycastle.org/java.html) (bcprov-jdk15on) is added to the classpath.
 
 ## Changes since fork:
 See [ChangeLog.md](ChangeLog.md)

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -170,6 +170,13 @@ public class JSch{
 
     config.put("cast128-cbc",    "com.jcraft.jsch.bc.CAST128CBC");
     config.put("cast128-ctr",    "com.jcraft.jsch.bc.CAST128CTR");
+    config.put("twofish128-cbc",    "com.jcraft.jsch.bc.Twofish128CBC");
+    config.put("twofish192-cbc",    "com.jcraft.jsch.bc.Twofish192CBC");
+    config.put("twofish256-cbc",    "com.jcraft.jsch.bc.Twofish256CBC");
+    config.put("twofish-cbc",    "com.jcraft.jsch.bc.Twofish256CBC");
+    config.put("twofish128-ctr",    "com.jcraft.jsch.bc.Twofish128CTR");
+    config.put("twofish192-ctr",    "com.jcraft.jsch.bc.Twofish192CTR");
+    config.put("twofish256-ctr",    "com.jcraft.jsch.bc.Twofish256CTR");
     config.put("seed-cbc@ssh.com",    "com.jcraft.jsch.bc.SEEDCBC");
 
     config.put("aes128-ctr",    "com.jcraft.jsch.jce.AES128CTR");

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -154,6 +154,10 @@ public class JSch{
     config.put("keypairgen.ecdsa", "com.jcraft.jsch.jce.KeyPairGenECDSA");
     config.put("random",        "com.jcraft.jsch.jce.Random");
 
+    config.put("hmac-ripemd160", "com.jcraft.jsch.bc.HMACRIPEMD160");
+    config.put("hmac-ripemd160@openssh.com", "com.jcraft.jsch.bc.HMACRIPEMD160OpenSSH");
+    config.put("hmac-ripemd160-etm@openssh.com", "com.jcraft.jsch.bc.HMACRIPEMD160ETM");
+
     config.put("none",           "com.jcraft.jsch.CipherNone");
 
     config.put("aes128-gcm@openssh.com",    "com.jcraft.jsch.jce.AES128GCM");

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -162,6 +162,7 @@ public class JSch{
     config.put("aes128-cbc",    "com.jcraft.jsch.jce.AES128CBC");
     config.put("aes192-cbc",    "com.jcraft.jsch.jce.AES192CBC");
     config.put("aes256-cbc",    "com.jcraft.jsch.jce.AES256CBC");
+    config.put("rijndael-cbc@lysator.liu.se",    "com.jcraft.jsch.jce.AES256CBC");
 
     config.put("aes128-ctr",    "com.jcraft.jsch.jce.AES128CTR");
     config.put("aes192-ctr",    "com.jcraft.jsch.jce.AES192CTR");

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -170,6 +170,7 @@ public class JSch{
 
     config.put("cast128-cbc",    "com.jcraft.jsch.bc.CAST128CBC");
     config.put("cast128-ctr",    "com.jcraft.jsch.bc.CAST128CTR");
+    config.put("seed-cbc@ssh.com",    "com.jcraft.jsch.bc.SEEDCBC");
 
     config.put("aes128-ctr",    "com.jcraft.jsch.jce.AES128CTR");
     config.put("aes192-ctr",    "com.jcraft.jsch.jce.AES192CTR");

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -168,6 +168,9 @@ public class JSch{
     config.put("aes256-cbc",    "com.jcraft.jsch.jce.AES256CBC");
     config.put("rijndael-cbc@lysator.liu.se",    "com.jcraft.jsch.jce.AES256CBC");
 
+    config.put("cast128-cbc",    "com.jcraft.jsch.bc.CAST128CBC");
+    config.put("cast128-ctr",    "com.jcraft.jsch.bc.CAST128CTR");
+
     config.put("aes128-ctr",    "com.jcraft.jsch.jce.AES128CTR");
     config.put("aes192-ctr",    "com.jcraft.jsch.jce.AES192CTR");
     config.put("aes256-ctr",    "com.jcraft.jsch.jce.AES256CTR");

--- a/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
+++ b/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
@@ -124,7 +124,7 @@ public class OpenSSHConfig implements ConfigRepository {
       if(key_value.length <= 1)
         continue;
 
-      if(key_value[0].equals("Host")){
+      if(key_value[0].toUpperCase().equals("Host")){
         config.put(host, kv);
         hosts.addElement(host);
         host = key_value[1];

--- a/src/main/java/com/jcraft/jsch/bc/CAST128CBC.java
+++ b/src/main/java/com/jcraft/jsch/bc/CAST128CBC.java
@@ -1,0 +1,91 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import com.jcraft.jsch.Cipher;
+import org.bouncycastle.crypto.BufferedBlockCipher;
+import org.bouncycastle.crypto.engines.CAST5Engine;
+import org.bouncycastle.crypto.modes.CBCBlockCipher;
+import org.bouncycastle.crypto.params.*;
+
+public class CAST128CBC implements Cipher{
+  private static final int ivsize=8;
+  private static final int bsize=16;
+  private BufferedBlockCipher cipher;
+  @Override
+  public int getIVSize(){return ivsize;}
+  @Override
+  public int getBlockSize(){return bsize;}
+  @Override
+  public int getTagSize(){return 0;}
+  @Override
+  public void init(int mode, byte[] key, byte[] iv) throws Exception{
+    byte[] tmp;
+    if(iv.length>ivsize){
+      tmp=new byte[ivsize];
+      System.arraycopy(iv, 0, tmp, 0, tmp.length);
+      iv=tmp;
+    }
+    if(key.length>bsize){
+      tmp=new byte[bsize];
+      System.arraycopy(key, 0, tmp, 0, tmp.length);
+      key=tmp;
+    }
+
+    try{
+      ParametersWithIV keyspec=new ParametersWithIV(new KeyParameter(key, 0, key.length), iv, 0, iv.length);
+      cipher=new BufferedBlockCipher(new CBCBlockCipher(new CAST5Engine()));
+      cipher.init(mode==ENCRYPT_MODE, keyspec);
+    }
+    catch(Exception e){
+      cipher=null;
+      throw e;
+    }
+  }
+  @Override
+  public void update(int foo) throws Exception{
+  }
+  @Override
+  public void update(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+    cipher.processBytes(foo, s1, len, bar, s2);
+  }
+  @Override
+  public void updateAAD(byte[] foo, int s1, int len) throws Exception{
+  }
+  @Override
+  public void doFinal(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+  }
+  @Override
+  public boolean isCBC(){return true; }
+  @Override
+  public boolean isAEAD(){return false; }
+  @Override
+  public boolean isChaCha20(){return false; }
+}

--- a/src/main/java/com/jcraft/jsch/bc/CAST128CTR.java
+++ b/src/main/java/com/jcraft/jsch/bc/CAST128CTR.java
@@ -1,0 +1,90 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import com.jcraft.jsch.Cipher;
+import org.bouncycastle.crypto.engines.CAST5Engine;
+import org.bouncycastle.crypto.modes.SICBlockCipher;
+import org.bouncycastle.crypto.params.*;
+
+public class CAST128CTR implements Cipher{
+  private static final int ivsize=8;
+  private static final int bsize=16;
+  private SICBlockCipher cipher;
+  @Override
+  public int getIVSize(){return ivsize;}
+  @Override
+  public int getBlockSize(){return bsize;}
+  @Override
+  public int getTagSize(){return 0;}
+  @Override
+  public void init(int mode, byte[] key, byte[] iv) throws Exception{
+    byte[] tmp;
+    if(iv.length>ivsize){
+      tmp=new byte[ivsize];
+      System.arraycopy(iv, 0, tmp, 0, tmp.length);
+      iv=tmp;
+    }
+    if(key.length>bsize){
+      tmp=new byte[bsize];
+      System.arraycopy(key, 0, tmp, 0, tmp.length);
+      key=tmp;
+    }
+
+    try{
+      ParametersWithIV keyspec=new ParametersWithIV(new KeyParameter(key, 0, key.length), iv, 0, iv.length);
+      cipher=new SICBlockCipher(new CAST5Engine());
+      cipher.init(mode==ENCRYPT_MODE, keyspec);
+    }
+    catch(Exception e){
+      cipher=null;
+      throw e;
+    }
+  }
+  @Override
+  public void update(int foo) throws Exception{
+  }
+  @Override
+  public void update(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+    cipher.processBytes(foo, s1, len, bar, s2);
+  }
+  @Override
+  public void updateAAD(byte[] foo, int s1, int len) throws Exception{
+  }
+  @Override
+  public void doFinal(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+  }
+  @Override
+  public boolean isCBC(){return false; }
+  @Override
+  public boolean isAEAD(){return false; }
+  @Override
+  public boolean isChaCha20(){return false; }
+}

--- a/src/main/java/com/jcraft/jsch/bc/HMAC.java
+++ b/src/main/java/com/jcraft/jsch/bc/HMAC.java
@@ -1,0 +1,90 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2012-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import com.jcraft.jsch.MAC;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.macs.HMac;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+abstract class HMAC implements MAC {
+  protected String name;
+  protected int bsize;
+  protected Digest digest;
+  protected boolean etm;
+  private HMac mac;
+
+  @Override
+  public int getBlockSize() {
+    return bsize;
+  };
+
+  @Override
+  public void init(byte[] key) throws Exception {
+    if(key.length>bsize){
+      byte[] tmp = new byte[bsize];
+      System.arraycopy(key, 0, tmp, 0, bsize);	  
+      key = tmp;
+    }
+    KeyParameter skey = new KeyParameter(key, 0, key.length);
+    mac = new HMac(digest);
+    mac.init(skey);
+  } 
+
+  private final byte[] tmp = new byte[4];
+  @Override
+  public void update(int i){
+    tmp[0] = (byte)(i>>>24);
+    tmp[1] = (byte)(i>>>16);
+    tmp[2] = (byte)(i>>>8);
+    tmp[3] = (byte)i;
+    update(tmp, 0, 4);
+  }
+
+  @Override
+  public void update(byte foo[], int s, int l){
+    mac.update(foo, s, l);      
+  }
+
+  @Override
+  public void doFinal(byte[] buf, int offset){
+    mac.doFinal(buf, offset);
+  }
+
+  @Override
+  public String getName(){
+    return name;
+  }
+
+  @Override
+  public boolean isEtM(){
+    return etm;
+  }
+}

--- a/src/main/java/com/jcraft/jsch/bc/HMACRIPEMD160.java
+++ b/src/main/java/com/jcraft/jsch/bc/HMACRIPEMD160.java
@@ -1,0 +1,40 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2002-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import org.bouncycastle.crypto.digests.RIPEMD160Digest;
+
+public class HMACRIPEMD160 extends HMAC {
+  public HMACRIPEMD160(){
+    name = "hmac-ripemd160";
+    bsize = 20;
+    digest = new RIPEMD160Digest();
+  }
+}

--- a/src/main/java/com/jcraft/jsch/bc/HMACRIPEMD160ETM.java
+++ b/src/main/java/com/jcraft/jsch/bc/HMACRIPEMD160ETM.java
@@ -1,0 +1,37 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2002-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class HMACRIPEMD160ETM extends HMACRIPEMD160 {
+  public HMACRIPEMD160ETM(){
+    name = "hmac-ripemd160-etm@openssh.com";
+    etm = true;
+  }
+}

--- a/src/main/java/com/jcraft/jsch/bc/HMACRIPEMD160OpenSSH.java
+++ b/src/main/java/com/jcraft/jsch/bc/HMACRIPEMD160OpenSSH.java
@@ -1,0 +1,36 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2002-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class HMACRIPEMD160OpenSSH extends HMACRIPEMD160 {
+  public HMACRIPEMD160OpenSSH(){
+    name = "hmac-ripemd160@openssh.com";
+  }
+}

--- a/src/main/java/com/jcraft/jsch/bc/SEEDCBC.java
+++ b/src/main/java/com/jcraft/jsch/bc/SEEDCBC.java
@@ -1,0 +1,91 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import com.jcraft.jsch.Cipher;
+import org.bouncycastle.crypto.BufferedBlockCipher;
+import org.bouncycastle.crypto.engines.SEEDEngine;
+import org.bouncycastle.crypto.modes.CBCBlockCipher;
+import org.bouncycastle.crypto.params.*;
+
+public class SEEDCBC implements Cipher{
+  private static final int ivsize=16;
+  private static final int bsize=16;
+  private BufferedBlockCipher cipher;
+  @Override
+  public int getIVSize(){return ivsize;}
+  @Override
+  public int getBlockSize(){return bsize;}
+  @Override
+  public int getTagSize(){return 0;}
+  @Override
+  public void init(int mode, byte[] key, byte[] iv) throws Exception{
+    byte[] tmp;
+    if(iv.length>ivsize){
+      tmp=new byte[ivsize];
+      System.arraycopy(iv, 0, tmp, 0, tmp.length);
+      iv=tmp;
+    }
+    if(key.length>bsize){
+      tmp=new byte[bsize];
+      System.arraycopy(key, 0, tmp, 0, tmp.length);
+      key=tmp;
+    }
+
+    try{
+      ParametersWithIV keyspec=new ParametersWithIV(new KeyParameter(key, 0, key.length), iv, 0, iv.length);
+      cipher=new BufferedBlockCipher(new CBCBlockCipher(new SEEDEngine()));
+      cipher.init(mode==ENCRYPT_MODE, keyspec);
+    }
+    catch(Exception e){
+      cipher=null;
+      throw e;
+    }
+  }
+  @Override
+  public void update(int foo) throws Exception{
+  }
+  @Override
+  public void update(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+    cipher.processBytes(foo, s1, len, bar, s2);
+  }
+  @Override
+  public void updateAAD(byte[] foo, int s1, int len) throws Exception{
+  }
+  @Override
+  public void doFinal(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+  }
+  @Override
+  public boolean isCBC(){return true; }
+  @Override
+  public boolean isAEAD(){return false; }
+  @Override
+  public boolean isChaCha20(){return false; }
+}

--- a/src/main/java/com/jcraft/jsch/bc/Twofish128CBC.java
+++ b/src/main/java/com/jcraft/jsch/bc/Twofish128CBC.java
@@ -1,0 +1,36 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class Twofish128CBC extends TwofishCBC{
+  private static final int bsize=16;
+  @Override
+  public int getBlockSize(){return bsize;}
+}

--- a/src/main/java/com/jcraft/jsch/bc/Twofish128CTR.java
+++ b/src/main/java/com/jcraft/jsch/bc/Twofish128CTR.java
@@ -1,0 +1,36 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class Twofish128CTR extends TwofishCTR{
+  private static final int bsize=16;
+  @Override
+  public int getBlockSize(){return bsize;}
+}

--- a/src/main/java/com/jcraft/jsch/bc/Twofish192CBC.java
+++ b/src/main/java/com/jcraft/jsch/bc/Twofish192CBC.java
@@ -1,0 +1,36 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class Twofish192CBC extends TwofishCBC{
+  private static final int bsize=24;
+  @Override
+  public int getBlockSize(){return bsize;}
+}

--- a/src/main/java/com/jcraft/jsch/bc/Twofish192CTR.java
+++ b/src/main/java/com/jcraft/jsch/bc/Twofish192CTR.java
@@ -1,0 +1,36 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class Twofish192CTR extends TwofishCTR{
+  private static final int bsize=24;
+  @Override
+  public int getBlockSize(){return bsize;}
+}

--- a/src/main/java/com/jcraft/jsch/bc/Twofish256CBC.java
+++ b/src/main/java/com/jcraft/jsch/bc/Twofish256CBC.java
@@ -1,0 +1,36 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class Twofish256CBC extends TwofishCBC{
+  private static final int bsize=32;
+  @Override
+  public int getBlockSize(){return bsize;}
+}

--- a/src/main/java/com/jcraft/jsch/bc/Twofish256CTR.java
+++ b/src/main/java/com/jcraft/jsch/bc/Twofish256CTR.java
@@ -1,0 +1,36 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+public class Twofish256CTR extends TwofishCTR{
+  private static final int bsize=32;
+  @Override
+  public int getBlockSize(){return bsize;}
+}

--- a/src/main/java/com/jcraft/jsch/bc/TwofishCBC.java
+++ b/src/main/java/com/jcraft/jsch/bc/TwofishCBC.java
@@ -1,0 +1,89 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import com.jcraft.jsch.Cipher;
+import org.bouncycastle.crypto.BufferedBlockCipher;
+import org.bouncycastle.crypto.engines.TwofishEngine;
+import org.bouncycastle.crypto.modes.CBCBlockCipher;
+import org.bouncycastle.crypto.params.*;
+
+public abstract class TwofishCBC implements Cipher{
+  private static final int ivsize=16;
+  private BufferedBlockCipher cipher;
+  @Override
+  public int getIVSize(){return ivsize;}
+  @Override
+  public int getTagSize(){return 0;}
+  @Override
+  public void init(int mode, byte[] key, byte[] iv) throws Exception{
+    byte[] tmp;
+    if(iv.length>ivsize){
+      tmp=new byte[ivsize];
+      System.arraycopy(iv, 0, tmp, 0, tmp.length);
+      iv=tmp;
+    }
+    int bsize=getBlockSize();
+    if(key.length>bsize){
+      tmp=new byte[bsize];
+      System.arraycopy(key, 0, tmp, 0, tmp.length);
+      key=tmp;
+    }
+
+    try{
+      ParametersWithIV keyspec=new ParametersWithIV(new KeyParameter(key, 0, key.length), iv, 0, iv.length);
+      cipher=new BufferedBlockCipher(new CBCBlockCipher(new TwofishEngine()));
+      cipher.init(mode==ENCRYPT_MODE, keyspec);
+    }
+    catch(Exception e){
+      cipher=null;
+      throw e;
+    }
+  }
+  @Override
+  public void update(int foo) throws Exception{
+  }
+  @Override
+  public void update(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+    cipher.processBytes(foo, s1, len, bar, s2);
+  }
+  @Override
+  public void updateAAD(byte[] foo, int s1, int len) throws Exception{
+  }
+  @Override
+  public void doFinal(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+  }
+  @Override
+  public boolean isCBC(){return true; }
+  @Override
+  public boolean isAEAD(){return false; }
+  @Override
+  public boolean isChaCha20(){return false; }
+}

--- a/src/main/java/com/jcraft/jsch/bc/TwofishCTR.java
+++ b/src/main/java/com/jcraft/jsch/bc/TwofishCTR.java
@@ -1,0 +1,88 @@
+/* -*-mode:java; c-basic-offset:2; indent-tabs-mode:nil -*- */
+/*
+Copyright (c) 2005-2018 ymnk, JCraft,Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright 
+     notice, this list of conditions and the following disclaimer in 
+     the documentation and/or other materials provided with the distribution.
+
+  3. The names of the authors may not be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.jcraft.jsch.bc;
+
+import com.jcraft.jsch.Cipher;
+import org.bouncycastle.crypto.engines.TwofishEngine;
+import org.bouncycastle.crypto.modes.SICBlockCipher;
+import org.bouncycastle.crypto.params.*;
+
+public abstract class TwofishCTR implements Cipher{
+  private static final int ivsize=16;
+  private SICBlockCipher cipher;
+  @Override
+  public int getIVSize(){return ivsize;}
+  @Override
+  public int getTagSize(){return 0;}
+  @Override
+  public void init(int mode, byte[] key, byte[] iv) throws Exception{
+    byte[] tmp;
+    if(iv.length>ivsize){
+      tmp=new byte[ivsize];
+      System.arraycopy(iv, 0, tmp, 0, tmp.length);
+      iv=tmp;
+    }
+    int bsize=getBlockSize();
+    if(key.length>bsize){
+      tmp=new byte[bsize];
+      System.arraycopy(key, 0, tmp, 0, tmp.length);
+      key=tmp;
+    }
+
+    try{
+      ParametersWithIV keyspec=new ParametersWithIV(new KeyParameter(key, 0, key.length), iv, 0, iv.length);
+      cipher=new SICBlockCipher(new TwofishEngine());
+      cipher.init(mode==ENCRYPT_MODE, keyspec);
+    }
+    catch(Exception e){
+      cipher=null;
+      throw e;
+    }
+  }
+  @Override
+  public void update(int foo) throws Exception{
+  }
+  @Override
+  public void update(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+    cipher.processBytes(foo, s1, len, bar, s2);
+  }
+  @Override
+  public void updateAAD(byte[] foo, int s1, int len) throws Exception{
+  }
+  @Override
+  public void doFinal(byte[] foo, int s1, int len, byte[] bar, int s2) throws Exception{
+  }
+  @Override
+  public boolean isCBC(){return false; }
+  @Override
+  public boolean isAEAD(){return false; }
+  @Override
+  public boolean isChaCha20(){return false; }
+}

--- a/src/test/java/com/jcraft/jsch/Algorithms2IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms2IT.java
@@ -267,6 +267,27 @@ public class Algorithms2IT {
   @ParameterizedTest
   @CsvSource(
       value = {
+        "seed-cbc@ssh.com,none",
+        "seed-cbc@ssh.com,zlib@openssh.com"
+      })
+  public void testCiphers(String cipher, String compression) throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+    session.setConfig("cipher.s2c", cipher);
+    session.setConfig("cipher.c2s", cipher);
+    session.setConfig("compression.s2c", compression);
+    session.setConfig("compression.c2s", compression);
+    doSftp(session, true);
+
+    String expectedS2C = String.format("kex: server->client cipher: %s.*", cipher);
+    String expectedC2S = String.format("kex: client->server cipher: %s.*", cipher);
+    checkLogs(expectedS2C);
+    checkLogs(expectedC2S);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {
         "hmac-sha512@ssh.com,none",
         "hmac-sha512@ssh.com,zlib@openssh.com",
         "hmac-sha384@ssh.com,none",

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -419,7 +419,13 @@ public class AlgorithmsIT {
         "hmac-md5,none",
         "hmac-md5,zlib@openssh.com",
         "hmac-md5-96,none",
-        "hmac-md5-96,zlib@openssh.com"
+        "hmac-md5-96,zlib@openssh.com",
+        "hmac-ripemd160,none",
+        "hmac-ripemd160,zlib@openssh.com",
+        "hmac-ripemd160@openssh.com,none",
+        "hmac-ripemd160@openssh.com,zlib@openssh.com",
+        "hmac-ripemd160-etm@openssh.com,none",
+        "hmac-ripemd160-etm@openssh.com,zlib@openssh.com"
       })
   public void testMACs(String mac, String compression) throws Exception {
     JSch ssh = createRSAIdentity();

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -376,7 +376,9 @@ public class AlgorithmsIT {
         "arcfour128,none",
         "arcfour128,zlib@openssh.com",
         "rijndael-cbc@lysator.liu.se,none",
-        "rijndael-cbc@lysator.liu.se,zlib@openssh.com"
+        "rijndael-cbc@lysator.liu.se,zlib@openssh.com",
+        "cast128-cbc,none",
+        "cast128-cbc,zlib@openssh.com"
       })
   public void testCiphers(String cipher, String compression) throws Exception {
     JSch ssh = createRSAIdentity();

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -374,7 +374,9 @@ public class AlgorithmsIT {
         "arcfour256,none",
         "arcfour256,zlib@openssh.com",
         "arcfour128,none",
-        "arcfour128,zlib@openssh.com"
+        "arcfour128,zlib@openssh.com",
+        "rijndael-cbc@lysator.liu.se,none",
+        "rijndael-cbc@lysator.liu.se,zlib@openssh.com"
       })
   public void testCiphers(String cipher, String compression) throws Exception {
     JSch ssh = createRSAIdentity();

--- a/src/test/resources/docker/asyncsshd.py
+++ b/src/test/resources/docker/asyncsshd.py
@@ -38,7 +38,7 @@ async def start_server():
                           encryption_algs=['chacha20-poly1305@openssh.com', 'aes256-gcm@openssh.com',
                                            'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr',
                                            'aes256-cbc', 'aes192-cbc', 'aes128-cbc', '3des-cbc', 'blowfish-cbc',
-                                           'arcfour', 'arcfour256', 'arcfour128', 'cast128-cbc'],
+                                           'arcfour', 'arcfour256', 'arcfour128', 'cast128-cbc', 'seed-cbc@ssh.com'],
                           mac_algs=['hmac-sha2-512-etm@openssh.com', 'hmac-sha2-256-etm@openssh.com',
                                     'hmac-sha1-etm@openssh.com', 'hmac-sha2-512', 'hmac-sha2-256', 'hmac-sha1',
                                     'hmac-sha1-96-etm@openssh.com', 'hmac-sha1-96', 'hmac-md5-etm@openssh.com',

--- a/src/test/resources/docker/asyncsshd.py
+++ b/src/test/resources/docker/asyncsshd.py
@@ -38,7 +38,7 @@ async def start_server():
                           encryption_algs=['chacha20-poly1305@openssh.com', 'aes256-gcm@openssh.com',
                                            'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr',
                                            'aes256-cbc', 'aes192-cbc', 'aes128-cbc', '3des-cbc', 'blowfish-cbc',
-                                           'arcfour', 'arcfour256', 'arcfour128'],
+                                           'arcfour', 'arcfour256', 'arcfour128', 'cast128-cbc'],
                           mac_algs=['hmac-sha2-512-etm@openssh.com', 'hmac-sha2-256-etm@openssh.com',
                                     'hmac-sha1-etm@openssh.com', 'hmac-sha2-512', 'hmac-sha2-256', 'hmac-sha1',
                                     'hmac-sha1-96-etm@openssh.com', 'hmac-sha1-96', 'hmac-md5-etm@openssh.com',

--- a/src/test/resources/docker/sshd_config
+++ b/src/test/resources/docker/sshd_config
@@ -16,6 +16,6 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
 KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
 HostKeyAlgorithms ecdsa-sha2-nistp521,ecdsa-sha2-nistp384,ecdsa-sha2-nistp256,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa,ssh-dss
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc,blowfish-cbc,arcfour,arcfour256,arcfour128
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc,blowfish-cbc,arcfour,arcfour256,arcfour128,rijndael-cbc@lysator.liu.se
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-96-etm@openssh.com,hmac-sha1-96,hmac-md5-etm@openssh.com,hmac-md5,hmac-md5-96-etm@openssh.com,hmac-md5-96
 LogLevel DEBUG3

--- a/src/test/resources/docker/sshd_config
+++ b/src/test/resources/docker/sshd_config
@@ -17,5 +17,5 @@ HostKey /etc/ssh/ssh_host_dsa_key
 KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
 HostKeyAlgorithms ecdsa-sha2-nistp521,ecdsa-sha2-nistp384,ecdsa-sha2-nistp256,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa,ssh-dss
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc,blowfish-cbc,arcfour,arcfour256,arcfour128,rijndael-cbc@lysator.liu.se
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-96-etm@openssh.com,hmac-sha1-96,hmac-md5-etm@openssh.com,hmac-md5,hmac-md5-96-etm@openssh.com,hmac-md5-96
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-96-etm@openssh.com,hmac-sha1-96,hmac-md5-etm@openssh.com,hmac-md5,hmac-md5-96-etm@openssh.com,hmac-md5-96,hmac-ripemd160,hmac-ripemd160@openssh.com,hmac-ripemd160-etm@openssh.com
 LogLevel DEBUG3

--- a/src/test/resources/docker/sshd_config
+++ b/src/test/resources/docker/sshd_config
@@ -16,6 +16,6 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
 KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512,diffie-hellman-group14-sha256,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
 HostKeyAlgorithms ecdsa-sha2-nistp521,ecdsa-sha2-nistp384,ecdsa-sha2-nistp256,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa,ssh-dss
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc,blowfish-cbc,arcfour,arcfour256,arcfour128,rijndael-cbc@lysator.liu.se
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr,aes256-cbc,aes192-cbc,aes128-cbc,3des-cbc,blowfish-cbc,arcfour,arcfour256,arcfour128,rijndael-cbc@lysator.liu.se,cast128-cbc
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-96-etm@openssh.com,hmac-sha1-96,hmac-md5-etm@openssh.com,hmac-md5,hmac-md5-96-etm@openssh.com,hmac-md5-96,hmac-ripemd160,hmac-ripemd160@openssh.com,hmac-ripemd160-etm@openssh.com
 LogLevel DEBUG3


### PR DESCRIPTION
* Added support for the rijndael-cbc@<!-- -->lysator.liu.se algorithm
* Added support for the hmac-ripemd160, hmac-ripemd160@<!-- -->openssh.com and hmac-ripemd160-etm@<!-- -->openssh.com algorithms using [Bouncy Castle](https://www.bouncycastle.org/java.html)
* Added support for various algorithms from [RFC 4253](https://datatracker.ietf.org/doc/html/rfc4253) and [RFC 4344](https://datatracker.ietf.org/doc/html/rfc4344) using [Bouncy Castle](https://www.bouncycastle.org/java.html)
  * cast128-cbc
  * cast128-ctr
  * twofish-cbc
  * twofish128-cbc
  * twofish128-ctr
  * twofish192-cbc
  * twofish192-ctr
  * twofish256-cbc
  * twofish256-ctr
* Added support for the seed-cbc@<!-- -->ssh.com algorithm using [Bouncy Castle](https://www.bouncycastle.org/java.html)
* Address [#76](https://github.com/mwiede/jsch/issues/76) by making the "Host" keyword case-insensitive