### PR TITLE
Fix PageantConnector struct class visibility

### DIFF
--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -88,7 +88,7 @@ public class PageantConnector implements AgentConnector {
     long SendMessage(HWND hWnd, int msg, WPARAM num1, byte[] num2);
   }
 
-  private static class COPYDATASTRUCT32 extends Structure {
+  public static class COPYDATASTRUCT32 extends Structure {
     public int dwData;
     public int cbData;
     public Pointer lpData;
@@ -99,7 +99,7 @@ public class PageantConnector implements AgentConnector {
     }
   }
 
-  private static class COPYDATASTRUCT64 extends Structure {
+  public static class COPYDATASTRUCT64 extends Structure {
     public int dwData;
     public long cbData;
     public Pointer lpData;


### PR DESCRIPTION
The visibility of the struct classes need to be public otherwise the following exception will be thrown:

````txt
Caused by: java.lang.IllegalAccessException: Class com.sun.jna.Structure can not access a member of class com.jcraft.jsch.PageantConnector$COPYDATASTRUCT64 with modifiers "public"
	at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:102)
	at java.lang.reflect.AccessibleObject.slowCheckMemberAccess(AccessibleObject.java:296)
	at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:288)
	at java.lang.reflect.Field.get(Field.java:390)
	at com.sun.jna.Structure.getFieldValue(Structure.java:650)
	... 101 more
````

`protected` seems to work as well, but this might be due to the test setup.

However, this causes these internal data classes to become accessible from the outside.
As a workaround it is also possible to move the data classes inside the private `User32` interface.
Should we do this instead?

See also: https://stackoverflow.com/questions/66214743/instantiating-subclass-of-jna-structure-throws-illegalaccessexception

I have verified the code with gitlab, jgit and KeePass (as Pageant SSHAgent):

https://github.com/mwiede/jsch/issues/85#issuecomment-942086643