### PR TITLE
env passing should be unwant reply

### DIFF
--- a/src/main/java/com/jcraft/jsch/ChannelSession.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSession.java
@@ -219,7 +219,8 @@ class ChannelSession extends Channel{
         byte[] name=_env.nextElement();
         byte[] value=env.get(name);
         request=new RequestEnv();
-        ((RequestEnv)request).setEnv(toByteArray(name), 
+        request.setReply(false);
+        ((RequestEnv)request).setEnv(toByteArray(name),
                                      toByteArray(value));
         request.request(_session, this);
       }


### PR DESCRIPTION
RFC4254 Section 6.4 describe environment variable passing can be filtered in security imprecations.
This can be resulted a reply become false, but it is not an error.

According to JGit discussion about behavior of Jsch env request,
it should be 'unwant-reply' and its JSch bug.
https://bugs.eclipse.org/bugs/show_bug.cgi?id=576922

When JGit request GIT_PROTOCOL=version=2 environment variable,
JSch should return even when it is not succeeded.

This modification intend to change env request to be unwant-reply.

resolve #93

Signed-off-by: Hiroshi Miura <miurahr@linux.com>