### PR TITLE
Use spaces as indentation consistently

### DIFF
--- a/examples/AES.java
+++ b/examples/AES.java
@@ -137,7 +137,7 @@ public class AES{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/ChangePassphrase.java
+++ b/examples/ChangePassphrase.java
@@ -31,21 +31,21 @@ class ChangePassphrase{
 
       String passphrase="";
       while(kpair.isEncrypted()){
-	JTextField passphraseField=(JTextField)new JPasswordField(20);
-	Object[] ob={passphraseField};
-	int result=JOptionPane.showConfirmDialog(null, ob, 
-						 "Enter passphrase for "+pkey,
-						 JOptionPane.OK_CANCEL_OPTION);
-	if(result!=JOptionPane.OK_OPTION){
-	  System.exit(-1);
-	}
-	passphrase=passphraseField.getText();
-	if(!kpair.decrypt(passphrase)){
-	  System.out.println("failed to decrypt "+pkey);
-	}
-	else{
-	  System.out.println(pkey+" is decrypted.");
-	}
+        JTextField passphraseField=(JTextField)new JPasswordField(20);
+        Object[] ob={passphraseField};
+        int result=JOptionPane.showConfirmDialog(null, ob, 
+                                                 "Enter passphrase for "+pkey,
+                                                 JOptionPane.OK_CANCEL_OPTION);
+        if(result!=JOptionPane.OK_OPTION){
+          System.exit(-1);
+        }
+        passphrase=passphraseField.getText();
+        if(!kpair.decrypt(passphrase)){
+          System.out.println("failed to decrypt "+pkey);
+        }
+        else{
+          System.out.println(pkey+" is decrypted.");
+        }
       }
 
       passphrase="";
@@ -53,11 +53,11 @@ class ChangePassphrase{
       JTextField passphraseField=(JTextField)new JPasswordField(20);
       Object[] ob={passphraseField};
       int result=JOptionPane.showConfirmDialog(null, ob, 
-					       "Enter new passphrase for "+pkey+
-					       " (empty for no passphrase)",
-					       JOptionPane.OK_CANCEL_OPTION);
+                                               "Enter new passphrase for "+pkey+
+                                               " (empty for no passphrase)",
+                                               JOptionPane.OK_CANCEL_OPTION);
       if(result!=JOptionPane.OK_OPTION){
-	System.exit(-1);
+        System.exit(-1);
       }
       passphrase=passphraseField.getText();
 

--- a/examples/Compression.java
+++ b/examples/Compression.java
@@ -75,11 +75,11 @@ public class Compression{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -137,7 +137,7 @@ public class Compression{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/Daemon.java
+++ b/examples/Daemon.java
@@ -165,7 +165,7 @@ public class Daemon{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/Exec.java
+++ b/examples/Exec.java
@@ -177,7 +177,7 @@ public class Exec{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/KeyGen.java
+++ b/examples/KeyGen.java
@@ -61,7 +61,7 @@ class KeyGen{
     Object[] ob={passphraseField};
     int result=
       JOptionPane.showConfirmDialog(null, ob, "Enter passphrase (empty for no passphrase)",
-				    JOptionPane.OK_CANCEL_OPTION);
+                                    JOptionPane.OK_CANCEL_OPTION);
     if(result==JOptionPane.OK_OPTION){
       passphrase=passphraseField.getText();
     }

--- a/examples/KnownHosts.java
+++ b/examples/KnownHosts.java
@@ -25,21 +25,21 @@ public class KnownHosts{
       int returnVal=chooser.showOpenDialog(null);
       if(returnVal==JFileChooser.APPROVE_OPTION) {
         System.out.println("You chose "+
-			   chooser.getSelectedFile().getAbsolutePath()+".");
-	jsch.setKnownHosts(chooser.getSelectedFile().getAbsolutePath());
+                           chooser.getSelectedFile().getAbsolutePath()+".");
+        jsch.setKnownHosts(chooser.getSelectedFile().getAbsolutePath());
       }
 
       HostKeyRepository hkr=jsch.getHostKeyRepository();
       HostKey[] hks=hkr.getHostKey();
       if(hks!=null){
-	System.out.println("Host keys in "+hkr.getKnownHostsRepositoryID());
-	for(int i=0; i<hks.length; i++){
-	  HostKey hk=hks[i];
-	  System.out.println(hk.getHost()+" "+
-			     hk.getType()+" "+
-			     hk.getFingerPrint(jsch));
-	}
-	System.out.println("");
+        System.out.println("Host keys in "+hkr.getKnownHostsRepositoryID());
+        for(int i=0; i<hks.length; i++){
+          HostKey hk=hks[i];
+          System.out.println(hk.getHost()+" "+
+                             hk.getType()+" "+
+                             hk.getFingerPrint(jsch));
+        }
+        System.out.println("");
       }
 
       String host=null;
@@ -68,11 +68,11 @@ public class KnownHosts{
       session.connect();
 
       {
-	HostKey hk=session.getHostKey();
-	System.out.println("HostKey: "+
-			   hk.getHost()+" "+
-			   hk.getType()+" "+
-			   hk.getFingerPrint(jsch));
+        HostKey hk=session.getHostKey();
+        System.out.println("HostKey: "+
+                           hk.getHost()+" "+
+                           hk.getType()+" "+
+                           hk.getFingerPrint(jsch));
       }
 
       Channel channel=session.openChannel("shell");
@@ -108,11 +108,11 @@ public class KnownHosts{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -170,7 +170,7 @@ public class KnownHosts{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/Logger.java
+++ b/examples/Logger.java
@@ -148,7 +148,7 @@ public class Logger{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/PortForwardingL.java
+++ b/examples/PortForwardingL.java
@@ -39,7 +39,7 @@ public class PortForwardingL{
       Session session=jsch.getSession(user, host, 22);
 
       String foo=JOptionPane.showInputDialog("Enter -L port:host:hostport",
-					     "port:host:hostport");
+                                             "port:host:hostport");
       lport=Integer.parseInt(foo.substring(0, foo.indexOf(':')));
       foo=foo.substring(foo.indexOf(':')+1);
       rhost=foo.substring(0, foo.indexOf(':'));
@@ -83,11 +83,11 @@ public class PortForwardingL{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -145,7 +145,7 @@ public class PortForwardingL{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/PortForwardingR.java
+++ b/examples/PortForwardingR.java
@@ -39,7 +39,7 @@ public class PortForwardingR{
       Session session=jsch.getSession(user, host, 22);
 
       String foo=JOptionPane.showInputDialog("Enter -R port:host:hostport", 
-					     "port:host:hostport");
+                                             "port:host:hostport");
       rport=Integer.parseInt(foo.substring(0, foo.indexOf(':')));
       foo=foo.substring(foo.indexOf(':')+1);
       lhost=foo.substring(0, foo.indexOf(':'));
@@ -84,11 +84,11 @@ public class PortForwardingR{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -146,7 +146,7 @@ public class PortForwardingR{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/ScpFrom.java
+++ b/examples/ScpFrom.java
@@ -61,10 +61,10 @@ public class ScpFrom{
       buf[0]=0; out.write(buf, 0, 1); out.flush();
 
       while(true){
-	int c=checkAck(in);
+        int c=checkAck(in);
         if(c!='C'){
-	  break;
-	}
+          break;
+        }
 
         // read '0644 '
         in.read(buf, 0, 5);
@@ -85,10 +85,10 @@ public class ScpFrom{
           if(buf[i]==(byte)0x0a){
             file=new String(buf, 0, i);
             break;
-  	  }
+            }
         }
 
-	//System.out.println("filesize="+filesize+", file="+file);
+        //System.out.println("filesize="+filesize+", file="+file);
 
         // send '\0'
         buf[0]=0; out.write(buf, 0, 1); out.flush();
@@ -98,7 +98,7 @@ public class ScpFrom{
         int foo;
         while(true){
           if(buf.length<filesize) foo=buf.length;
-	  else foo=(int)filesize;
+          else foo=(int)filesize;
           foo=in.read(buf, 0, foo);
           if(foo<0){
             // error 
@@ -111,9 +111,9 @@ public class ScpFrom{
         fos.close();
         fos=null;
 
-	if(checkAck(in)!=0){
-	  System.exit(0);
-	}
+        if(checkAck(in)!=0){
+          System.exit(0);
+        }
 
         // send '\0'
         buf[0]=0; out.write(buf, 0, 1); out.flush();
@@ -142,15 +142,15 @@ public class ScpFrom{
       StringBuffer sb=new StringBuffer();
       int c;
       do {
-	c=in.read();
-	sb.append((char)c);
+        c=in.read();
+        sb.append((char)c);
       }
       while(c!='\n');
       if(b==1){ // error
-	System.out.print(sb.toString());
+        System.out.print(sb.toString());
       }
       if(b==2){ // fatal error
-	System.out.print(sb.toString());
+        System.out.print(sb.toString());
       }
     }
     return b;
@@ -177,11 +177,11 @@ public class ScpFrom{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -239,7 +239,7 @@ public class ScpFrom{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/ScpTo.java
+++ b/examples/ScpTo.java
@@ -53,7 +53,7 @@ public class ScpTo{
       channel.connect();
 
       if(checkAck(in)!=0){
-	System.exit(0);
+        System.exit(0);
       }
 
       File _lfile = new File(lfile);
@@ -65,7 +65,7 @@ public class ScpTo{
         command+=(" "+(_lfile.lastModified()/1000)+" 0\n"); 
         out.write(command.getBytes()); out.flush();
         if(checkAck(in)!=0){
-  	  System.exit(0);
+            System.exit(0);
         }
       }
 
@@ -81,7 +81,7 @@ public class ScpTo{
       command+="\n";
       out.write(command.getBytes()); out.flush();
       if(checkAck(in)!=0){
-	System.exit(0);
+        System.exit(0);
       }
 
       // send a content of lfile
@@ -89,7 +89,7 @@ public class ScpTo{
       byte[] buf=new byte[1024];
       while(true){
         int len=fis.read(buf, 0, buf.length);
-	if(len<=0) break;
+        if(len<=0) break;
         out.write(buf, 0, len); //out.flush();
       }
       fis.close();
@@ -97,7 +97,7 @@ public class ScpTo{
       // send '\0'
       buf[0]=0; out.write(buf, 0, 1); out.flush();
       if(checkAck(in)!=0){
-	System.exit(0);
+        System.exit(0);
       }
       out.close();
 
@@ -125,15 +125,15 @@ public class ScpTo{
       StringBuffer sb=new StringBuffer();
       int c;
       do {
-	c=in.read();
-	sb.append((char)c);
+        c=in.read();
+        sb.append((char)c);
       }
       while(c!='\n');
       if(b==1){ // error
-	System.out.print(sb.toString());
+        System.out.print(sb.toString());
       }
       if(b==2){ // fatal error
-	System.out.print(sb.toString());
+        System.out.print(sb.toString());
       }
     }
     return b;
@@ -160,11 +160,11 @@ public class ScpTo{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -222,7 +222,7 @@ public class ScpTo{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/ScpToNoneCipher.java
+++ b/examples/ScpToNoneCipher.java
@@ -51,7 +51,7 @@ public class ScpToNoneCipher{
       channel.connect();
 
       if(checkAck(in)!=0){
-	System.exit(0);
+        System.exit(0);
       }
 
       // send "C0644 filesize filename", where filename should not include '/'
@@ -67,7 +67,7 @@ public class ScpToNoneCipher{
       out.write(command.getBytes()); out.flush();
 
       if(checkAck(in)!=0){
-	System.exit(0);
+        System.exit(0);
       }
 
       // send a content of lfile
@@ -75,7 +75,7 @@ public class ScpToNoneCipher{
       byte[] buf=new byte[1024];
       while(true){
         int len=fis.read(buf, 0, buf.length);
-	if(len<=0) break;
+        if(len<=0) break;
         out.write(buf, 0, len); out.flush();
       }
       fis.close();
@@ -85,7 +85,7 @@ public class ScpToNoneCipher{
       buf[0]=0; out.write(buf, 0, 1); out.flush();
 
       if(checkAck(in)!=0){
-	System.exit(0);
+        System.exit(0);
       }
 
       session.disconnect();
@@ -111,15 +111,15 @@ public class ScpToNoneCipher{
       StringBuffer sb=new StringBuffer();
       int c;
       do {
-	c=in.read();
-	sb.append((char)c);
+        c=in.read();
+        sb.append((char)c);
       }
       while(c!='\n');
       if(b==1){ // error
-	System.out.print(sb.toString());
+        System.out.print(sb.toString());
       }
       if(b==2){ // fatal error
-	System.out.print(sb.toString());
+        System.out.print(sb.toString());
       }
     }
     return b;
@@ -146,11 +146,11 @@ public class ScpToNoneCipher{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -208,7 +208,7 @@ public class ScpToNoneCipher{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/Sftp.java
+++ b/examples/Sftp.java
@@ -56,211 +56,211 @@ public class Sftp{
 
       while(true){
         out.print("sftp> ");
-	cmds.removeAllElements();
+        cmds.removeAllElements();
         i=in.read(buf, 0, 1024);
-	if(i<=0)break;
+        if(i<=0)break;
 
         i--;
         if(i>0 && buf[i-1]==0x0d)i--;
         //str=new String(buf, 0, i);
         //System.out.println("|"+str+"|");
-	int s=0;
-	for(int ii=0; ii<i; ii++){
+        int s=0;
+        for(int ii=0; ii<i; ii++){
           if(buf[ii]==' '){
             if(ii-s>0){ cmds.addElement(new String(buf, s, ii-s)); }
-	    while(ii<i){if(buf[ii]!=' ')break; ii++;}
-	    s=ii;
-	  }
-	}
-	if(s<i){ cmds.addElement(new String(buf, s, i-s)); }
-	if(cmds.size()==0)continue;
+            while(ii<i){if(buf[ii]!=' ')break; ii++;}
+            s=ii;
+          }
+        }
+        if(s<i){ cmds.addElement(new String(buf, s, i-s)); }
+        if(cmds.size()==0)continue;
 
-	String cmd=(String)cmds.elementAt(0);
-	if(cmd.equals("quit")){
+        String cmd=(String)cmds.elementAt(0);
+        if(cmd.equals("quit")){
           c.quit();
-	  break;
-	}
-	if(cmd.equals("exit")){
+          break;
+        }
+        if(cmd.equals("exit")){
           c.exit();
-	  break;
-	}
- 	if(cmd.equals("rekey")){
- 	  session.rekey();
- 	  continue;
- 	}
- 	if(cmd.equals("compression")){
+          break;
+        }
+         if(cmd.equals("rekey")){
+           session.rekey();
+           continue;
+         }
+         if(cmd.equals("compression")){
           if(cmds.size()<2){
-	    out.println("compression level: "+level);
+            out.println("compression level: "+level);
             continue;
-	  }
-	  try{
-	    level=Integer.parseInt((String)cmds.elementAt(1));
-	    if(level==0){
-	      session.setConfig("compression.s2c", "none");
-	      session.setConfig("compression.c2s", "none");
-	    }
-	    else{
+          }
+          try{
+            level=Integer.parseInt((String)cmds.elementAt(1));
+            if(level==0){
+              session.setConfig("compression.s2c", "none");
+              session.setConfig("compression.c2s", "none");
+            }
+            else{
               session.setConfig("compression.s2c", "zlib@openssh.com,zlib,none");
               session.setConfig("compression.c2s", "zlib@openssh.com,zlib,none");
-	    }
-	  }
-	  catch(Exception e){}
+            }
+          }
+          catch(Exception e){}
           session.rekey();
- 	  continue;
-	}
-	if(cmd.equals("cd") || cmd.equals("lcd")){
+           continue;
+        }
+        if(cmd.equals("cd") || cmd.equals("lcd")){
           if(cmds.size()<2) continue;
-	  String path=(String)cmds.elementAt(1);
-	  try{
-	    if(cmd.equals("cd")) c.cd(path);
-	    else c.lcd(path);
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("rm") || cmd.equals("rmdir") || cmd.equals("mkdir")){
+          String path=(String)cmds.elementAt(1);
+          try{
+            if(cmd.equals("cd")) c.cd(path);
+            else c.lcd(path);
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("rm") || cmd.equals("rmdir") || cmd.equals("mkdir")){
           if(cmds.size()<2) continue;
-	  String path=(String)cmds.elementAt(1);
-	  try{
-	    if(cmd.equals("rm")) c.rm(path);
-	    else if(cmd.equals("rmdir")) c.rmdir(path);
-	    else c.mkdir(path);
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("chgrp") || cmd.equals("chown") || cmd.equals("chmod")){
+          String path=(String)cmds.elementAt(1);
+          try{
+            if(cmd.equals("rm")) c.rm(path);
+            else if(cmd.equals("rmdir")) c.rmdir(path);
+            else c.mkdir(path);
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("chgrp") || cmd.equals("chown") || cmd.equals("chmod")){
           if(cmds.size()!=3) continue;
-	  String path=(String)cmds.elementAt(2);
-	  int foo=0;
-	  if(cmd.equals("chmod")){
+          String path=(String)cmds.elementAt(2);
+          int foo=0;
+          if(cmd.equals("chmod")){
             byte[] bar=((String)cmds.elementAt(1)).getBytes();
             int k;
             for(int j=0; j<bar.length; j++){
               k=bar[j];
-	      if(k<'0'||k>'7'){foo=-1; break;}
-  	      foo<<=3;
-	      foo|=(k-'0');
-	    }
-	    if(foo==-1)continue;
-	  }
-	  else{
-  	    try{foo=Integer.parseInt((String)cmds.elementAt(1));}
-	    catch(Exception e){continue;}
-	  }
-	  try{
-	    if(cmd.equals("chgrp")){ c.chgrp(foo, path); }
-	    else if(cmd.equals("chown")){ c.chown(foo, path); }
-	    else if(cmd.equals("chmod")){ c.chmod(foo, path); }
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("pwd") || cmd.equals("lpwd")){
+              if(k<'0'||k>'7'){foo=-1; break;}
+                foo<<=3;
+              foo|=(k-'0');
+            }
+            if(foo==-1)continue;
+          }
+          else{
+              try{foo=Integer.parseInt((String)cmds.elementAt(1));}
+            catch(Exception e){continue;}
+          }
+          try{
+            if(cmd.equals("chgrp")){ c.chgrp(foo, path); }
+            else if(cmd.equals("chown")){ c.chown(foo, path); }
+            else if(cmd.equals("chmod")){ c.chmod(foo, path); }
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("pwd") || cmd.equals("lpwd")){
            str=(cmd.equals("pwd")?"Remote":"Local");
-	   str+=" working directory: ";
+           str+=" working directory: ";
           if(cmd.equals("pwd")) str+=c.pwd();
-	  else str+=c.lpwd();
-	  out.println(str);
-	  continue;
-	}
-	if(cmd.equals("ls") || cmd.equals("dir")){
-	  String path=".";
-	  if(cmds.size()==2) path=(String)cmds.elementAt(1);
-	  try{
-	    java.util.Vector vv=c.ls(path);
-	    if(vv!=null){
-	      for(int ii=0; ii<vv.size(); ii++){
-//		out.println(vv.elementAt(ii).toString());
+          else str+=c.lpwd();
+          out.println(str);
+          continue;
+        }
+        if(cmd.equals("ls") || cmd.equals("dir")){
+          String path=".";
+          if(cmds.size()==2) path=(String)cmds.elementAt(1);
+          try{
+            java.util.Vector vv=c.ls(path);
+            if(vv!=null){
+              for(int ii=0; ii<vv.size(); ii++){
+//                out.println(vv.elementAt(ii).toString());
 
                 Object obj=vv.elementAt(ii);
                 if(obj instanceof com.jcraft.jsch.ChannelSftp.LsEntry){
                   out.println(((com.jcraft.jsch.ChannelSftp.LsEntry)obj).getLongname());
                 }
 
-	      }
-	    }
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("lls") || cmd.equals("ldir")){
-	  String path=".";
-	  if(cmds.size()==2) path=(String)cmds.elementAt(1);
-	  try{
-	    java.io.File file=new java.io.File(path);
-	    if(!file.exists()){
-	      out.println(path+": No such file or directory");
+              }
+            }
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("lls") || cmd.equals("ldir")){
+          String path=".";
+          if(cmds.size()==2) path=(String)cmds.elementAt(1);
+          try{
+            java.io.File file=new java.io.File(path);
+            if(!file.exists()){
+              out.println(path+": No such file or directory");
               continue; 
             }
-	    if(file.isDirectory()){
-	      String[] list=file.list();
-	      for(int ii=0; ii<list.length; ii++){
-		out.println(list[ii]);
-	      }
-	      continue;
-	    }
-	    out.println(path);
-	  }
-	  catch(Exception e){
-	    System.out.println(e);
-	  }
-	  continue;
-	}
-	if(cmd.equals("get") || 
-	   cmd.equals("get-resume") || cmd.equals("get-append") || 
-	   cmd.equals("put") || 
-	   cmd.equals("put-resume") || cmd.equals("put-append")
-	   ){
-	  if(cmds.size()!=2 && cmds.size()!=3) continue;
-	  String p1=(String)cmds.elementAt(1);
-//	  String p2=p1;
-	  String p2=".";
-	  if(cmds.size()==3)p2=(String)cmds.elementAt(2);
-	  try{
-	    SftpProgressMonitor monitor=new MyProgressMonitor();
-	    if(cmd.startsWith("get")){
-	      int mode=ChannelSftp.OVERWRITE;
-	      if(cmd.equals("get-resume")){ mode=ChannelSftp.RESUME; }
-	      else if(cmd.equals("get-append")){ mode=ChannelSftp.APPEND; } 
-	      c.get(p1, p2, monitor, mode);
-	    }
-	    else{ 
-	      int mode=ChannelSftp.OVERWRITE;
-	      if(cmd.equals("put-resume")){ mode=ChannelSftp.RESUME; }
-	      else if(cmd.equals("put-append")){ mode=ChannelSftp.APPEND; } 
-	      c.put(p1, p2, monitor, mode); 
-	    }
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("ln") || cmd.equals("symlink") ||
+            if(file.isDirectory()){
+              String[] list=file.list();
+              for(int ii=0; ii<list.length; ii++){
+                out.println(list[ii]);
+              }
+              continue;
+            }
+            out.println(path);
+          }
+          catch(Exception e){
+            System.out.println(e);
+          }
+          continue;
+        }
+        if(cmd.equals("get") || 
+           cmd.equals("get-resume") || cmd.equals("get-append") || 
+           cmd.equals("put") || 
+           cmd.equals("put-resume") || cmd.equals("put-append")
+           ){
+          if(cmds.size()!=2 && cmds.size()!=3) continue;
+          String p1=(String)cmds.elementAt(1);
+//          String p2=p1;
+          String p2=".";
+          if(cmds.size()==3)p2=(String)cmds.elementAt(2);
+          try{
+            SftpProgressMonitor monitor=new MyProgressMonitor();
+            if(cmd.startsWith("get")){
+              int mode=ChannelSftp.OVERWRITE;
+              if(cmd.equals("get-resume")){ mode=ChannelSftp.RESUME; }
+              else if(cmd.equals("get-append")){ mode=ChannelSftp.APPEND; } 
+              c.get(p1, p2, monitor, mode);
+            }
+            else{ 
+              int mode=ChannelSftp.OVERWRITE;
+              if(cmd.equals("put-resume")){ mode=ChannelSftp.RESUME; }
+              else if(cmd.equals("put-append")){ mode=ChannelSftp.APPEND; } 
+              c.put(p1, p2, monitor, mode); 
+            }
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("ln") || cmd.equals("symlink") ||
            cmd.equals("rename") || cmd.equals("hardlink")){
           if(cmds.size()!=3) continue;
-	  String p1=(String)cmds.elementAt(1);
-	  String p2=(String)cmds.elementAt(2);
-	  try{
-	    if(cmd.equals("hardlink")){  c.hardlink(p1, p2); }
-	    else if(cmd.equals("rename")) c.rename(p1, p2);
-	    else c.symlink(p1, p2);
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("df")){
+          String p1=(String)cmds.elementAt(1);
+          String p2=(String)cmds.elementAt(2);
+          try{
+            if(cmd.equals("hardlink")){  c.hardlink(p1, p2); }
+            else if(cmd.equals("rename")) c.rename(p1, p2);
+            else c.symlink(p1, p2);
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("df")){
           if(cmds.size()>2) continue;
           String p1 = cmds.size()==1 ? ".": (String)cmds.elementAt(1);
           SftpStatVFS stat = c.statVFS(p1);
@@ -279,58 +279,58 @@ public class Sftp{
 
           continue;
         }
-	if(cmd.equals("stat") || cmd.equals("lstat")){
+        if(cmd.equals("stat") || cmd.equals("lstat")){
           if(cmds.size()!=2) continue;
-	  String p1=(String)cmds.elementAt(1);
-	  SftpATTRS attrs=null;
-	  try{
-	    if(cmd.equals("stat")) attrs=c.stat(p1);
-	    else attrs=c.lstat(p1);
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  if(attrs!=null){
+          String p1=(String)cmds.elementAt(1);
+          SftpATTRS attrs=null;
+          try{
+            if(cmd.equals("stat")) attrs=c.stat(p1);
+            else attrs=c.lstat(p1);
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          if(attrs!=null){
             out.println(attrs);
-	  }
-	  else{
-	  }
-	  continue;
-	}
-	if(cmd.equals("readlink")){
+          }
+          else{
+          }
+          continue;
+        }
+        if(cmd.equals("readlink")){
           if(cmds.size()!=2) continue;
-	  String p1=(String)cmds.elementAt(1);
-	  String filename=null;
-	  try{
-	    filename=c.readlink(p1);
+          String p1=(String)cmds.elementAt(1);
+          String filename=null;
+          try{
+            filename=c.readlink(p1);
             out.println(filename);
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("realpath")){
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("realpath")){
           if(cmds.size()!=2) continue;
-	  String p1=(String)cmds.elementAt(1);
-	  String filename=null;
-	  try{
-	    filename=c.realpath(p1);
+          String p1=(String)cmds.elementAt(1);
+          String filename=null;
+          try{
+            filename=c.realpath(p1);
             out.println(filename);
-	  }
-	  catch(SftpException e){
-	    System.out.println(e.toString());
-	  }
-	  continue;
-	}
-	if(cmd.equals("version")){
-	  out.println("SFTP protocol version "+c.version());
-	  continue;
-	}
-	if(cmd.equals("help") || cmd.equals("?")){
-	  out.println(help);
-	  continue;
-	}
+          }
+          catch(SftpException e){
+            System.out.println(e.toString());
+          }
+          continue;
+        }
+        if(cmd.equals("version")){
+          out.println("SFTP protocol version "+c.version());
+          continue;
+        }
+        if(cmd.equals("help") || cmd.equals("?")){
+          out.println(help);
+          continue;
+        }
         out.println("unimplemented command: "+cmd);
       }
       session.disconnect();
@@ -362,11 +362,11 @@ public class Sftp{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -424,7 +424,7 @@ public class Sftp{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel
@@ -443,7 +443,7 @@ public class Sftp{
       this.max=max;
       if(frame==null){
         frame=new JFrame();
-	frame.setSize(200, 20);
+        frame.setSize(200, 20);
         progressBar = new JProgressBar();
       }
       count=0;

--- a/examples/StreamForwarding.java
+++ b/examples/StreamForwarding.java
@@ -42,12 +42,12 @@ public class StreamForwarding{
       session.connect();
 
       String foo=JOptionPane.showInputDialog("Enter host and port", 
-						 "host:port");
+                                                 "host:port");
       host=foo.substring(0, foo.indexOf(':'));
       port=Integer.parseInt(foo.substring(foo.indexOf(':')+1));
 
       System.out.println("System.{in,out} will be forwarded to "+
-			 host+":"+port+".");
+                         host+":"+port+".");
       Channel channel = session.getStreamForwarder(host, port);
       // InputStream in = channel.getInputStream();
       // OutpuStream out = channel.getOutputStream();
@@ -81,11 +81,11 @@ public class StreamForwarding{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -143,7 +143,7 @@ public class StreamForwarding{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/Subsystem.java
+++ b/examples/Subsystem.java
@@ -154,7 +154,7 @@ public class Subsystem{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/Sudo.java
+++ b/examples/Sudo.java
@@ -174,7 +174,7 @@ public class Sudo{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/UserAuthKI.java
+++ b/examples/UserAuthKI.java
@@ -142,7 +142,7 @@ System.out.println("prompt: "+prompt[0]);
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/UserAuthPubKey.java
+++ b/examples/UserAuthPubKey.java
@@ -23,10 +23,10 @@ public class UserAuthPubKey{
       int returnVal = chooser.showOpenDialog(null);
       if(returnVal == JFileChooser.APPROVE_OPTION) {
         System.out.println("You chose "+
-			   chooser.getSelectedFile().getAbsolutePath()+".");
+                           chooser.getSelectedFile().getAbsolutePath()+".");
         jsch.addIdentity(chooser.getSelectedFile().getAbsolutePath()
-//			 , "passphrase"
-			 );
+//                         , "passphrase"
+                         );
       }
 
       String host=null;
@@ -81,8 +81,8 @@ public class UserAuthPubKey{
     public boolean promptPassphrase(String message){
       Object[] ob={passphraseField};
       int result=
-	JOptionPane.showConfirmDialog(null, ob, message,
-				      JOptionPane.OK_CANCEL_OPTION);
+        JOptionPane.showConfirmDialog(null, ob, message,
+                                      JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
         passphrase=passphraseField.getText();
         return true;
@@ -144,7 +144,7 @@ public class UserAuthPubKey{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/ViaHTTP.java
+++ b/examples/ViaHTTP.java
@@ -80,11 +80,11 @@ public class ViaHTTP{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -142,7 +142,7 @@ public class ViaHTTP{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/ViaSOCKS5.java
+++ b/examples/ViaSOCKS5.java
@@ -80,11 +80,11 @@ public class ViaSOCKS5{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -142,7 +142,7 @@ public class ViaSOCKS5{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/examples/X11Forwarding.java
+++ b/examples/X11Forwarding.java
@@ -37,7 +37,7 @@ public class X11Forwarding{
       Session session=jsch.getSession(user, host, 22);
 
       String display=JOptionPane.showInputDialog("Please enter display name", 
-						 xhost+":"+xport);
+                                                 xhost+":"+xport);
       xhost=display.substring(0, display.indexOf(':'));
       xport=Integer.parseInt(display.substring(display.indexOf(':')+1));
 
@@ -84,11 +84,11 @@ public class X11Forwarding{
     public boolean promptPassword(String message){
       Object[] ob={passwordField}; 
       int result=
-	  JOptionPane.showConfirmDialog(null, ob, message,
-					JOptionPane.OK_CANCEL_OPTION);
+          JOptionPane.showConfirmDialog(null, ob, message,
+                                        JOptionPane.OK_CANCEL_OPTION);
       if(result==JOptionPane.OK_OPTION){
-	passwd=passwordField.getText();
-	return true;
+        passwd=passwordField.getText();
+        return true;
       }
       else{ return false; }
     }
@@ -146,7 +146,7 @@ public class X11Forwarding{
         for(int i=0; i<prompt.length; i++){
           response[i]=texts[i].getText();
         }
-	return response;
+        return response;
       }
       else{
         return null;  // cancel

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -550,14 +550,14 @@ public abstract class Channel implements Runnable{
     synchronized(pool){
       channels=new Channel[pool.size()];
       for(int i=0; i<pool.size(); i++){
-	try{
-	  Channel c=pool.elementAt(i);
-	  if(c.session==session){
-	    channels[count++]=c;
-	  }
-	}
-	catch(Exception e){
-	}
+        try{
+          Channel c=pool.elementAt(i);
+          if(c.session==session){
+            channels[count++]=c;
+          }
+        }
+        catch(Exception e){
+        }
       } 
     }
     for(int i=0; i<count; i++){

--- a/src/main/java/com/jcraft/jsch/ChannelSession.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSession.java
@@ -242,27 +242,27 @@ class ChannelSession extends Channel{
     int i=-1;
     try{
       while(isConnected() &&
-	    thread!=null && 
+            thread!=null && 
             io!=null && 
             io.in!=null){
         i=io.in.read(buf.buffer, 
                      14,    
                      buf.buffer.length-14
                      -Session.buffer_margin
-		     );
-	if(i==0)continue;
-	if(i==-1){
-	  eof();
-	  break;
-	}
-	if(close)break;
+                     );
+        if(i==0)continue;
+        if(i==-1){
+          eof();
+          break;
+        }
+        if(close)break;
         //System.out.println("write: "+i);
         packet.reset();
         buf.putByte((byte)Session.SSH_MSG_CHANNEL_DATA);
         buf.putInt(recipient);
         buf.putInt(i);
         buf.skip(i);
-	getSession().write(packet, this, i);
+        getSession().write(packet, this, i);
       }
     }
     catch(Exception e){

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -324,7 +324,7 @@ public class ChannelSftp extends ChannelSession{
     path=localAbsolutePath(path);
     if((new File(path)).isDirectory()){
       try{
-	path=(new File(path)).getCanonicalPath();
+        path=(new File(path)).getCanonicalPath();
       }
       catch(Exception e){}
       lcwd=path;
@@ -367,7 +367,7 @@ public class ChannelSftp extends ChannelSession{
     put(src, dst, null, mode);
   }
   public void put(String src, String dst, 
-		  SftpProgressMonitor monitor) throws SftpException{
+                  SftpProgressMonitor monitor) throws SftpException{
     put(src, dst, monitor, OVERWRITE);
   }
 
@@ -382,7 +382,7 @@ public class ChannelSftp extends ChannelSession{
    * @param mode how data should be added to dst
    */
   public void put(String src, String dst, 
-		  SftpProgressMonitor monitor, int mode) throws SftpException{
+                  SftpProgressMonitor monitor, int mode) throws SftpException{
 
     try{
       ((MyPipedInputStream)io_in).updateReadSide();
@@ -413,7 +413,7 @@ public class ChannelSftp extends ChannelSession{
       StringBuilder dstsb=null;
       if(isRemoteDir){
         if(!dst.endsWith("/")){
-	    dst+="/";
+            dst+="/";
         }
         dstsb=new StringBuilder(dst);
       }
@@ -423,61 +423,61 @@ public class ChannelSftp extends ChannelSession{
       }
 
       for(int j=0; j<vsize; j++){
-	String _src=v.elementAt(j);
-	String _dst=null;
-	if(isRemoteDir){
-	  int i=_src.lastIndexOf(file_separatorc);
+        String _src=v.elementAt(j);
+        String _dst=null;
+        if(isRemoteDir){
+          int i=_src.lastIndexOf(file_separatorc);
           if(fs_is_bs){
             int ii=_src.lastIndexOf('/');
             if(ii!=-1 && ii>i)
               i=ii; 
           }
-	  if(i==-1) dstsb.append(_src);
-	  else dstsb.append(_src.substring(i + 1));
+          if(i==-1) dstsb.append(_src);
+          else dstsb.append(_src.substring(i + 1));
           _dst=dstsb.toString();
           dstsb.delete(dst.length(), _dst.length());
-	}
+        }
         else{
           _dst=dst;
         }
         //System.err.println("_dst "+_dst);
 
-	long size_of_dst=0;
-	if(mode==RESUME){
-	  try{
-	    SftpATTRS attr=_stat(_dst);
-	    size_of_dst=attr.getSize();
-	  }
-	  catch(Exception eee){
-	    //System.err.println(eee);
-	  }
-	  long size_of_src=new File(_src).length();
-	  if(size_of_src<size_of_dst){
-	    throw new SftpException(SSH_FX_FAILURE, 
+        long size_of_dst=0;
+        if(mode==RESUME){
+          try{
+            SftpATTRS attr=_stat(_dst);
+            size_of_dst=attr.getSize();
+          }
+          catch(Exception eee){
+            //System.err.println(eee);
+          }
+          long size_of_src=new File(_src).length();
+          if(size_of_src<size_of_dst){
+            throw new SftpException(SSH_FX_FAILURE, 
                                     "failed to resume for "+_dst);
-	  }
-	  if(size_of_src==size_of_dst){
-	    return;
-	  }
-	}
+          }
+          if(size_of_src==size_of_dst){
+            return;
+          }
+        }
 
         if(monitor!=null){
- 	  monitor.init(SftpProgressMonitor.PUT, _src, _dst,
-		       (new File(_src)).length());
-	  if(mode==RESUME){
-	    monitor.count(size_of_dst);
-	  }
+           monitor.init(SftpProgressMonitor.PUT, _src, _dst,
+                       (new File(_src)).length());
+          if(mode==RESUME){
+            monitor.count(size_of_dst);
+          }
         }
-	FileInputStream fis=null;
-	try{
-	  fis=new FileInputStream(_src);
-	  _put(fis, _dst, monitor, mode);
-	}
-	finally{
-	  if(fis!=null) {
-	    fis.close();
-	  }
-	}
+        FileInputStream fis=null;
+        try{
+          fis=new FileInputStream(_src);
+          _put(fis, _dst, monitor, mode);
+        }
+        finally{
+          if(fis!=null) {
+            fis.close();
+          }
+        }
       }
     }
     catch(Exception e){
@@ -492,7 +492,7 @@ public class ChannelSftp extends ChannelSession{
     put(src, dst, null, mode);
   }
   public void put(InputStream src, String dst, 
-		  SftpProgressMonitor monitor) throws SftpException{
+                  SftpProgressMonitor monitor) throws SftpException{
     put(src, dst, monitor, OVERWRITE);
   }
 
@@ -507,7 +507,7 @@ public class ChannelSftp extends ChannelSession{
    * @param mode how data should be added to dst
    */
   public void put(InputStream src, String dst, 
-		  SftpProgressMonitor monitor, int mode) throws SftpException{
+                  SftpProgressMonitor monitor, int mode) throws SftpException{
     try{
       ((MyPipedInputStream)io_in).updateReadSide();
 
@@ -556,19 +556,19 @@ public class ChannelSftp extends ChannelSession{
       byte[] dstb=Util.str2byte(dst, fEncoding);
       long skip=0;
       if(mode==RESUME || mode==APPEND){
-	try{
-	  SftpATTRS attr=_stat(dstb);
-	  skip=attr.getSize();
-	}
-	catch(Exception eee){
-	  //System.err.println(eee);
-	}
+        try{
+          SftpATTRS attr=_stat(dstb);
+          skip=attr.getSize();
+        }
+        catch(Exception eee){
+          //System.err.println(eee);
+        }
       }
       if(mode==RESUME && skip>0){
-	long skipped=src.skip(skip);
-	if(skipped<skip){
-	  throw new SftpException(SSH_FX_FAILURE, "failed to resume for "+dst);
-	}
+        long skipped=src.skip(skip);
+        if(skipped<skip){
+          throw new SftpException(SSH_FX_FAILURE, "failed to resume for "+dst);
+        }
       }
 
       if(mode==OVERWRITE){ sendOPENW(dstb); }
@@ -582,7 +582,7 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_STATUS && type!=SSH_FXP_HANDLE){
-	throw new SftpException(SSH_FX_FAILURE, "invalid type="+type);
+        throw new SftpException(SSH_FX_FAILURE, "invalid type="+type);
       }
       if(type==SSH_FXP_STATUS){
         int i=buf.getInt();
@@ -602,7 +602,7 @@ public class ChannelSftp extends ChannelSession{
 
       long offset=0;
       if(mode==RESUME || mode==APPEND){
-	offset+=skip;
+        offset+=skip;
       }
 
       int startid=seq;
@@ -672,9 +672,9 @@ public class ChannelSftp extends ChannelSession{
           }
         }
         offset+=count;
-	if(monitor!=null && !monitor.count(count)){
+        if(monitor!=null && !monitor.count(count)){
           break;
-	}
+        }
       }
       int _ackcount=seq-startid;
       while(_ackcount>ackcount){
@@ -721,20 +721,20 @@ public class ChannelSftp extends ChannelSession{
       dst=isUnique(dst);
 
       if(isRemoteDir(dst)){
-	throw new SftpException(SSH_FX_FAILURE, dst+" is a directory");
+        throw new SftpException(SSH_FX_FAILURE, dst+" is a directory");
       }
 
       byte[] dstb=Util.str2byte(dst, fEncoding);
 
       long skip=0;
       if(mode==RESUME || mode==APPEND){
-	try{
-	  SftpATTRS attr=_stat(dstb);
-	  skip=attr.getSize();
-	}
-	catch(Exception eee){
-	  //System.err.println(eee);
-	}
+        try{
+          SftpATTRS attr=_stat(dstb);
+          skip=attr.getSize();
+        }
+        catch(Exception eee){
+          //System.err.println(eee);
+        }
       }
 
       if(monitor!=null){
@@ -754,7 +754,7 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_STATUS && type!=SSH_FXP_HANDLE){
-	throw new SftpException(SSH_FX_FAILURE, "");
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
       if(type==SSH_FXP_STATUS){
         int i=buf.getInt();
@@ -763,7 +763,7 @@ public class ChannelSftp extends ChannelSession{
       final byte[] handle=buf.getString();         // handle
 
       if(mode==RESUME || mode==APPEND){
-	offset+=skip;
+        offset+=skip;
       }
 
       final long[] _offset=new long[1];
@@ -819,10 +819,10 @@ public class ChannelSftp extends ChannelSession{
                 }
               }
             }
-    	    if(monitor!=null && !monitor.count(len)){
+                if(monitor!=null && !monitor.count(len)){
               close();
               throw new IOException("canceled");
-	    }
+            }
           }
           catch(IOException e){ throw e; }
           catch(Exception e){ throw new IOException(e.toString(), e);  }
@@ -884,11 +884,11 @@ public class ChannelSftp extends ChannelSession{
     get(src, dst, null, OVERWRITE);
   }
   public void get(String src, String dst,
-		  SftpProgressMonitor monitor) throws SftpException{
+                  SftpProgressMonitor monitor) throws SftpException{
     get(src, dst, monitor, OVERWRITE);
   }
   public void get(String src, String dst,
-		  SftpProgressMonitor monitor, int mode) throws SftpException{
+                  SftpProgressMonitor monitor, int mode) throws SftpException{
     // System.out.println("get: "+src+" "+dst);
 
     boolean _dstExist = false;
@@ -920,18 +920,18 @@ public class ChannelSftp extends ChannelSession{
       }
 
       for(int j=0; j<vsize; j++){
-	String _src=v.elementAt(j);
-	SftpATTRS attr=_stat(_src);
+        String _src=v.elementAt(j);
+        SftpATTRS attr=_stat(_src);
         if(attr.isDir()){
           throw new SftpException(SSH_FX_FAILURE, 
                                   "not supported to get directory "+_src);
         } 
 
-	_dst=null;
-	if(isDstDir){
-	  int i=_src.lastIndexOf('/');
-	  if(i==-1) dstsb.append(_src);
-	  else dstsb.append(_src.substring(i + 1));
+        _dst=null;
+        if(isDstDir){
+          int i=_src.lastIndexOf('/');
+          if(i==-1) dstsb.append(_src);
+          else dstsb.append(_src.substring(i + 1));
           _dst=dstsb.toString();
           if(_dst.indexOf("..")!=-1){
             String dstc = (new File(dst)).getCanonicalPath();
@@ -943,30 +943,30 @@ public class ChannelSftp extends ChannelSession{
             }
           }
           dstsb.delete(dst.length(), _dst.length());
-	}
+        }
         else{
           _dst=dst;
         }
 
         File _dstFile=new File(_dst);
-	if(mode==RESUME){
-	  long size_of_src=attr.getSize();
-	  long size_of_dst=_dstFile.length();
-	  if(size_of_dst>size_of_src){
-	    throw new SftpException(SSH_FX_FAILURE, 
+        if(mode==RESUME){
+          long size_of_src=attr.getSize();
+          long size_of_dst=_dstFile.length();
+          if(size_of_dst>size_of_src){
+            throw new SftpException(SSH_FX_FAILURE, 
                                     "failed to resume for "+_dst);
-	  }
-	  if(size_of_dst==size_of_src){
-	    return;
-	  }
-	}
+          }
+          if(size_of_dst==size_of_src){
+            return;
+          }
+        }
 
-	if(monitor!=null){
-	  monitor.init(SftpProgressMonitor.GET, _src, _dst, attr.getSize());
-	  if(mode==RESUME){
-	    monitor.count(_dstFile.length());
-	  }
-	}
+        if(monitor!=null){
+          monitor.init(SftpProgressMonitor.GET, _src, _dst, attr.getSize());
+          if(mode==RESUME){
+            monitor.count(_dstFile.length());
+          }
+        }
 
         FileOutputStream fos=null;
         _dstExist = _dstFile.exists();
@@ -1002,11 +1002,11 @@ public class ChannelSftp extends ChannelSession{
     get(src, dst, null, OVERWRITE, 0);
   }
   public void get(String src, OutputStream dst,
-		  SftpProgressMonitor monitor) throws SftpException{
+                  SftpProgressMonitor monitor) throws SftpException{
     get(src, dst, monitor, OVERWRITE, 0);
   }
   public void get(String src, OutputStream dst,
-		   SftpProgressMonitor monitor, int mode, long skip) throws SftpException{
+                   SftpProgressMonitor monitor, int mode, long skip) throws SftpException{
 //System.err.println("get: "+src+", "+dst);
     try{
       ((MyPipedInputStream)io_in).updateReadSide();
@@ -1015,7 +1015,7 @@ public class ChannelSftp extends ChannelSession{
       src=isUnique(src);
 
       if(monitor!=null){
-	SftpATTRS attr=_stat(src);
+        SftpATTRS attr=_stat(src);
         monitor.init(SftpProgressMonitor.GET, src, "??", attr.getSize());
         if(mode==RESUME){
           monitor.count(skip);
@@ -1045,7 +1045,7 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_STATUS && type!=SSH_FXP_HANDLE){
-	throw new SftpException(SSH_FX_FAILURE, "");
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
 
       if(type==SSH_FXP_STATUS){
@@ -1057,7 +1057,7 @@ public class ChannelSftp extends ChannelSession{
 
       long offset=0;
       if(mode==RESUME){
-	offset+=skip;
+        offset+=skip;
       }
 
       int request_max=1;
@@ -1100,7 +1100,7 @@ public class ChannelSftp extends ChannelSession{
         }
 
         if(type!=SSH_FXP_DATA){ 
-	  break loop;
+          break loop;
         }
 
         buf.rewind();
@@ -1128,7 +1128,7 @@ public class ChannelSftp extends ChannelSession{
           int data_len = io_in.read(buf.buffer, 0, bar);
           if(data_len<0){
             break loop;
-	  }
+          }
           
           dst.write(buf.buffer, 0, data_len);
 
@@ -1146,7 +1146,7 @@ public class ChannelSftp extends ChannelSession{
           }
 
         }
-	//System.err.println("length: "+length);  // length should be 0
+        //System.err.println("length: "+length);  // length should be 0
 
         if(optional_data>0){
           skip(optional_data);
@@ -1323,7 +1323,7 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_STATUS && type!=SSH_FXP_HANDLE){
-	throw new SftpException(SSH_FX_FAILURE, "");
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
       if(type==SSH_FXP_STATUS){
         int i=buf.getInt();
@@ -1954,7 +1954,7 @@ public class ChannelSftp extends ChannelSession{
       Header header=new Header();
 
       for(int j=0; j<vsize; j++){
-	path=v.elementAt(j);
+        path=v.elementAt(j);
         sendREMOVE(Util.str2byte(path, fEncoding));
 
         header=header(buf, header);
@@ -1964,12 +1964,12 @@ public class ChannelSftp extends ChannelSession{
         fill(buf, length);
 
         if(type!=SSH_FXP_STATUS){
-	  throw new SftpException(SSH_FX_FAILURE, "");
+          throw new SftpException(SSH_FX_FAILURE, "");
         }
         int i=buf.getInt();
-	if(i!=SSH_FX_OK){
-	  throwStatusError(buf, i);
-	}
+        if(i!=SSH_FX_OK){
+          throwStatusError(buf, i);
+        }
       }
     }
     catch(Exception e){
@@ -2008,13 +2008,13 @@ public class ChannelSftp extends ChannelSession{
       Vector<String> v=glob_remote(path);
       int vsize=v.size();
       for(int j=0; j<vsize; j++){
-	path=v.elementAt(j);
+        path=v.elementAt(j);
 
         SftpATTRS attr=_stat(path);
 
-	attr.setFLAGS(0);
-	attr.setUIDGID(attr.uid, gid); 
-	_setStat(path, attr);
+        attr.setFLAGS(0);
+        attr.setUIDGID(attr.uid, gid); 
+        _setStat(path, attr);
       }
     }
     catch(Exception e){
@@ -2032,13 +2032,13 @@ public class ChannelSftp extends ChannelSession{
       Vector<String> v=glob_remote(path);
       int vsize=v.size();
       for(int j=0; j<vsize; j++){
-	path=v.elementAt(j);
+        path=v.elementAt(j);
 
         SftpATTRS attr=_stat(path);
 
-	attr.setFLAGS(0);
-	attr.setUIDGID(uid, attr.gid); 
-	_setStat(path, attr);
+        attr.setFLAGS(0);
+        attr.setUIDGID(uid, attr.gid); 
+        _setStat(path, attr);
       }
     }
     catch(Exception e){
@@ -2056,13 +2056,13 @@ public class ChannelSftp extends ChannelSession{
       Vector<String> v=glob_remote(path);
       int vsize=v.size();
       for(int j=0; j<vsize; j++){
-	path=v.elementAt(j);
+        path=v.elementAt(j);
 
-	SftpATTRS attr=_stat(path);
+        SftpATTRS attr=_stat(path);
 
-	attr.setFLAGS(0);
-	attr.setPERMISSIONS(permissions); 
-	_setStat(path, attr);
+        attr.setFLAGS(0);
+        attr.setPERMISSIONS(permissions); 
+        _setStat(path, attr);
       }
     }
     catch(Exception e){
@@ -2080,13 +2080,13 @@ public class ChannelSftp extends ChannelSession{
       Vector<String> v=glob_remote(path);
       int vsize=v.size();
       for(int j=0; j<vsize; j++){
-	path=v.elementAt(j);
+        path=v.elementAt(j);
 
         SftpATTRS attr=_stat(path);
 
-	attr.setFLAGS(0);
-	attr.setACMODTIME(attr.getATime(), mtime);
-	_setStat(path, attr);
+        attr.setFLAGS(0);
+        attr.setACMODTIME(attr.getATime(), mtime);
+        _setStat(path, attr);
       }
     }
     catch(Exception e){
@@ -2107,8 +2107,8 @@ public class ChannelSftp extends ChannelSession{
       Header header=new Header();
 
       for(int j=0; j<vsize; j++){
-	path=v.elementAt(j);
-	sendRMDIR(Util.str2byte(path, fEncoding));
+        path=v.elementAt(j);
+        sendRMDIR(Util.str2byte(path, fEncoding));
 
         header=header(buf, header);
         int length=header.length;
@@ -2116,14 +2116,14 @@ public class ChannelSftp extends ChannelSession{
 
         fill(buf, length);
 
-	if(type!=SSH_FXP_STATUS){
-	  throw new SftpException(SSH_FX_FAILURE, "");
-	}
+        if(type!=SSH_FXP_STATUS){
+          throw new SftpException(SSH_FX_FAILURE, "");
+        }
 
-	int i=buf.getInt();
-	if(i!=SSH_FX_OK){
-	  throwStatusError(buf, i);
-	}
+        int i=buf.getInt();
+        if(i!=SSH_FX_OK){
+          throwStatusError(buf, i);
+        }
       }
     }
     catch(Exception e){
@@ -2148,7 +2148,7 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_STATUS){
-	throw new SftpException(SSH_FX_FAILURE, "");
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
 
       int i=buf.getInt();
@@ -2190,11 +2190,11 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_ATTRS){
-	if(type==SSH_FXP_STATUS){
-	  int i=buf.getInt();
-	  throwStatusError(buf, i);
-	}
-	throw new SftpException(SSH_FX_FAILURE, "");
+        if(type==SSH_FXP_STATUS){
+          int i=buf.getInt();
+          throwStatusError(buf, i);
+        }
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
       SftpATTRS attr=SftpATTRS.getATTR(buf);
       return attr;
@@ -2293,11 +2293,11 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_ATTRS){
-	if(type==SSH_FXP_STATUS){
-	  int i=buf.getInt();
-	  throwStatusError(buf, i);
-	}
-	throw new SftpException(SSH_FX_FAILURE, "");
+        if(type==SSH_FXP_STATUS){
+          int i=buf.getInt();
+          throwStatusError(buf, i);
+        }
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
       SftpATTRS attr=SftpATTRS.getATTR(buf);
       return attr;
@@ -2348,8 +2348,8 @@ public class ChannelSftp extends ChannelSession{
       Vector<String> v=glob_remote(path);
       int vsize=v.size();
       for(int j=0; j<vsize; j++){
-	path=v.elementAt(j);
-	_setStat(path, attr);
+        path=v.elementAt(j);
+        _setStat(path, attr);
       }
     }
     catch(Exception e){
@@ -2369,11 +2369,11 @@ public class ChannelSftp extends ChannelSession{
       fill(buf, length);
 
       if(type!=SSH_FXP_STATUS){
-	throw new SftpException(SSH_FX_FAILURE, "");
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
       int i=buf.getInt();
       if(i!=SSH_FX_OK){
-	throwStatusError(buf, i);
+        throwStatusError(buf, i);
       }
     }
     catch(Exception e){
@@ -2684,11 +2684,11 @@ public class ChannelSftp extends ChannelSession{
       type=header.type;
 
       if(type!=SSH_FXP_STATUS && type!=SSH_FXP_NAME){
-	throw new SftpException(SSH_FX_FAILURE, "");
+        throw new SftpException(SSH_FX_FAILURE, "");
       }
       if(type==SSH_FXP_STATUS){ 
         fill(buf, length);
-	break;
+        break;
       }
 
       buf.rewind();
@@ -2700,21 +2700,21 @@ public class ChannelSftp extends ChannelSession{
 
       buf.reset();
       while(count>0){
-	if(length>0){
-	  buf.shift();
+        if(length>0){
+          buf.shift();
           int j=(buf.buffer.length>(buf.index+length)) ? length : (buf.buffer.length-buf.index);
-	  i=io_in.read(buf.buffer, buf.index, j);
-	  if(i<=0)break;
-	  buf.index+=i;
-	  length-=i;
-	}
+          i=io_in.read(buf.buffer, buf.index, j);
+          if(i<=0)break;
+          buf.index+=i;
+          length-=i;
+        }
 
-	byte[] filename=buf.getString();
-	//System.err.println("filename: "+new String(filename));
+        byte[] filename=buf.getString();
+        //System.err.println("filename: "+new String(filename));
         if(server_version<=3){
           str=buf.getString();  // longname
         }
-	SftpATTRS attrs=SftpATTRS.getATTR(buf);
+        SftpATTRS attrs=SftpATTRS.getATTR(buf);
 
         byte[] _filename=filename;
         String f=null;
@@ -2726,7 +2726,7 @@ public class ChannelSftp extends ChannelSession{
         }
         found=Util.glob(pattern, _filename);
 
-	if(found){
+        if(found){
           if(f==null){
             f=Util.byte2str(filename, fEncoding);
           }
@@ -2736,9 +2736,9 @@ public class ChannelSftp extends ChannelSession{
               pdir+="/";
             }
           }
-	  v.addElement(pdir+f);
-	}
-	count--; 
+          v.addElement(pdir+f);
+        }
+        count--; 
       }
     }
     if(_sendCLOSE(handle, header)) 
@@ -2809,9 +2809,9 @@ public class ChannelSftp extends ChannelSession{
       String pdir=Util.byte2str(dir)+file_separator;
       for(int j=0; j<children.length; j++){
 //System.err.println("children: "+children[j]);
-	if(Util.glob(pattern, Util.str2byte(children[j], StandardCharsets.UTF_8))){
-	  v.addElement(pdir+children[j]);
-	}
+        if(Util.glob(pattern, Util.str2byte(children[j], StandardCharsets.UTF_8))){
+          v.addElement(pdir+children[j]);
+        }
       }
     }
     catch(Exception e){

--- a/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
@@ -46,8 +46,8 @@ public class ChannelSubsystem extends ChannelSession{
         request.request(_session, this);
       }
       if(pty){
-	request=new RequestPtyReq();
-	request.request(_session, this);
+        request=new RequestPtyReq();
+        request.request(_session, this);
       }
       request=new RequestSubsystem();
       ((RequestSubsystem)request).request(_session, this, subsystem, want_reply);

--- a/src/main/java/com/jcraft/jsch/ChannelX11.java
+++ b/src/main/java/com/jcraft/jsch/ChannelX11.java
@@ -66,8 +66,8 @@ class ChannelX11 extends Channel{
     cookie_hex=Util.str2byte(foo); 
     cookie=new byte[16];
     for(int i=0; i<16; i++){
-	cookie[i]=(byte)(((revtable(cookie_hex[i*2])<<4)&0xf0) |
-			 ((revtable(cookie_hex[i*2+1]))&0xf));
+        cookie[i]=(byte)(((revtable(cookie_hex[i*2])<<4)&0xf0) |
+                         ((revtable(cookie_hex[i*2+1]))&0xf));
     }
   }
   static void setHost(String foo){ host=foo; }
@@ -76,11 +76,11 @@ class ChannelX11 extends Channel{
     synchronized(faked_cookie_hex_pool){
       byte[] foo=faked_cookie_hex_pool.get(session);
       if(foo==null){
-	Random random=Session.random;
-	foo=new byte[16];
-	synchronized(random){
-	  random.fill(foo, 0, 16);
-	}
+        Random random=Session.random;
+        foo=new byte[16];
+        synchronized(random){
+          random.fill(foo, 0, 16);
+        }
 /*
 System.err.print("faked_cookie: ");
 for(int i=0; i<foo.length; i++){
@@ -88,14 +88,14 @@ for(int i=0; i<foo.length; i++){
 }
 System.err.println("");
 */
-	faked_cookie_pool.put(session, foo);
-	byte[] bar=new byte[32];
-	for(int i=0; i<16; i++){
-	  bar[2*i]=table[(foo[i]>>>4)&0xf];
-	  bar[2*i+1]=table[(foo[i])&0xf];
-	}
-	faked_cookie_hex_pool.put(session, bar);
-	foo=bar;
+        faked_cookie_pool.put(session, foo);
+        byte[] bar=new byte[32];
+        for(int i=0; i<16; i++){
+          bar[2*i]=table[(foo[i]>>>4)&0xf];
+          bar[2*i+1]=table[(foo[i])&0xf];
+        }
+        faked_cookie_hex_pool.put(session, bar);
+        foo=bar;
       }
       return foo;
     }
@@ -159,19 +159,19 @@ System.err.println("");
             io!=null &&
             io.in!=null){
         i=io.in.read(buf.buffer, 
-		     14, 
-		     buf.buffer.length-14-Session.buffer_margin);
-	if(i<=0){
-	  eof();
+                     14, 
+                     buf.buffer.length-14-Session.buffer_margin);
+        if(i<=0){
+          eof();
           break;
-	}
-	if(close)break;
+        }
+        if(close)break;
         packet.reset();
         buf.putByte((byte)Session.SSH_MSG_CHANNEL_DATA);
         buf.putInt(recipient);
         buf.putInt(i);
         buf.skip(i);
-	getSession().write(packet, this, i);
+        getSession().write(packet, this, i);
       }
     }
     catch(Exception e){
@@ -221,7 +221,7 @@ System.err.println("");
          dlen=((dlen>>>8)&0xff)|((dlen<<8)&0xff00);
       }
       else{
-	  // ??
+          // ??
       }
 
       if(l<12+plen+((-plen)&3)+dlen)
@@ -232,7 +232,7 @@ System.err.println("");
       byte[] faked_cookie=null;
 
       synchronized(faked_cookie_pool){
-	faked_cookie=faked_cookie_pool.get(_session);
+        faked_cookie=faked_cookie_pool.get(_session);
       }
 
       /*
@@ -253,7 +253,7 @@ System.err.println("");
           System.arraycopy(cookie, 0, foo, s+12+plen+((-plen)&3), dlen);
       }
       else{
-	  //System.err.println("wrong cookie");
+          //System.err.println("wrong cookie");
           thread=null;
           eof();
           io.close();

--- a/src/main/java/com/jcraft/jsch/DHECN.java
+++ b/src/main/java/com/jcraft/jsch/DHECN.java
@@ -54,7 +54,7 @@ public abstract class DHECN extends KeyExchange{
 
   @Override
   public void init(Session session,
-		   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
+                   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
     this.session=session;
     this.V_S=V_S;      
     this.V_C=V_C;      
@@ -118,8 +118,8 @@ public abstract class DHECN extends KeyExchange{
       j=_buf.getByte();
       j=_buf.getByte();
       if(j!=SSH_MSG_KEX_ECDH_REPLY){
-	System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY "+j);
-	return false;
+        System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY "+j);
+        return false;
       }
 
       K_S=_buf.getString();
@@ -135,7 +135,7 @@ public abstract class DHECN extends KeyExchange{
       //   Section 3.2.2 of [SEC1].  If a key fails validation,
       //   the key exchange MUST fail.
       if(!ecdh.validate(r_s[0], r_s[1])){
-	return false;
+        return false;
       }
 
       K = ecdh.getSecret(r_s[0], r_s[1]);
@@ -171,7 +171,7 @@ public abstract class DHECN extends KeyExchange{
       i=0;
       j=0;
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
-	((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
+        ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
       String alg=Util.byte2str(K_S, i, j);
       i+=j;
 

--- a/src/main/java/com/jcraft/jsch/DHGEX.java
+++ b/src/main/java/com/jcraft/jsch/DHGEX.java
@@ -60,7 +60,7 @@ public class DHGEX extends KeyExchange{
 
   @Override
   public void init(Session session,
-		   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
+                   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
     this.session=session;
     this.V_S=V_S;      
     this.V_C=V_C;      
@@ -123,8 +123,8 @@ public class DHGEX extends KeyExchange{
       _buf.getByte();
       j=_buf.getByte();
       if(j!=SSH_MSG_KEX_DH_GEX_GROUP){
-	System.err.println("type: must be SSH_MSG_KEX_DH_GEX_GROUP "+j);
-	return false;
+        System.err.println("type: must be SSH_MSG_KEX_DH_GEX_GROUP "+j);
+        return false;
       }
 
       p=_buf.getMPInt();
@@ -165,8 +165,8 @@ public class DHGEX extends KeyExchange{
       j=_buf.getByte();
       j=_buf.getByte();
       if(j!=SSH_MSG_KEX_DH_GEX_REPLY){
-	System.err.println("type: must be SSH_MSG_KEX_DH_GEX_REPLY "+j);
-	return false;
+        System.err.println("type: must be SSH_MSG_KEX_DH_GEX_REPLY "+j);
+        return false;
       }
 
       K_S=_buf.getString();
@@ -217,7 +217,7 @@ public class DHGEX extends KeyExchange{
       i=0;
       j=0;
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
-	((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
+        ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
       String alg=Util.byte2str(K_S, i, j);
       i+=j;
 

--- a/src/main/java/com/jcraft/jsch/DHGN.java
+++ b/src/main/java/com/jcraft/jsch/DHGN.java
@@ -54,7 +54,7 @@ public abstract class DHGN extends KeyExchange{
 
   @Override
   public void init(Session session,
-		   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
+                   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
     this.session=session;
     this.V_S=V_S;      
     this.V_C=V_C;      
@@ -126,8 +126,8 @@ public abstract class DHGN extends KeyExchange{
       j=_buf.getByte();
       j=_buf.getByte();
       if(j!=31){
-	System.err.println("type: must be 31 "+j);
-	return false;
+        System.err.println("type: must be 31 "+j);
+        return false;
       }
 
       K_S=_buf.getString();
@@ -168,7 +168,7 @@ public abstract class DHGN extends KeyExchange{
       i=0;
       j=0;
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
-	((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
+        ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
       String alg=Util.byte2str(K_S, i, j);
       i+=j;
 

--- a/src/main/java/com/jcraft/jsch/DHXEC.java
+++ b/src/main/java/com/jcraft/jsch/DHXEC.java
@@ -59,7 +59,7 @@ public abstract class DHXEC extends KeyExchange{
 
   @Override
   public void init(Session session,
-		   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
+                   byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception{
     this.session=session;
     this.V_S=V_S;      
     this.V_C=V_C;      
@@ -123,8 +123,8 @@ public abstract class DHXEC extends KeyExchange{
       j=_buf.getByte();
       j=_buf.getByte();
       if(j!=SSH_MSG_KEX_ECDH_REPLY){
-	System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY "+j);
-	return false;
+        System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY "+j);
+        return false;
       }
 
       K_S=_buf.getString();
@@ -138,7 +138,7 @@ public abstract class DHXEC extends KeyExchange{
       //   Section 3.2.2 of [SEC1].  If a key fails validation,
       //   the key exchange MUST fail.
       if(!xdh.validate(Q_S)){
-	return false;
+        return false;
       }
 
       K = xdh.getSecret(Q_S);
@@ -188,7 +188,7 @@ public abstract class DHXEC extends KeyExchange{
       i=0;
       j=0;
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
-	((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
+        ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
       String alg=Util.byte2str(K_S, i, j);
       i+=j;
 

--- a/src/main/java/com/jcraft/jsch/HostKey.java
+++ b/src/main/java/com/jcraft/jsch/HostKey.java
@@ -141,7 +141,7 @@ public class HostKey{
        return hosts.regionMatches(true, i, _host, 0, hostlen);
       }
       if(hostlen==(j-i)){
-	if(hosts.regionMatches(true, i, _host, 0, hostlen)) return true;
+        if(hosts.regionMatches(true, i, _host, 0, hostlen)) return true;
       }
       i=j+1;
     }

--- a/src/main/java/com/jcraft/jsch/IO.java
+++ b/src/main/java/com/jcraft/jsch/IO.java
@@ -82,7 +82,7 @@ public class IO{
     do{
       int completed = in.read(array, begin, length);
       if(completed<0){
-	throw new IOException("End of IO Stream Read");
+        throw new IOException("End of IO Stream Read");
       }
       begin+=completed;
       length-=completed;

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -65,7 +65,7 @@ public class JSch{
     config.put("diffie-hellman-group-exchange-sha1", 
                                 "com.jcraft.jsch.DHGEX");
     config.put("diffie-hellman-group1-sha1", 
-	                        "com.jcraft.jsch.DHG1");
+                                "com.jcraft.jsch.DHG1");
     config.put("diffie-hellman-group14-sha1", 
                "com.jcraft.jsch.DHG14");
     config.put("diffie-hellman-group-exchange-sha256", 
@@ -401,7 +401,7 @@ public class JSch{
     if(known_hosts==null) known_hosts=new KnownHosts(this);
     if(known_hosts instanceof KnownHosts){
       synchronized(known_hosts){
-	((KnownHosts)known_hosts).setKnownHosts(filename); 
+        ((KnownHosts)known_hosts).setKnownHosts(filename); 
       }
     }
   }
@@ -421,7 +421,7 @@ public class JSch{
     if(known_hosts==null) known_hosts=new KnownHosts(this);
     if(known_hosts instanceof KnownHosts){
       synchronized(known_hosts){
-	((KnownHosts)known_hosts).setKnownHosts(stream); 
+        ((KnownHosts)known_hosts).setKnownHosts(stream); 
       }
     }
   }
@@ -648,9 +648,9 @@ public class JSch{
   public static void setConfig(Hashtable<String, String> newconf){
     synchronized(config){
       for(Enumeration<String> e=newconf.keys() ; e.hasMoreElements() ;) {
-	String newkey=e.nextElement();
-	String key=(newkey.equals("PubkeyAcceptedKeyTypes") ? "PubkeyAcceptedAlgorithms" : newkey);
-	config.put(key, newconf.get(newkey));
+        String newkey=e.nextElement();
+        String key=(newkey.equals("PubkeyAcceptedKeyTypes") ? "PubkeyAcceptedAlgorithms" : newkey);
+        config.put(key, newconf.get(newkey));
       }
     }
   }

--- a/src/main/java/com/jcraft/jsch/KeyExchange.java
+++ b/src/main/java/com/jcraft/jsch/KeyExchange.java
@@ -68,7 +68,7 @@ public abstract class KeyExchange{
   protected byte[] K_S=null;
 
   public abstract void init(Session session, 
-			    byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception;
+                            byte[] V_S, byte[] V_C, byte[] I_S, byte[] I_C) throws Exception;
   public abstract boolean next(Buffer buf) throws Exception;
 
   public abstract int getState();
@@ -117,29 +117,29 @@ public abstract class KeyExchange{
 
       loop:
       while(j<cp.length){
-	while(j<cp.length && cp[j]!=',')j++; 
-	if(k==j) return null;
-	String algorithm=Util.byte2str(cp, k, j-k);
-	int l=0;
-	int m=0;
-	while(l<sp.length){
-	  while(l<sp.length && sp[l]!=',')l++; 
-	  if(m==l) return null;
-	  if(algorithm.equals(Util.byte2str(sp, m, l-m))){
-	    guess[i]=algorithm;
-	    break loop;
-	  }
-	  l++;
-	  m=l;
-	}	
-	j++;
-	k=j;
+        while(j<cp.length && cp[j]!=',')j++; 
+        if(k==j) return null;
+        String algorithm=Util.byte2str(cp, k, j-k);
+        int l=0;
+        int m=0;
+        while(l<sp.length){
+          while(l<sp.length && sp[l]!=',')l++; 
+          if(m==l) return null;
+          if(algorithm.equals(Util.byte2str(sp, m, l-m))){
+            guess[i]=algorithm;
+            break loop;
+          }
+          l++;
+          m=l;
+        }
+        j++;
+        k=j;
       }
       if(j==0){
-	guess[i]="";
+        guess[i]="";
       }
       else if(guess[i]==null){
-	return null;
+        return null;
       }
     }
 
@@ -239,7 +239,7 @@ public abstract class KeyExchange{
         ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
       tmp=new byte[j]; System.arraycopy(K_S, i, tmp, 0, j); i+=j;
       n=tmp;
-	
+
       SignatureRSA sig=null;
       Buffer buf=new Buffer(sig_of_H);
       String foo=Util.byte2str(buf.getString());
@@ -271,7 +271,7 @@ public abstract class KeyExchange{
       key_alg_name=alg;
 
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
-	  ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
+          ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
       tmp=new byte[j]; System.arraycopy(K_S, i, tmp, 0, j); i+=j;
       p=tmp;
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
@@ -279,7 +279,7 @@ public abstract class KeyExchange{
       tmp=new byte[j]; System.arraycopy(K_S, i, tmp, 0, j); i+=j;
       q=tmp;
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
-	  ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
+          ((K_S[i++]<<8)&0x0000ff00)|((K_S[i++])&0x000000ff);
       tmp=new byte[j]; System.arraycopy(K_S, i, tmp, 0, j); i+=j;
       g=tmp;
       j=((K_S[i++]<<24)&0xff000000)|((K_S[i++]<<16)&0x00ff0000)|
@@ -385,7 +385,7 @@ public abstract class KeyExchange{
     }
     else{
       System.err.println("unknown alg");
-    }	    
+    }
 
     return result;
   }

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -143,26 +143,26 @@ public abstract class KeyPair{
     try{
       out.write(getBegin()); out.write(cr);
       if(passphrase!=null){
-	out.write(header[0]); out.write(cr);
-	out.write(header[1]); 
-	for(int i=0; i<iv.length; i++){
-	  out.write(b2a((byte)((iv[i]>>>4)&0x0f)));
-	  out.write(b2a((byte)(iv[i]&0x0f)));
-	}
+        out.write(header[0]); out.write(cr);
+        out.write(header[1]); 
+        for(int i=0; i<iv.length; i++){
+          out.write(b2a((byte)((iv[i]>>>4)&0x0f)));
+          out.write(b2a((byte)(iv[i]&0x0f)));
+        }
         out.write(cr);
-	out.write(cr);
+        out.write(cr);
       }
       int i=0;
       while(i<prv.length){
-	if(i+64<prv.length){
-	  out.write(prv, i, 64);
-	  out.write(cr);
-	  i+=64;
-	  continue;
-	}
-	out.write(prv, i, prv.length-i);
-	out.write(cr);
-	break;
+        if(i+64<prv.length){
+          out.write(prv, i, 64);
+          out.write(cr);
+          i+=64;
+          continue;
+        }
+        out.write(prv, i, prv.length-i);
+        out.write(cr);
+        break;
       }
       out.write(getEnd()); out.write(cr);
       //out.close();
@@ -231,10 +231,10 @@ public abstract class KeyPair{
       out.write(Util.str2byte("Comment: \""+comment+"\"")); out.write(cr);
       int index=0;
       while(index<pub.length){
-	int len=70;
-	if((pub.length-index)<len)len=pub.length-index;
-	out.write(pub, index, len); out.write(cr);
-	index+=len;
+        int len=70;
+        if((pub.length-index)<len)len=pub.length-index;
+        out.write(pub, index, len); out.write(cr);
+        index+=len;
       }
       out.write(Util.str2byte("---- END SSH2 PUBLIC KEY ----")); out.write(cr);
     }
@@ -399,7 +399,7 @@ public abstract class KeyPair{
   private Random genRandom(){
     if(random==null){
       try{
-	Class<?> c=Class.forName(JSch.getConfig("random"));
+        Class<?> c=Class.forName(JSch.getConfig("random"));
         random=(Random)(c.getDeclaredConstructor().newInstance());
       }
       catch(Exception e){ System.err.println("connect: random "+e); }
@@ -440,29 +440,29 @@ public abstract class KeyPair{
     byte[] key=new byte[cipher.getBlockSize()];
     int hsize=hash.getBlockSize();
     byte[] hn=new byte[key.length/hsize*hsize+
-		       (key.length%hsize==0?0:hsize)];
+                       (key.length%hsize==0?0:hsize)];
     try{
       byte[] tmp=null;
       if(vendor==VENDOR_OPENSSH){
-	for(int index=0; index+hsize<=hn.length;){
-	  if(tmp!=null){ hash.update(tmp, 0, tmp.length); }
-	  hash.update(passphrase, 0, passphrase.length);
+        for(int index=0; index+hsize<=hn.length;){
+          if(tmp!=null){ hash.update(tmp, 0, tmp.length); }
+          hash.update(passphrase, 0, passphrase.length);
           hash.update(iv, 0, iv.length > 8 ? 8: iv.length);
-	  tmp=hash.digest();
-	  System.arraycopy(tmp, 0, hn, index, tmp.length);
-	  index+=tmp.length;
-	}
-	System.arraycopy(hn, 0, key, 0, key.length); 
+          tmp=hash.digest();
+          System.arraycopy(tmp, 0, hn, index, tmp.length);
+          index+=tmp.length;
+        }
+        System.arraycopy(hn, 0, key, 0, key.length); 
       }
       else if(vendor==VENDOR_FSECURE){
-	for(int index=0; index+hsize<=hn.length;){
-	  if(tmp!=null){ hash.update(tmp, 0, tmp.length); }
-	  hash.update(passphrase, 0, passphrase.length);
-	  tmp=hash.digest();
-	  System.arraycopy(tmp, 0, hn, index, tmp.length);
-	  index+=tmp.length;
-	}
-	System.arraycopy(hn, 0, key, 0, key.length); 
+        for(int index=0; index+hsize<=hn.length;){
+          if(tmp!=null){ hash.update(tmp, 0, tmp.length); }
+          hash.update(passphrase, 0, passphrase.length);
+          tmp=hash.digest();
+          System.arraycopy(tmp, 0, hn, index, tmp.length);
+          index+=tmp.length;
+        }
+        System.arraycopy(hn, 0, key, 0, key.length); 
       }
       else if(vendor==VENDOR_PUTTY){
         Class<?> c=Class.forName(JSch.getConfig("sha-1"));
@@ -656,41 +656,41 @@ public abstract class KeyPair{
         if(buf[i]=='B'&& i+3<len && buf[i+1]=='E'&& buf[i+2]=='G'&& buf[i+3]=='I'){
           i+=6;
           if(i+2 >= len)
-	    throw new JSchException("invalid privatekey");
+            throw new JSchException("invalid privatekey");
           if(buf[i]=='D'&& buf[i+1]=='S'&& buf[i+2]=='A'){ type=DSA; }
-	  else if(buf[i]=='R'&& buf[i+1]=='S'&& buf[i+2]=='A'){ type=RSA; }
-	  else if(buf[i]=='E'&& buf[i+1]=='C'){ type=ECDSA; }
-	  else if(buf[i]=='S'&& buf[i+1]=='S'&& buf[i+2]=='H'){ // FSecure
-	    type=UNKNOWN;
-	    vendor=VENDOR_FSECURE;
-	  }
-	  else if(i+6 < len &&
+          else if(buf[i]=='R'&& buf[i+1]=='S'&& buf[i+2]=='A'){ type=RSA; }
+          else if(buf[i]=='E'&& buf[i+1]=='C'){ type=ECDSA; }
+          else if(buf[i]=='S'&& buf[i+1]=='S'&& buf[i+2]=='H'){ // FSecure
+            type=UNKNOWN;
+            vendor=VENDOR_FSECURE;
+          }
+          else if(i+6 < len &&
                   buf[i]=='P' && buf[i+1]=='R' &&
                   buf[i+2]=='I' && buf[i+3]=='V' &&
                   buf[i+4]=='A' && buf[i+5]=='T' && buf[i+6]=='E'){
-	    type=UNKNOWN;
-	    vendor=VENDOR_PKCS8;
+            type=UNKNOWN;
+            vendor=VENDOR_PKCS8;
             encrypted=false;
             i+=3;
-	  }
-	  else if(i+8 < len &&
+          }
+          else if(i+8 < len &&
                   buf[i]=='E' && buf[i+1]=='N' &&
                   buf[i+2]=='C' && buf[i+3]=='R' &&
                   buf[i+4]=='Y' && buf[i+5]=='P' && buf[i+6]=='T' &&
                   buf[i+7]=='E' && buf[i+8]=='D'){
-	    type=UNKNOWN;
-	    vendor=VENDOR_PKCS8;
+            type=UNKNOWN;
+            vendor=VENDOR_PKCS8;
             i+=5;
 
       } else if (isOpenSSHPrivateKey(buf, i, len)) {
           type = UNKNOWN;
           vendor = VENDOR_OPENSSH_V1;
       } else {
-	    throw new JSchException("invalid privatekey");
-	  }
+            throw new JSchException("invalid privatekey");
+          }
           i+=3;
-	  continue;
-	}
+          continue;
+        }
         if(buf[i]=='A'&& i+7<len && buf[i+1]=='E'&& buf[i+2]=='S'&& buf[i+3]=='-' && 
            buf[i+4]=='2'&& buf[i+5]=='5'&& buf[i+6]=='6'&& buf[i+7]=='-'){
           i+=8;
@@ -735,35 +735,35 @@ public abstract class KeyPair{
         }
         if(buf[i]=='C'&& i+3<len && buf[i+1]=='B'&& buf[i+2]=='C'&& buf[i+3]==','){
           i+=4;
-	  for(int ii=0; ii<iv.length; ii++){
+          for(int ii=0; ii<iv.length; ii++){
             iv[ii]=(byte)(((a2b(buf[i++])<<4)&0xf0)+(a2b(buf[i++])&0xf));
-  	  }
-	  continue;
-	}
-	if(buf[i]==0x0d && i+1<buf.length && buf[i+1]==0x0a){
-	  i++;
-	  continue;
-	}
-	if(buf[i]==0x0a && i+1<buf.length){
-	  if(buf[i+1]==0x0a){ i+=2; break; }
-	  if(buf[i+1]==0x0d &&
-	     i+2<buf.length && buf[i+2]==0x0a){
-	     i+=3; break;
-	  }
-	  boolean inheader=false;
-	  for(int j=i+1; j<buf.length; j++){
-	    if(buf[j]==0x0a) break;
-	    //if(buf[j]==0x0d) break;
-	    if(buf[j]==':'){inheader=true; break;}
-	  }
-	  if(!inheader){
-	    i++; 
-	    if(vendor!=VENDOR_PKCS8)
+            }
+          continue;
+        }
+        if(buf[i]==0x0d && i+1<buf.length && buf[i+1]==0x0a){
+          i++;
+          continue;
+        }
+        if(buf[i]==0x0a && i+1<buf.length){
+          if(buf[i+1]==0x0a){ i+=2; break; }
+          if(buf[i+1]==0x0d &&
+             i+2<buf.length && buf[i+2]==0x0a){
+             i+=3; break;
+          }
+          boolean inheader=false;
+          for(int j=i+1; j<buf.length; j++){
+            if(buf[j]==0x0a) break;
+            //if(buf[j]==0x0d) break;
+            if(buf[j]==':'){inheader=true; break;}
+          }
+          if(!inheader){
+            i++; 
+            if(vendor!=VENDOR_PKCS8)
               encrypted=false;    // no passphrase
-	    break;
-	  }
-	}
-	i++;
+            break;
+          }
+        }
+        i++;
       }
 
       if(buf!=null){
@@ -812,36 +812,36 @@ public abstract class KeyPair{
 
       if(data!=null &&
          data.length>4 &&            // FSecure
-	 data[0]==(byte)0x3f &&
-	 data[1]==(byte)0x6f &&
-	 data[2]==(byte)0xf9 &&
-	 data[3]==(byte)0xeb){
+         data[0]==(byte)0x3f &&
+         data[1]==(byte)0x6f &&
+         data[2]==(byte)0xf9 &&
+         data[3]==(byte)0xeb){
 
-	Buffer _buf=new Buffer(data);
-	_buf.getInt();  // 0x3f6ff9be
-	_buf.getInt();
-	byte[]_type=_buf.getString();
-	//System.err.println("type: "+Util.byte2str(_type)); 
-	String _cipher=Util.byte2str(_buf.getString());
-	//System.err.println("cipher: "+_cipher); 
-	if(_cipher.equals("3des-cbc")){
-  	   _buf.getInt();
-	   byte[] foo=new byte[data.length-_buf.getOffSet()];
-	   _buf.getByte(foo);
-	   data=foo;
-	   encrypted=true;
-	   throw new JSchException("unknown privatekey format");
-	}
-	else if(_cipher.equals("none")){
-  	   _buf.getInt();
-  	   _buf.getInt();
+        Buffer _buf=new Buffer(data);
+        _buf.getInt();  // 0x3f6ff9be
+        _buf.getInt();
+        byte[]_type=_buf.getString();
+        //System.err.println("type: "+Util.byte2str(_type)); 
+        String _cipher=Util.byte2str(_buf.getString());
+        //System.err.println("cipher: "+_cipher); 
+        if(_cipher.equals("3des-cbc")){
+             _buf.getInt();
+           byte[] foo=new byte[data.length-_buf.getOffSet()];
+           _buf.getByte(foo);
+           data=foo;
+           encrypted=true;
+           throw new JSchException("unknown privatekey format");
+        }
+        else if(_cipher.equals("none")){
+             _buf.getInt();
+             _buf.getInt();
 
            encrypted=false;
 
-	   byte[] foo=new byte[data.length-_buf.getOffSet()];
-	   _buf.getByte(foo);
-	   data=foo;
-	}
+           byte[] foo=new byte[data.length-_buf.getOffSet()];
+           _buf.getByte(foo);
+           data=foo;
+        }
     }
     // OPENSSH V1 PRIVATE KEY
     else if (data != null &&
@@ -880,67 +880,67 @@ public abstract class KeyPair{
     }
 
       if(pubkey!=null){
-	try{
-	  buf=pubkey;
+        try{
+          buf=pubkey;
           len=buf.length;
-	  if(buf.length>4 &&             // FSecure's public key
-	     buf[0]=='-' && buf[1]=='-' && buf[2]=='-' && buf[3]=='-'){
+          if(buf.length>4 &&             // FSecure's public key
+             buf[0]=='-' && buf[1]=='-' && buf[2]=='-' && buf[3]=='-'){
 
-	    boolean valid=true;
-	    i=0;
-	    do{i++;}while(buf.length>i && buf[i]!=0x0a);
-	    if(buf.length<=i) {valid=false;}
+            boolean valid=true;
+            i=0;
+            do{i++;}while(buf.length>i && buf[i]!=0x0a);
+            if(buf.length<=i) {valid=false;}
 
-	    while(valid){
-	      if(buf[i]==0x0a){
-		boolean inheader=false;
-		for(int j=i+1; j<buf.length; j++){
-		  if(buf[j]==0x0a) break;
-		  if(buf[j]==':'){inheader=true; break;}
-		}
-		if(!inheader){
-		  i++; 
-		  break;
-		}
-	      }
-	      i++;
-	    }
-	    if(buf.length<=i){valid=false;}
+            while(valid){
+              if(buf[i]==0x0a){
+                boolean inheader=false;
+                for(int j=i+1; j<buf.length; j++){
+                  if(buf[j]==0x0a) break;
+                  if(buf[j]==':'){inheader=true; break;}
+                }
+                if(!inheader){
+                  i++; 
+                  break;
+                }
+              }
+              i++;
+            }
+            if(buf.length<=i){valid=false;}
 
-	    int start=i;
-	    while(valid && i<len){
-	      if(buf[i]==0x0a){
-		System.arraycopy(buf, i+1, buf, i, len-i-1);
-		len--;
-		continue;
-	      }
-	      if(buf[i]=='-'){  break; }
-	      i++;
-	    }
-	    if(valid){
-	      publickeyblob=Util.fromBase64(buf, start, i-start);
-	      if(prvkey==null || type==UNKNOWN){
-		if(publickeyblob[8]=='d'){ type=DSA; }
-		else if(publickeyblob[8]=='r'){ type=RSA; }
-	      }
-	    }
-	  }
-	  else{
-	    if(buf[0]=='s'&& buf[1]=='s'&& buf[2]=='h' && buf[3]=='-'){
+            int start=i;
+            while(valid && i<len){
+              if(buf[i]==0x0a){
+                System.arraycopy(buf, i+1, buf, i, len-i-1);
+                len--;
+                continue;
+              }
+              if(buf[i]=='-'){  break; }
+              i++;
+            }
+            if(valid){
+              publickeyblob=Util.fromBase64(buf, start, i-start);
+              if(prvkey==null || type==UNKNOWN){
+                if(publickeyblob[8]=='d'){ type=DSA; }
+                else if(publickeyblob[8]=='r'){ type=RSA; }
+              }
+            }
+          }
+          else{
+            if(buf[0]=='s'&& buf[1]=='s'&& buf[2]=='h' && buf[3]=='-'){
               if(prvkey==null &&
                  buf.length>7){
-		if(buf[4]=='d'){ type=DSA; }
-		else if(buf[4]=='r'){ type=RSA; }
-		else if(buf[4]=='e' && buf[6]=='2'){ type=ED25519; }
-		else if(buf[4]=='e' && buf[6]=='4'){ type=ED448; }
+                if(buf[4]=='d'){ type=DSA; }
+                else if(buf[4]=='r'){ type=RSA; }
+                else if(buf[4]=='e' && buf[6]=='2'){ type=ED25519; }
+                else if(buf[4]=='e' && buf[6]=='4'){ type=ED448; }
               }
-	      i=0;
-	      while(i<len){ if(buf[i]==' ')break; i++;} i++;
-	      if(i<len){
-		int start=i;
-		while(i<len){ if(buf[i]==' ')break; i++;}
-		publickeyblob=Util.fromBase64(buf, start, i-start);
-	      }
+              i=0;
+              while(i<len){ if(buf[i]==' ')break; i++;} i++;
+              if(i<len){
+                int start=i;
+                while(i<len){ if(buf[i]==' ')break; i++;}
+                publickeyblob=Util.fromBase64(buf, start, i-start);
+              }
               if(i++<len){
                 int start=i;
                 while(i<len){ if(buf[i]=='\n')break; i++;}
@@ -949,7 +949,7 @@ public abstract class KeyPair{
                   publicKeyComment = Util.byte2str(buf, start, i-start);
                 }
               } 
-	    }
+            }
             else if(buf[0]=='e'&& buf[1]=='c'&& buf[2]=='d' && buf[3]=='s'){
               if(prvkey==null && buf.length>7){
                type=ECDSA;
@@ -970,10 +970,10 @@ public abstract class KeyPair{
                 }
               } 
             }
-	  }
-	}
-	catch(Exception ee){
-	}
+          }
+        }
+        catch(Exception ee){
+        }
       }
     }
     catch(Exception e){

--- a/src/main/java/com/jcraft/jsch/KeyPairDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairDSA.java
@@ -120,19 +120,19 @@ public class KeyPairDSA extends KeyPair{
     try{
 
       if(vendor==VENDOR_FSECURE){
-	if(plain[0]!=0x30){              // FSecure
-	  Buffer buf=new Buffer(plain);
-	  buf.getInt();
-	  P_array=buf.getMPIntBits();
-	  G_array=buf.getMPIntBits();
-	  Q_array=buf.getMPIntBits();
-	  pub_array=buf.getMPIntBits();
-	  prv_array=buf.getMPIntBits();
+        if(plain[0]!=0x30){              // FSecure
+          Buffer buf=new Buffer(plain);
+          buf.getInt();
+          P_array=buf.getMPIntBits();
+          G_array=buf.getMPIntBits();
+          Q_array=buf.getMPIntBits();
+          pub_array=buf.getMPIntBits();
+          prv_array=buf.getMPIntBits();
           if(P_array!=null)
             key_size = (new BigInteger(P_array)).bitLength();
-	  return true;
-	}
-	return false;
+          return true;
+        }
+        return false;
       }
       else if(vendor==VENDOR_PUTTY){
         Buffer buf=new Buffer(plain);

--- a/src/main/java/com/jcraft/jsch/KeyPairECDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairECDSA.java
@@ -170,12 +170,12 @@ public class KeyPairECDSA extends KeyPair{
 
       if(vendor==VENDOR_FSECURE){
         /*
-	if(plain[0]!=0x30){              // FSecure
-	  return true;
-	}
-	return false;
+        if(plain[0]!=0x30){              // FSecure
+          return true;
+        }
+        return false;
         */
-	return false;
+        return false;
       }
       else if(vendor==VENDOR_PUTTY){
         /*
@@ -192,7 +192,7 @@ public class KeyPairECDSA extends KeyPair{
 
         return true;
         */
-	return false;
+        return false;
       }
 
       // OPENSSH Key v1 Format

--- a/src/main/java/com/jcraft/jsch/KeyPairRSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairRSA.java
@@ -154,14 +154,14 @@ public class KeyPairRSA extends KeyPair{
       }
 
       if(vendor==VENDOR_FSECURE){
-	if(plain[index]!=0x30){                  // FSecure
-	  Buffer buf=new Buffer(plain);
-	  pub_array=buf.getMPIntBits();
-	  prv_array=buf.getMPIntBits();
-	  n_array=buf.getMPIntBits();
-	  byte[] u_array=buf.getMPIntBits();
-	  p_array=buf.getMPIntBits();
-	  q_array=buf.getMPIntBits();
+        if(plain[index]!=0x30){                  // FSecure
+          Buffer buf=new Buffer(plain);
+          pub_array=buf.getMPIntBits();
+          prv_array=buf.getMPIntBits();
+          n_array=buf.getMPIntBits();
+          byte[] u_array=buf.getMPIntBits();
+          p_array=buf.getMPIntBits();
+          q_array=buf.getMPIntBits();
           if(n_array!=null){
             key_size = (new BigInteger(n_array)).bitLength();
           }
@@ -170,9 +170,9 @@ public class KeyPairRSA extends KeyPair{
           getEQArray();
           getCArray();
 
-	  return true;
-	}
-	return false;
+          return true;
+        }
+        return false;
       }
 
             // OPENSSH Key v1 Format

--- a/src/main/java/com/jcraft/jsch/KnownHosts.java
+++ b/src/main/java/com/jcraft/jsch/KnownHosts.java
@@ -76,15 +76,15 @@ class KnownHosts implements HostKeyRepository{
       int bufl=0;
 loop:
       while(true){
-	bufl=0;
+        bufl=0;
         while(true){
           j=fis.read();
           if(j==-1){
             if(bufl==0){ break loop; }
             else{ break; }
           }
-	  if(j==0x0d){ continue; }
-	  if(j==0x0a){ break; }
+          if(j==0x0d){ continue; }
+          if(j==0x0a){ break; }
           if(buf.length<=bufl){
             if(bufl>1024*10) break;   // too long...
             byte[] newbuf=new byte[buf.length*2];
@@ -92,38 +92,38 @@ loop:
             buf=newbuf;
           }
           buf[bufl++]=(byte)j;
-	}
+        }
 
-	j=0;
+        j=0;
         while(j<bufl){
           i=buf[j];
-	  if(i==' '||i=='\t'){ j++; continue; }
-	  if(i=='#'){
-	    addInvalidLine(Util.byte2str(buf, 0, bufl));
-	    continue loop;
-	  }
-	  break;
-	}
-	if(j>=bufl){ 
-	  addInvalidLine(Util.byte2str(buf, 0, bufl));
-	  continue loop; 
-	}
+          if(i==' '||i=='\t'){ j++; continue; }
+          if(i=='#'){
+            addInvalidLine(Util.byte2str(buf, 0, bufl));
+            continue loop;
+          }
+          break;
+        }
+        if(j>=bufl){ 
+          addInvalidLine(Util.byte2str(buf, 0, bufl));
+          continue loop; 
+        }
 
         sb.setLength(0);
         while(j<bufl){
           i=buf[j++];
           if(i==0x20 || i=='\t'){ break; }
           sb.append((char)i);
-	}
-	host=sb.toString();
-	if(j>=bufl || host.length()==0){
-	  addInvalidLine(Util.byte2str(buf, 0, bufl));
-	  continue loop; 
-	}
+        }
+        host=sb.toString();
+        if(j>=bufl || host.length()==0){
+          addInvalidLine(Util.byte2str(buf, 0, bufl));
+          continue loop; 
+        }
 
         while(j<bufl){
           i=buf[j];
-	  if(i==' '||i=='\t'){ j++; continue; }
+          if(i==' '||i=='\t'){ j++; continue; }
           break;
         }
 
@@ -151,25 +151,25 @@ loop:
         }
 
         sb.setLength(0);
-	type=-1;
+        type=-1;
         while(j<bufl){
           i=buf[j++];
           if(i==0x20 || i=='\t'){ break; }
           sb.append((char)i);
-	}
-	String tmp = sb.toString();
-	if(HostKey.name2type(tmp)!=HostKey.UNKNOWN){
-	  type=HostKey.name2type(tmp);
-	}
-	else { j=bufl; }
-	if(j>=bufl){
-	  addInvalidLine(Util.byte2str(buf, 0, bufl));
-	  continue loop; 
-	}
+        }
+        String tmp = sb.toString();
+        if(HostKey.name2type(tmp)!=HostKey.UNKNOWN){
+          type=HostKey.name2type(tmp);
+        }
+        else { j=bufl; }
+        if(j>=bufl){
+          addInvalidLine(Util.byte2str(buf, 0, bufl));
+          continue loop; 
+        }
 
         while(j<bufl){
           i=buf[j];
-	  if(i==' '||i=='\t'){ j++; continue; }
+          if(i==' '||i=='\t'){ j++; continue; }
           break;
         }
 
@@ -180,16 +180,16 @@ loop:
           if(i==0x0a){ break; }
           if(i==0x20 || i=='\t'){ break; }
           sb.append((char)i);
-	}
-	key=sb.toString();
-	if(key.length()==0){
-	  addInvalidLine(Util.byte2str(buf, 0, bufl));
-	  continue loop; 
-	}
+        }
+        key=sb.toString();
+        if(key.length()==0){
+          addInvalidLine(Util.byte2str(buf, 0, bufl));
+          continue loop; 
+        }
 
         while(j<bufl){
           i=buf[j];
-	  if(i==' '||i=='\t'){ j++; continue; }
+          if(i==' '||i=='\t'){ j++; continue; }
           break;
         }
 
@@ -215,22 +215,22 @@ loop:
           comment=sb.toString();
         }
 
-	//System.err.println(host);
-	//System.err.println("|"+key+"|");
+        //System.err.println(host);
+        //System.err.println("|"+key+"|");
 
-	HostKey hk = null;
+        HostKey hk = null;
         hk = new HashedHostKey(marker, host, type, 
                                Util.fromBase64(Util.str2byte(key), 0, 
                                                key.length()), comment);
-	pool.addElement(hk);
+        pool.addElement(hk);
       }
       if(error){
-	throw new JSchException("KnownHosts: invalid format");
+        throw new JSchException("KnownHosts: invalid format");
       }
     }
     catch(Exception e){
       if(e instanceof JSchException)
-	throw (JSchException)e;         
+        throw (JSchException)e;         
       throw new JSchException(e.toString(), e);
     }
     finally {
@@ -272,7 +272,7 @@ loop:
           }
           else{
             result=CHANGED;
-	  }
+          }
         }
       }
     }
@@ -299,15 +299,15 @@ loop:
         hk=pool.elementAt(i);
         if(hk.isMatched(host) && hk.type==type){
 /*
-	  if(Util.array_equals(hk.key, key)){ return; }
-	  if(hk.host.equals(host)){
-	    hk.key=key;
-	    return;
-	  }
-	  else{
-	    hk.host=deleteSubString(hk.host, host);
-	    break;
-	  }
+          if(Util.array_equals(hk.key, key)){ return; }
+          if(hk.host.equals(host)){
+            hk.key=key;
+            return;
+          }
+          else{
+            hk.host=deleteSubString(hk.host, host);
+            break;
+          }
 */
         }
       }
@@ -363,13 +363,13 @@ loop:
     synchronized(pool){
       List<HostKey> v = new ArrayList<>();
       for(int i=0; i<pool.size(); i++){
-	HostKey hk=pool.elementAt(i);
-	if(hk.type==HostKey.UNKNOWN) continue;
-	if(host==null || 
-	   (hk.isMatched(host) && 
-	    (type==null || hk.getType().equals(type)))){
+        HostKey hk=pool.elementAt(i);
+        if(hk.type==HostKey.UNKNOWN) continue;
+        if(host==null || 
+           (hk.isMatched(host) && 
+            (type==null || hk.getType().equals(type)))){
           v.add(hk);
-	}
+        }
       }
       HostKey[] foo = new HostKey[v.size()];
       for(int i=0; i<v.size(); i++){
@@ -399,9 +399,9 @@ loop:
     for(int i=0; i<pool.size(); i++){
       HostKey hk=pool.elementAt(i);
       if(host==null ||
-	 (hk.isMatched(host) && 
-	  (type==null || (hk.getType().equals(type) &&
-			  (key==null || Util.array_equals(key, hk.key)))))){
+         (hk.isMatched(host) && 
+          (type==null || (hk.getType().equals(type) &&
+                          (key==null || Util.array_equals(key, hk.key)))))){
         String hosts=hk.getHost();
         if(hosts.equals(host) || 
            ((hk instanceof HashedHostKey) &&
@@ -411,7 +411,7 @@ loop:
         else{
           hk.host=deleteSubString(hosts, host);
         }
-	sync=true;
+        sync=true;
       }
     }
     }
@@ -440,29 +440,29 @@ loop:
       for(int i=0; i<pool.size(); i++){
         hk=pool.elementAt(i);
         //hk.dump(out);
-	String marker=hk.getMarker();
-	String host=hk.getHost();
-	String type=hk.getType();
+        String marker=hk.getMarker();
+        String host=hk.getHost();
+        String type=hk.getType();
         String comment = hk.getComment();
-	if(type.equals("UNKNOWN")){
-	  out.write(Util.str2byte(host));
-	  out.write(cr);
-	  continue;
-	}
+        if(type.equals("UNKNOWN")){
+          out.write(Util.str2byte(host));
+          out.write(cr);
+          continue;
+        }
         if(marker.length()!=0){
           out.write(Util.str2byte(marker));
           out.write(space);
         }
-	out.write(Util.str2byte(host));
-	out.write(space);
-	out.write(Util.str2byte(type));
-	out.write(space);
-	out.write(Util.str2byte(hk.getKey()));
+        out.write(Util.str2byte(host));
+        out.write(space);
+        out.write(Util.str2byte(type));
+        out.write(space);
+        out.write(Util.str2byte(hk.getKey()));
         if(comment!=null){
           out.write(space);
           out.write(Util.str2byte(comment));
         }
-	out.write(cr);
+        out.write(cr);
       }
       }
     }
@@ -480,7 +480,7 @@ loop:
       j=hosts.indexOf(',', i);
       if(j==-1) break;
       if(!host.equals(hosts.substring(i, j))){
-        i=j+1;	  
+        i=j+1;
         continue;
       }
       return hosts.substring(0, i)+hosts.substring(j+1);

--- a/src/main/java/com/jcraft/jsch/Packet.java
+++ b/src/main/java/com/jcraft/jsch/Packet.java
@@ -97,8 +97,8 @@ System.err.println("");
 //  System.err.println("buffer.buffer.length="+buffer.buffer.length+" s="+(s));
 
     System.arraycopy(buffer.buffer, 
-		     len+5+9, 
-		     buffer.buffer, s, buffer.index-5-9-len);
+                     len+5+9, 
+                     buffer.buffer, s, buffer.index-5-9-len);
 
     buffer.index=10;
     buffer.putInt(len);
@@ -107,8 +107,8 @@ System.err.println("");
   }
   void unshift(byte command, int recipient, int s, int len){
     System.arraycopy(buffer.buffer, 
-		     s, 
-		     buffer.buffer, 5+9, len);
+                     s, 
+                     buffer.buffer, 5+9, len);
     buffer.buffer[5]=command;
     buffer.index=6;
     buffer.putInt(recipient);

--- a/src/main/java/com/jcraft/jsch/PortWatcher.java
+++ b/src/main/java/com/jcraft/jsch/PortWatcher.java
@@ -92,10 +92,10 @@ class PortWatcher implements Runnable{
     Vector<String> foo=new Vector<>();
     synchronized(pool){
       for(int i=0; i<pool.size(); i++){
-	PortWatcher p=pool.elementAt(i);
-	if(p.session==session){
-	  foo.addElement(p.lport+":"+p.host+":"+p.rport);
-	}
+        PortWatcher p=pool.elementAt(i);
+        if(p.session==session){
+          foo.addElement(p.lport+":"+p.host+":"+p.rport);
+        }
       }
     }
     String[] bar=new String[foo.size()];
@@ -114,13 +114,13 @@ class PortWatcher implements Runnable{
     }
     synchronized(pool){
       for(int i=0; i<pool.size(); i++){
-	PortWatcher p=pool.elementAt(i);
-	if(p.session==session && p.lport==lport){
-	  if(/*p.boundaddress.isAnyLocalAddress() ||*/
+        PortWatcher p=pool.elementAt(i);
+        if(p.session==session && p.lport==lport){
+          if(/*p.boundaddress.isAnyLocalAddress() ||*/
              (anyLocalAddress!=null &&  p.boundaddress.equals(anyLocalAddress)) ||
-	     p.boundaddress.equals(addr))
-	  return p;
-	}
+             p.boundaddress.equals(addr))
+          return p;
+        }
       }
       return null;
     }
@@ -157,21 +157,21 @@ class PortWatcher implements Runnable{
       PortWatcher[] foo=new PortWatcher[pool.size()];
       int count=0;
       for(int i=0; i<pool.size(); i++){
-	PortWatcher p=pool.elementAt(i);
-	if(p.session==session) {
-	  p.delete();
-	  foo[count++]=p;
-	}
+        PortWatcher p=pool.elementAt(i);
+        if(p.session==session) {
+          p.delete();
+          foo[count++]=p;
+        }
       }
       for(int i=0; i<count; i++){
-	PortWatcher p=foo[i];
-	pool.removeElement(p);
+        PortWatcher p=foo[i];
+        pool.removeElement(p);
       }
     }
   }
   PortWatcher(Session session,
-	      String address, int lport,
-	      String host, int rport,
+              String address, int lport,
+              String host, int rport,
               ServerSocketFactory factory) throws JSchException{
     this.session=session;
     this.lport=lport;
@@ -196,7 +196,7 @@ class PortWatcher implements Runnable{
     try{
       while(thread!=null){
         Socket socket=ss.accept();
-	socket.setTcpNoDelay(true);
+        socket.setTcpNoDelay(true);
         InputStream in=socket.getInputStream();
         OutputStream out=socket.getOutputStream();
         if(socketPath!=null && socketPath.length()>0){

--- a/src/main/java/com/jcraft/jsch/ProxyHTTP.java
+++ b/src/main/java/com/jcraft/jsch/ProxyHTTP.java
@@ -48,8 +48,8 @@ public class ProxyHTTP implements Proxy{
     String host=proxy_host;
     if(proxy_host.indexOf(':')!=-1){
       try{
-	host=proxy_host.substring(0, proxy_host.indexOf(':'));
-	port=Integer.parseInt(proxy_host.substring(proxy_host.indexOf(':')+1));
+        host=proxy_host.substring(0, proxy_host.indexOf(':'));
+        port=Integer.parseInt(proxy_host.substring(proxy_host.indexOf(':')+1));
       }
       catch(Exception e){
       }
@@ -86,11 +86,11 @@ public class ProxyHTTP implements Proxy{
       out.write(Util.str2byte("CONNECT "+host+":"+port+" HTTP/1.0\r\n"));
 
       if(user!=null && passwd!=null){
-	byte[] code=Util.str2byte(user+":"+passwd);
-	code=Util.toBase64(code, 0, code.length, true);
-	out.write(Util.str2byte("Proxy-Authorization: Basic "));
-	out.write(code);
-	out.write(Util.str2byte("\r\n"));
+        byte[] code=Util.str2byte(user+":"+passwd);
+        code=Util.toBase64(code, 0, code.length, true);
+        out.write(Util.str2byte("Proxy-Authorization: Basic "));
+        out.write(code);
+        out.write(Util.str2byte("\r\n"));
       }
 
       out.write(Util.str2byte("\r\n"));

--- a/src/main/java/com/jcraft/jsch/ProxySOCKS4.java
+++ b/src/main/java/com/jcraft/jsch/ProxySOCKS4.java
@@ -53,8 +53,8 @@ public class ProxySOCKS4 implements Proxy{
     String host=proxy_host;
     if(proxy_host.indexOf(':')!=-1){
       try{
-	host=proxy_host.substring(0, proxy_host.indexOf(':'));
-	port=Integer.parseInt(proxy_host.substring(proxy_host.indexOf(':')+1));
+        host=proxy_host.substring(0, proxy_host.indexOf(':'));
+        port=Integer.parseInt(proxy_host.substring(proxy_host.indexOf(':')+1));
       }
       catch(Exception e){
       }
@@ -176,8 +176,8 @@ public class ProxySOCKS4 implements Proxy{
       }
       if(buf[1]!=90){
         try{ socket.close(); }
-	catch(Exception eee){
-	}
+        catch(Exception eee){
+        }
         String message="ProxySOCKS4: server returns CD "+buf[1];
         throw new JSchException(message);
       }

--- a/src/main/java/com/jcraft/jsch/ProxySOCKS5.java
+++ b/src/main/java/com/jcraft/jsch/ProxySOCKS5.java
@@ -53,8 +53,8 @@ public class ProxySOCKS5 implements Proxy{
     String host=proxy_host;
     if(proxy_host.indexOf(':')!=-1){
       try{
-	host=proxy_host.substring(0, proxy_host.indexOf(':'));
-	port=Integer.parseInt(proxy_host.substring(proxy_host.indexOf(':')+1));
+        host=proxy_host.substring(0, proxy_host.indexOf(':'));
+        port=Integer.parseInt(proxy_host.substring(proxy_host.indexOf(':')+1));
       }
       catch(Exception e){
       }
@@ -164,11 +164,11 @@ public class ProxySOCKS5 implements Proxy{
           index=0;
           buf[index++]=1;
           buf[index++]=(byte)(user.length());
-	  System.arraycopy(Util.str2byte(user), 0, buf, index, user.length());
-	  index+=user.length();
+          System.arraycopy(Util.str2byte(user), 0, buf, index, user.length());
+          index+=user.length();
           buf[index++]=(byte)(passwd.length());
-	  System.arraycopy(Util.str2byte(passwd), 0, buf, index, passwd.length());
-	  index+=passwd.length();
+          System.arraycopy(Util.str2byte(passwd), 0, buf, index, passwd.length());
+          index+=passwd.length();
 
           out.write(buf, 0, index);
 
@@ -196,8 +196,8 @@ public class ProxySOCKS5 implements Proxy{
 
       if(!check){
         try{ socket.close(); }
-	catch(Exception eee){
-	}
+        catch(Exception eee){
+        }
         throw new JSchException("fail in SOCKS5 proxy");
       }
 
@@ -283,8 +283,8 @@ public class ProxySOCKS5 implements Proxy{
 
       if(buf[1]!=0){
         try{ socket.close(); }
-	catch(Exception eee){
-	}
+        catch(Exception eee){
+        }
         throw new JSchException("ProxySOCKS5: server returns "+buf[1]);
       }
 
@@ -292,13 +292,13 @@ public class ProxySOCKS5 implements Proxy{
         case 1:
           //in.read(buf, 0, 6);
           fill(in, buf, 6);
-	  break;
+          break;
         case 3:
           //in.read(buf, 0, 1);
           fill(in, buf, 1);
           //in.read(buf, 0, buf[0]+2);
           fill(in, buf, (buf[0]&0xff)+2);
-	  break;
+          break;
         case 4:
           //in.read(buf, 0, 18);
           fill(in, buf, 18);

--- a/src/main/java/com/jcraft/jsch/Request.java
+++ b/src/main/java/com/jcraft/jsch/Request.java
@@ -51,9 +51,9 @@ abstract class Request{
       long start=System.currentTimeMillis();
       long timeout=channel.connectTimeout;
       while(channel.isConnected() && channel.reply==-1){
-	try{Thread.sleep(10);}
-	catch(Exception ee){
-	}
+        try{Thread.sleep(10);}
+        catch(Exception ee){
+        }
         if(timeout>0L &&
            (System.currentTimeMillis()-start)>timeout){
           channel.reply=0;
@@ -62,7 +62,7 @@ abstract class Request{
       }
 
       if(channel.reply==0){
-	throw new JSchException("failed to send channel request");
+        throw new JSchException("failed to send channel request");
       }
     }
   }

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -193,7 +193,7 @@ public class Session implements Runnable{
     io=new IO();
     if(random==null){
       try{
-	Class<?> c=Class.forName(getConfig("random"));
+        Class<?> c=Class.forName(getConfig("random"));
         random=(Random)(c.getDeclaredConstructor().newInstance());
       }
       catch(Exception e){
@@ -207,34 +207,34 @@ public class Session implements Runnable{
                            "Connecting to "+host+" port "+port);
     }
 
-    try	{
+    try {
       int i, j;
 
       if(proxy==null){
         InputStream in;
         OutputStream out;
-	if(socket_factory==null){
+        if(socket_factory==null){
           socket=Util.createSocket(host, port, connectTimeout);
-	  in=socket.getInputStream();
-	  out=socket.getOutputStream();
-	}
-	else{
+          in=socket.getInputStream();
+          out=socket.getOutputStream();
+        }
+        else{
           socket=socket_factory.createSocket(host, port);
-	  in=socket_factory.getInputStream(socket);
-	  out=socket_factory.getOutputStream(socket);
-	}
-	//if(timeout>0){ socket.setSoTimeout(timeout); }
+          in=socket_factory.getInputStream(socket);
+          out=socket_factory.getOutputStream(socket);
+        }
+        //if(timeout>0){ socket.setSoTimeout(timeout); }
         socket.setTcpNoDelay(true);
         io.setInputStream(in);
         io.setOutputStream(out);
       }
       else{
-	synchronized(proxy){
+        synchronized(proxy){
           proxy.connect(socket_factory, host, port, connectTimeout);
-	  io.setInputStream(proxy.getInputStream());
-	  io.setOutputStream(proxy.getOutputStream());
+          io.setInputStream(proxy.getInputStream());
+          io.setOutputStream(proxy.getOutputStream());
           socket=proxy.getSocket();
-	}
+        }
       }
 
       if(connectTimeout>0 && socket!=null){
@@ -251,12 +251,12 @@ public class Session implements Runnable{
       jsch.addSession(this);
 
       {
-	// Some Cisco devices will miss to read '\n' if it is sent separately.
-	byte[] foo=new byte[V_C.length+2];
-	System.arraycopy(V_C, 0, foo, 0, V_C.length);
-	foo[foo.length-2]=(byte)'\r';
-	foo[foo.length-1]=(byte)'\n';
-	io.put(foo, 0, foo.length);
+        // Some Cisco devices will miss to read '\n' if it is sent separately.
+        byte[] foo=new byte[V_C.length+2];
+        System.arraycopy(V_C, 0, foo, 0, V_C.length);
+        foo[foo.length-2]=(byte)'\r';
+        foo[foo.length-1]=(byte)'\n';
+        io.put(foo, 0, foo.length);
       }
 
       while(true){
@@ -314,7 +314,7 @@ public class Session implements Runnable{
       buf=read(buf);
       if(buf.getCommand()!=SSH_MSG_KEXINIT){
         in_kex=false;
-	throw new JSchException("invalid protocol: "+buf.getCommand());
+        throw new JSchException("invalid protocol: "+buf.getCommand());
       }
 
       if(JSch.getLogger().isEnabled(Logger.INFO)){
@@ -325,23 +325,23 @@ public class Session implements Runnable{
       KeyExchange kex=receive_kexinit(buf);
 
       while(true){
-	buf=read(buf);
-	if(kex.getState()==buf.getCommand()){
+        buf=read(buf);
+        if(kex.getState()==buf.getCommand()){
           kex_start_time=System.currentTimeMillis();
           boolean result=kex.next(buf);
-	  if(!result){
-	    //System.err.println("verify: "+result);
+          if(!result){
+            //System.err.println("verify: "+result);
             in_kex=false;
-	    throw new JSchException("verify: "+result);
-	  }
-	}
-	else{
+            throw new JSchException("verify: "+result);
+          }
+        }
+        else{
           in_kex=false;
-	  throw new JSchException("invalid protocol(kex): "+buf.getCommand());
-	}
-	if(kex.getState()==KeyExchange.STATE_END){
-	  break;
-	}
+          throw new JSchException("invalid protocol(kex): "+buf.getCommand());
+        }
+        if(kex.getState()==KeyExchange.STATE_END){
+          break;
+        }
       }
 
       try{
@@ -369,11 +369,11 @@ public class Session implements Runnable{
                                "SSH_MSG_NEWKEYS received");
         }
 
-	receive_newkeys(buf, kex);
+        receive_newkeys(buf, kex);
       }
       else{
         in_kex=false;
-	throw new JSchException("invalid protocol(newkyes): "+buf.getCommand());
+        throw new JSchException("invalid protocol(newkyes): "+buf.getCommand());
       }
 
       try{
@@ -391,7 +391,7 @@ public class Session implements Runnable{
 
       UserAuth ua=null;
       try{
-	Class<?> c=Class.forName(getConfig("userauth.none"));
+        Class<?> c=Class.forName(getConfig("userauth.none"));
         ua=(UserAuth)(c.getDeclaredConstructor().newInstance());
       }
       catch(Exception e){
@@ -424,8 +424,8 @@ public class Session implements Runnable{
       loop:
       while(true){
 
-	while(!auth &&
-	      cmethoda!=null && methodi<cmethoda.length){
+        while(!auth &&
+              cmethoda!=null && methodi<cmethoda.length){
 
           String method=cmethoda[methodi++];
           boolean acceptable=false;
@@ -454,7 +454,7 @@ public class Session implements Runnable{
                                  "Next authentication method: "+method);
           }
 
-	  ua=null;
+          ua=null;
           try{
             Class<?> c=null;
             if(getConfig("userauth."+method)!=null){
@@ -469,46 +469,46 @@ public class Session implements Runnable{
             }
           }
 
-	  if(ua!=null){
+          if(ua!=null){
             auth_cancel=false;
-	    try{
-	      auth=ua.start(this);
+            try{
+              auth=ua.start(this);
               if(auth &&
                  JSch.getLogger().isEnabled(Logger.INFO)){
                 JSch.getLogger().log(Logger.INFO,
                                      "Authentication succeeded ("+method+").");
               }
-	    }
-	    catch(JSchAuthCancelException ee){
-	      auth_cancel=true;
-	    }
-	    catch(JSchPartialAuthException ee){
+            }
+            catch(JSchAuthCancelException ee){
+              auth_cancel=true;
+            }
+            catch(JSchPartialAuthException ee){
               String tmp = smethods;
               smethods=ee.getMethods();
               smethoda=Util.split(smethods, ",");
               if(!tmp.equals(smethods)){
                 methodi=0;
               }
-	      //System.err.println("PartialAuth: "+methods);
-	      auth_cancel=false;
-	      continue loop;
-	    }
-	    catch(RuntimeException ee){
-	      throw ee;
-	    }
-	    catch(JSchException ee){
+              //System.err.println("PartialAuth: "+methods);
+              auth_cancel=false;
+              continue loop;
+            }
+            catch(RuntimeException ee){
               throw ee;
-	    }
-	    catch(Exception ee){
-	      //System.err.println("ee: "+ee); // SSH_MSG_DISCONNECT: 2 Too many authentication failures
+            }
+            catch(JSchException ee){
+              throw ee;
+            }
+            catch(Exception ee){
+              //System.err.println("ee: "+ee); // SSH_MSG_DISCONNECT: 2 Too many authentication failures
               if(JSch.getLogger().isEnabled(Logger.WARN)){
                 JSch.getLogger().log(Logger.WARN,
                                      "an exception during authentication\n"+ee.toString());
               }
               break loop;
-	    }
-	  }
-	}
+            }
+          }
+        }
         break;
       }
 
@@ -872,7 +872,7 @@ public class Session implements Runnable{
        i==HostKeyRepository.CHANGED){
       String file=null;
       synchronized(hkr){
-	file=hkr.getKnownHostsRepositoryID();
+        file=hkr.getKnownHostsRepositoryID();
       }
       if(file==null){file="known_hosts";}
 
@@ -913,24 +913,24 @@ key_fprint+".\n"+
     if((shkc.equals("ask") || shkc.equals("yes")) &&
        (i!=HostKeyRepository.OK) && !insert){
       if(shkc.equals("yes")){
-	throw new JSchException("reject HostKey: "+host);
+        throw new JSchException("reject HostKey: "+host);
       }
       //System.err.println("finger-print: "+key_fprint);
       if(userinfo!=null){
-	boolean foo=userinfo.promptYesNo(
+        boolean foo=userinfo.promptYesNo(
 "The authenticity of host '"+host+"' can't be established.\n"+
 key_type+" key fingerprint is "+key_fprint+".\n"+
 "Are you sure you want to continue connecting?"
-					 );
-	if(!foo){
-	  throw new JSchException("reject HostKey: "+host);
-	}
-	insert=true;
+                                         );
+        if(!foo){
+          throw new JSchException("reject HostKey: "+host);
+        }
+        insert=true;
       }
       else{
-	if(i==HostKeyRepository.NOT_INCLUDED)
-	  throw new JSchException("UnknownHostKey: "+host+". "+key_type+" key fingerprint is "+key_fprint);
-	else
+        if(i==HostKeyRepository.NOT_INCLUDED)
+          throw new JSchException("UnknownHostKey: "+host+". "+key_type+" key fingerprint is "+key_fprint);
+        else
           throw new JSchException("HostKey has been changed: "+host);
       }
     }
@@ -976,7 +976,7 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
 
     if(insert){
       synchronized(hkr){
-	hkr.add(hostkey, userinfo);
+        hkr.add(hostkey, userinfo);
       }
     }
   }
@@ -1233,17 +1233,17 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
 
       if(inflater!=null){
         //inflater.uncompress(buf);
-	int pad=buf.buffer[4];
-	uncompress_len[0]=buf.index-5-pad;
-	byte[] foo=inflater.uncompress(buf.buffer, 5, uncompress_len);
-	if(foo!=null){
-	  buf.buffer=foo;
-	  buf.index=5+uncompress_len[0];
-	}
-	else{
-	  System.err.println("fail in inflater");
-	  break;
-	}
+        int pad=buf.buffer[4];
+        uncompress_len[0]=buf.index-5-pad;
+        byte[] foo=inflater.uncompress(buf.buffer, 5, uncompress_len);
+        if(foo!=null){
+          buf.buffer=foo;
+          buf.index=5+uncompress_len[0];
+        }
+        else{
+          System.err.println("fail in inflater");
+          break;
+        }
       }
 
       int type=buf.getCommand()&0xff;
@@ -1251,21 +1251,21 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
       if(type==SSH_MSG_DISCONNECT){
         buf.rewind();
         buf.getInt();buf.getShort();
-	int reason_code=buf.getInt();
-	byte[] description=buf.getString();
-	byte[] language_tag=buf.getString();
-	throw new JSchException("SSH_MSG_DISCONNECT: "+
-				    reason_code+
-				" "+Util.byte2str(description)+
-				" "+Util.byte2str(language_tag));
-	//break;
+        int reason_code=buf.getInt();
+        byte[] description=buf.getString();
+        byte[] language_tag=buf.getString();
+        throw new JSchException("SSH_MSG_DISCONNECT: "+
+                                    reason_code+
+                                " "+Util.byte2str(description)+
+                                " "+Util.byte2str(language_tag));
+        //break;
       }
       else if(type==SSH_MSG_IGNORE){
       }
       else if(type==SSH_MSG_UNIMPLEMENTED){
         buf.rewind();
         buf.getInt();buf.getShort();
-	int reason_id=buf.getInt();
+        int reason_id=buf.getInt();
         if(JSch.getLogger().isEnabled(Logger.INFO)){
           JSch.getLogger().log(Logger.INFO,
                                "Received SSH_MSG_UNIMPLEMENTED for "+reason_id);
@@ -1275,23 +1275,23 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
         buf.rewind();
         buf.getInt();buf.getShort();
 /*
-	byte always_display=(byte)buf.getByte();
-	byte[] message=buf.getString();
-	byte[] language_tag=buf.getString();
-	System.err.println("SSH_MSG_DEBUG:"+
-			   " "+Util.byte2str(message)+
-			   " "+Util.byte2str(language_tag));
+        byte always_display=(byte)buf.getByte();
+        byte[] message=buf.getString();
+        byte[] language_tag=buf.getString();
+        System.err.println("SSH_MSG_DEBUG:"+
+                           " "+Util.byte2str(message)+
+                           " "+Util.byte2str(language_tag));
 */
       }
       else if(type==SSH_MSG_CHANNEL_WINDOW_ADJUST){
           buf.rewind();
           buf.getInt();buf.getShort();
-	  Channel c=Channel.getChannel(buf.getInt(), this);
-	  if(c==null){
-	  }
-	  else{
-	    c.addRemoteWindowSize(buf.getUInt());
-	  }
+          Channel c=Channel.getChannel(buf.getInt(), this);
+          if(c==null){
+          }
+          else{
+            c.addRemoteWindowSize(buf.getUInt());
+          }
       }
       else if(type==SSH_MSG_EXT_INFO){
         buf.rewind();
@@ -1479,9 +1479,9 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
         hash.update(buf.buffer, 0, buf.index);
         byte[] foo=hash.digest();
         byte[] bar=new byte[Es2c.length+foo.length];
-	System.arraycopy(Es2c, 0, bar, 0, Es2c.length);
-	System.arraycopy(foo, 0, bar, Es2c.length, foo.length);
-	Es2c=bar;
+        System.arraycopy(Es2c, 0, bar, 0, Es2c.length);
+        System.arraycopy(foo, 0, bar, Es2c.length, foo.length);
+        Es2c=bar;
       }
       s2ccipher.init(Cipher.DECRYPT_MODE, Es2c, IVs2c);
       s2ccipher_size=s2ccipher.getIVSize();
@@ -1508,9 +1508,9 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
         hash.update(buf.buffer, 0, buf.index);
         byte[] foo=hash.digest();
         byte[] bar=new byte[Ec2s.length+foo.length];
-	System.arraycopy(Ec2s, 0, bar, 0, Ec2s.length);
-	System.arraycopy(foo, 0, bar, Ec2s.length, foo.length);
-	Ec2s=bar;
+        System.arraycopy(Ec2s, 0, bar, 0, Ec2s.length);
+        System.arraycopy(foo, 0, bar, Ec2s.length, foo.length);
+        Ec2s=bar;
       }
       c2scipher.init(Cipher.ENCRYPT_MODE, Ec2s, IVc2s);
       c2scipher_size=c2scipher.getIVSize();
@@ -1607,7 +1607,7 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
 
       }
       if(c.close || !c.isConnected()){
-	throw new IOException("channel is broken");
+        throw new IOException("channel is broken");
       }
 
       boolean sendit=false;
@@ -1615,8 +1615,8 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
       byte command=0;
       int recipient=-1;
       synchronized(c){
-	if(c.rwsize>0){
-	  long len=c.rwsize;
+        if(c.rwsize>0){
+          long len=c.rwsize;
           if(len>length){
             len=length;
           }
@@ -1625,19 +1625,19 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
                            (c2scipher!=null ? c2scipher_size : 8),
                            (c2smac!=null ? c2smac.getBlockSize() : 0));
           }
-	  command=packet.buffer.getCommand();
-	  recipient=c.getRecipient();
-	  length-=len;
-	  c.rwsize-=len;
-	  sendit=true;
-	}
+          command=packet.buffer.getCommand();
+          recipient=c.getRecipient();
+          length-=len;
+          c.rwsize-=len;
+          sendit=true;
+        }
       }
       if(sendit){
-	_write(packet);
+        _write(packet);
         if(length==0){
           return;
         }
-	packet.unshift(command, recipient, s, length);
+        packet.unshift(command, recipient, s, length);
       }
 
       synchronized(c){
@@ -1720,7 +1720,7 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
     int stimeout=0;
     try{
       while(isConnected &&
-	    thread!=null){
+            thread!=null){
         try{
           buf=read(buf);
           stimeout=0;
@@ -1738,149 +1738,149 @@ key_type+" key fingerprint is "+key_fprint+".\n"+
           throw ee;
         }
 
-	int msgType=buf.getCommand()&0xff;
+        int msgType=buf.getCommand()&0xff;
 
-	if(kex!=null && kex.getState()==msgType){
+        if(kex!=null && kex.getState()==msgType){
           kex_start_time=System.currentTimeMillis();
-	  boolean result=kex.next(buf);
-	  if(!result){
-	    throw new JSchException("verify: "+result);
-	  }
-	  continue;
-	}
+          boolean result=kex.next(buf);
+          if(!result){
+            throw new JSchException("verify: "+result);
+          }
+          continue;
+        }
 
         switch(msgType){
-	case SSH_MSG_KEXINIT:
+        case SSH_MSG_KEXINIT:
 //System.err.println("KEXINIT");
-	  kex=receive_kexinit(buf);
-	  break;
+          kex=receive_kexinit(buf);
+          break;
 
-	case SSH_MSG_NEWKEYS:
+        case SSH_MSG_NEWKEYS:
 //System.err.println("NEWKEYS");
           send_newkeys();
-	  receive_newkeys(buf, kex);
-	  kex=null;
-	  break;
+          receive_newkeys(buf, kex);
+          kex=null;
+          break;
 
-	case SSH_MSG_CHANNEL_DATA:
+        case SSH_MSG_CHANNEL_DATA:
           buf.getInt();
           buf.getByte();
           buf.getByte();
           i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
-	  foo=buf.getString(start, length);
-	  if(channel==null){
-	    break;
-	  }
+          channel=Channel.getChannel(i, this);
+          foo=buf.getString(start, length);
+          if(channel==null){
+            break;
+          }
 
           if(length[0]==0){
-	    break;
+            break;
           }
 
 try{
-	  channel.write(foo, start[0], length[0]);
+          channel.write(foo, start[0], length[0]);
 }
 catch(Exception e){
 //System.err.println(e);
   try{channel.disconnect();}catch(Exception ee){}
 break;
 }
-	  int len=length[0];
-	  channel.setLocalWindowSize(channel.lwsize-len);
- 	  if(channel.lwsize<channel.lwsize_max/2){
+          int len=length[0];
+          channel.setLocalWindowSize(channel.lwsize-len);
+           if(channel.lwsize<channel.lwsize_max/2){
             packet.reset();
-	    buf.putByte((byte)SSH_MSG_CHANNEL_WINDOW_ADJUST);
-	    buf.putInt(channel.getRecipient());
-	    buf.putInt(channel.lwsize_max-channel.lwsize);
+            buf.putByte((byte)SSH_MSG_CHANNEL_WINDOW_ADJUST);
+            buf.putInt(channel.getRecipient());
+            buf.putInt(channel.lwsize_max-channel.lwsize);
             synchronized(channel){
               if(!channel.close)
                 write(packet);
             }
-	    channel.setLocalWindowSize(channel.lwsize_max);
-	  }
-	  break;
+            channel.setLocalWindowSize(channel.lwsize_max);
+          }
+          break;
 
         case SSH_MSG_CHANNEL_EXTENDED_DATA:
           buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
-	  buf.getInt();                   // data_type_code == 1
-	  foo=buf.getString(start, length);
-	  //System.err.println("stderr: "+new String(foo,start[0],length[0]));
-	  if(channel==null){
-	    break;
-	  }
-
-          if(length[0]==0){
-	    break;
+          buf.getShort();
+          i=buf.getInt();
+          channel=Channel.getChannel(i, this);
+          buf.getInt();                   // data_type_code == 1
+          foo=buf.getString(start, length);
+          //System.err.println("stderr: "+new String(foo,start[0],length[0]));
+          if(channel==null){
+            break;
           }
 
-	  channel.write_ext(foo, start[0], length[0]);
+          if(length[0]==0){
+            break;
+          }
 
-	  len=length[0];
-	  channel.setLocalWindowSize(channel.lwsize-len);
- 	  if(channel.lwsize<channel.lwsize_max/2){
+          channel.write_ext(foo, start[0], length[0]);
+
+          len=length[0];
+          channel.setLocalWindowSize(channel.lwsize-len);
+           if(channel.lwsize<channel.lwsize_max/2){
             packet.reset();
-	    buf.putByte((byte)SSH_MSG_CHANNEL_WINDOW_ADJUST);
-	    buf.putInt(channel.getRecipient());
-	    buf.putInt(channel.lwsize_max-channel.lwsize);
+            buf.putByte((byte)SSH_MSG_CHANNEL_WINDOW_ADJUST);
+            buf.putInt(channel.getRecipient());
+            buf.putInt(channel.lwsize_max-channel.lwsize);
             synchronized(channel){
               if(!channel.close)
                 write(packet);
             }
-	    channel.setLocalWindowSize(channel.lwsize_max);
-	  }
-	  break;
+            channel.setLocalWindowSize(channel.lwsize_max);
+          }
+          break;
 
-	case SSH_MSG_CHANNEL_WINDOW_ADJUST:
-          buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
-	  if(channel==null){
-	    break;
-	  }
-	  channel.addRemoteWindowSize(buf.getUInt());
-	  break;
-
-	case SSH_MSG_CHANNEL_EOF:
+        case SSH_MSG_CHANNEL_WINDOW_ADJUST:
           buf.getInt();
           buf.getShort();
           i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
-	  if(channel!=null){
-	    //channel.eof_remote=true;
-	    //channel.eof();
-	    channel.eof_remote();
-	  }
-	  /*
-	  packet.reset();
-	  buf.putByte((byte)SSH_MSG_CHANNEL_EOF);
-	  buf.putInt(channel.getRecipient());
-	  write(packet);
-	  */
-	  break;
-	case SSH_MSG_CHANNEL_CLOSE:
+          channel=Channel.getChannel(i, this);
+          if(channel==null){
+            break;
+          }
+          channel.addRemoteWindowSize(buf.getUInt());
+          break;
+
+        case SSH_MSG_CHANNEL_EOF:
           buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
-	  if(channel!=null){
-//	      channel.close();
-	    channel.disconnect();
-	  }
-	  /*
+          buf.getShort();
+          i=buf.getInt();
+          channel=Channel.getChannel(i, this);
+          if(channel!=null){
+            //channel.eof_remote=true;
+            //channel.eof();
+            channel.eof_remote();
+          }
+          /*
+          packet.reset();
+          buf.putByte((byte)SSH_MSG_CHANNEL_EOF);
+          buf.putInt(channel.getRecipient());
+          write(packet);
+          */
+          break;
+        case SSH_MSG_CHANNEL_CLOSE:
+          buf.getInt();
+          buf.getShort();
+          i=buf.getInt();
+          channel=Channel.getChannel(i, this);
+          if(channel!=null){
+//              channel.close();
+            channel.disconnect();
+          }
+          /*
           if(Channel.pool.size()==0){
-	    thread=null;
-	  }
-	  */
-	  break;
-	case SSH_MSG_CHANNEL_OPEN_CONFIRMATION:
+            thread=null;
+          }
+          */
+          break;
+        case SSH_MSG_CHANNEL_OPEN_CONFIRMATION:
           buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
+          buf.getShort();
+          i=buf.getInt();
+          channel=Channel.getChannel(i, this);
           int r=buf.getInt();
           long rws=buf.getUInt();
           int rps=buf.getInt();
@@ -1891,11 +1891,11 @@ break;
             channel.setRecipient(r);
           }
           break;
-	case SSH_MSG_CHANNEL_OPEN_FAILURE:
+        case SSH_MSG_CHANNEL_OPEN_FAILURE:
           buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
+          buf.getShort();
+          i=buf.getInt();
+          channel=Channel.getChannel(i, this);
           if(channel!=null){
             int reason_code=buf.getInt();
             //foo=buf.getString();  // additional textual information
@@ -1905,96 +1905,96 @@ break;
             channel.eof_remote=true;
             channel.setRecipient(0);
           }
-	  break;
-	case SSH_MSG_CHANNEL_REQUEST:
+          break;
+        case SSH_MSG_CHANNEL_REQUEST:
           buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  foo=buf.getString();
+          buf.getShort();
+          i=buf.getInt();
+          foo=buf.getString();
           boolean reply=(buf.getByte()!=0);
-	  channel=Channel.getChannel(i, this);
-	  if(channel!=null){
-	    byte reply_type=(byte)SSH_MSG_CHANNEL_FAILURE;
-	    if((Util.byte2str(foo)).equals("exit-status")){
-	      i=buf.getInt();             // exit-status
-	      channel.setExitStatus(i);
-	      reply_type=(byte)SSH_MSG_CHANNEL_SUCCESS;
-	    }
-	    if(reply){
-	      packet.reset();
-	      buf.putByte(reply_type);
-	      buf.putInt(channel.getRecipient());
-	      write(packet);
-	    }
-	  }
-	  else{
-	  }
-	  break;
-	case SSH_MSG_CHANNEL_OPEN:
+          channel=Channel.getChannel(i, this);
+          if(channel!=null){
+            byte reply_type=(byte)SSH_MSG_CHANNEL_FAILURE;
+            if((Util.byte2str(foo)).equals("exit-status")){
+              i=buf.getInt();             // exit-status
+              channel.setExitStatus(i);
+              reply_type=(byte)SSH_MSG_CHANNEL_SUCCESS;
+            }
+            if(reply){
+              packet.reset();
+              buf.putByte(reply_type);
+              buf.putInt(channel.getRecipient());
+              write(packet);
+            }
+          }
+          else{
+          }
+          break;
+        case SSH_MSG_CHANNEL_OPEN:
           buf.getInt();
-	  buf.getShort();
-	  foo=buf.getString();
-	  String ctyp=Util.byte2str(foo);
+          buf.getShort();
+          foo=buf.getString();
+          String ctyp=Util.byte2str(foo);
           if(!"forwarded-tcpip".equals(ctyp) &&
-	     !("x11".equals(ctyp) && x11_forwarding) &&
-	     !("auth-agent@openssh.com".equals(ctyp) && agent_forwarding)){
+             !("x11".equals(ctyp) && x11_forwarding) &&
+             !("auth-agent@openssh.com".equals(ctyp) && agent_forwarding)){
             //System.err.println("Session.run: CHANNEL OPEN "+ctyp);
-	    //throw new IOException("Session.run: CHANNEL OPEN "+ctyp);
-	    packet.reset();
-	    buf.putByte((byte)SSH_MSG_CHANNEL_OPEN_FAILURE);
-	    buf.putInt(buf.getInt());
- 	    buf.putInt(Channel.SSH_OPEN_ADMINISTRATIVELY_PROHIBITED);
-	    buf.putString(Util.empty);
-	    buf.putString(Util.empty);
-	    write(packet);
-	  }
-	  else{
-	    channel=Channel.getChannel(ctyp);
-	    addChannel(channel);
-	    channel.getData(buf);
-	    channel.init();
+            //throw new IOException("Session.run: CHANNEL OPEN "+ctyp);
+            packet.reset();
+            buf.putByte((byte)SSH_MSG_CHANNEL_OPEN_FAILURE);
+            buf.putInt(buf.getInt());
+             buf.putInt(Channel.SSH_OPEN_ADMINISTRATIVELY_PROHIBITED);
+            buf.putString(Util.empty);
+            buf.putString(Util.empty);
+            write(packet);
+          }
+          else{
+            channel=Channel.getChannel(ctyp);
+            addChannel(channel);
+            channel.getData(buf);
+            channel.init();
 
-	    Thread tmp=new Thread(channel);
-	    tmp.setName("Channel "+ctyp+" "+host);
+            Thread tmp=new Thread(channel);
+            tmp.setName("Channel "+ctyp+" "+host);
             if(daemon_thread){
               tmp.setDaemon(daemon_thread);
             }
-	    tmp.start();
-	  }
+            tmp.start();
+          }
           break;
-	case SSH_MSG_CHANNEL_SUCCESS:
+        case SSH_MSG_CHANNEL_SUCCESS:
           buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
-	  if(channel==null){
-	    break;
-	  }
-	  channel.reply=1;
-	  break;
-	case SSH_MSG_CHANNEL_FAILURE:
-	  buf.getInt();
-	  buf.getShort();
-	  i=buf.getInt();
-	  channel=Channel.getChannel(i, this);
-	  if(channel==null){
-	    break;
-	  }
-	  channel.reply=0;
-	  break;
-	case SSH_MSG_GLOBAL_REQUEST:
-	  buf.getInt();
-	  buf.getShort();
-	  foo=buf.getString();       // request name
-	  reply=(buf.getByte()!=0);
-	  if(reply){
-	    packet.reset();
-	    buf.putByte((byte)SSH_MSG_REQUEST_FAILURE);
-	    write(packet);
-	  }
-	  break;
-	case SSH_MSG_REQUEST_FAILURE:
-	case SSH_MSG_REQUEST_SUCCESS:
+          buf.getShort();
+          i=buf.getInt();
+          channel=Channel.getChannel(i, this);
+          if(channel==null){
+            break;
+          }
+          channel.reply=1;
+          break;
+        case SSH_MSG_CHANNEL_FAILURE:
+          buf.getInt();
+          buf.getShort();
+          i=buf.getInt();
+          channel=Channel.getChannel(i, this);
+          if(channel==null){
+            break;
+          }
+          channel.reply=0;
+          break;
+        case SSH_MSG_GLOBAL_REQUEST:
+          buf.getInt();
+          buf.getShort();
+          foo=buf.getString();       // request name
+          reply=(buf.getByte()!=0);
+          if(reply){
+            packet.reset();
+            buf.putByte((byte)SSH_MSG_REQUEST_FAILURE);
+            write(packet);
+          }
+          break;
+        case SSH_MSG_REQUEST_FAILURE:
+        case SSH_MSG_REQUEST_SUCCESS:
           Thread t=grr.getThread();
           if(t!=null){
             grr.setReply(msgType==SSH_MSG_REQUEST_SUCCESS? 1 : 0);
@@ -2005,11 +2005,11 @@ break;
             }
             t.interrupt();
           }
-	  break;
-	default:
+          break;
+        default:
           //System.err.println("Session.run: unsupported type "+msgType);
-	  throw new IOException("Unknown SSH message type "+msgType);
-	}
+          throw new IOException("Unknown SSH message type "+msgType);
+        }
       }
     }
     catch(Exception e){
@@ -2047,7 +2047,7 @@ break;
     for(int i=0; i<Channel.pool.size(); i++){
       try{
         Channel c=((Channel)(Channel.pool.elementAt(i)));
-	if(c.session==this) c.eof();
+        if(c.session==this) c.eof();
       }
       catch(Exception e){
       }
@@ -2072,19 +2072,19 @@ break;
     thread=null;
     try{
       if(io!=null){
-	if(io.in!=null) io.in.close();
-	if(io.out!=null) io.out.close();
-	if(io.out_ext!=null) io.out_ext.close();
+        if(io.in!=null) io.in.close();
+        if(io.out!=null) io.out.close();
+        if(io.out_ext!=null) io.out_ext.close();
       }
       if(proxy==null){
         if(socket!=null)
-	  socket.close();
+          socket.close();
       }
       else{
-	synchronized(proxy){
-	  proxy.close();
-	}
-	proxy=null;
+        synchronized(proxy){
+          proxy.close();
+        }
+        proxy=null;
       }
     }
     catch(Exception e){
@@ -2598,7 +2598,7 @@ break;
         }
         catch(Exception ee){
           throw new JSchException(ee.toString(), ee);
-	    //System.err.println(foo+" isn't accessible.");
+            //System.err.println(foo+" isn't accessible.");
         }
       }
     }

--- a/src/main/java/com/jcraft/jsch/SftpATTRS.java
+++ b/src/main/java/com/jcraft/jsch/SftpATTRS.java
@@ -145,7 +145,7 @@ public class SftpATTRS {
   }
 
   static SftpATTRS getATTR(Buffer buf){
-    SftpATTRS attr=new SftpATTRS();	
+    SftpATTRS attr=new SftpATTRS();
     attr.flags=buf.getInt();
     if((attr.flags&SSH_FILEXFER_ATTR_SIZE)!=0){ attr.size=buf.getLong(); }
     if((attr.flags&SSH_FILEXFER_ATTR_UIDGID)!=0){
@@ -163,11 +163,11 @@ public class SftpATTRS {
     if((attr.flags&SSH_FILEXFER_ATTR_EXTENDED)!=0){
       int count=buf.getInt();
       if(count>0){
-	attr.extended=new String[count*2];
-	for(int i=0; i<count; i++){
-	  attr.extended[i*2]=Util.byte2str(buf.getString());
-	  attr.extended[i*2+1]=Util.byte2str(buf.getString());
-	}
+        attr.extended=new String[count*2];
+        for(int i=0; i<count; i++){
+          attr.extended[i*2]=Util.byte2str(buf.getString());
+          attr.extended[i*2+1]=Util.byte2str(buf.getString());
+        }
       }
     }
     return attr;
@@ -184,10 +184,10 @@ public class SftpATTRS {
       len+=4;
       int count=extended.length/2;
       if(count>0){
-	for(int i=0; i<count; i++){
-	  len+=4; len+=extended[i*2].length();
-	  len+=4; len+=extended[i*2+1].length();
-	}
+        for(int i=0; i<count; i++){
+          len+=4; len+=extended[i*2].length();
+          len+=4; len+=extended[i*2+1].length();
+        }
       }
     }
     return len;
@@ -207,10 +207,10 @@ public class SftpATTRS {
     if((flags&SSH_FILEXFER_ATTR_EXTENDED)!=0){
       int count=extended.length/2;
       if(count>0){
-	for(int i=0; i<count; i++){
-	  buf.putString(Util.str2byte(extended[i*2]));
-	  buf.putString(Util.str2byte(extended[i*2+1]));
-	}
+        for(int i=0; i<count; i++){
+          buf.putString(Util.str2byte(extended[i*2]));
+          buf.putString(Util.str2byte(extended[i*2+1]));
+        }
       }
     }
   }

--- a/src/main/java/com/jcraft/jsch/SocketFactory.java
+++ b/src/main/java/com/jcraft/jsch/SocketFactory.java
@@ -34,7 +34,7 @@ import java.io.*;
 
 public interface SocketFactory{
   public Socket createSocket(String host, int port)throws IOException,
-							  UnknownHostException;
+                                                          UnknownHostException;
   public InputStream getInputStream(Socket socket)throws IOException;
   public OutputStream getOutputStream(Socket socket)throws IOException;
 }

--- a/src/main/java/com/jcraft/jsch/UIKeyboardInteractive.java
+++ b/src/main/java/com/jcraft/jsch/UIKeyboardInteractive.java
@@ -31,8 +31,8 @@ package com.jcraft.jsch;
 
 public interface UIKeyboardInteractive{
   String[] promptKeyboardInteractive(String destination,
-				     String name,
-				     String instruction,
-				     String[] prompt,
-				     boolean[] echo);
+                                     String name,
+                                     String instruction,
+                                     String[] prompt,
+                                     boolean[] echo);
 }

--- a/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
@@ -52,7 +52,7 @@ class UserAuthKeyboardInteractive extends UserAuth{
     while(true){
 
       if(session.auth_failures >= session.max_auth_tries){
-	return false;
+        return false;
       }
 
       // send
@@ -78,53 +78,53 @@ class UserAuthKeyboardInteractive extends UserAuth{
         buf=session.read(buf);
         int command=buf.getCommand()&0xff;
 
-	if(command==SSH_MSG_USERAUTH_SUCCESS){
-	  return true;
-	}
-	if(command==SSH_MSG_USERAUTH_BANNER){
-	  buf.getInt(); buf.getByte(); buf.getByte();
-	  byte[] _message=buf.getString();
-	  byte[] lang=buf.getString();
-	  String message=Util.byte2str(_message);
-	  if(userinfo!=null){
-	    userinfo.showMessage(message);
-	  }
-	  continue loop;
-	}
-	if(command==SSH_MSG_USERAUTH_FAILURE){
-	  buf.getInt(); buf.getByte(); buf.getByte(); 
-	  byte[] foo=buf.getString();
-	  int partial_success=buf.getByte();
-//	  System.err.println(new String(foo)+
-//			     " partial_success:"+(partial_success!=0));
+        if(command==SSH_MSG_USERAUTH_SUCCESS){
+          return true;
+        }
+        if(command==SSH_MSG_USERAUTH_BANNER){
+          buf.getInt(); buf.getByte(); buf.getByte();
+          byte[] _message=buf.getString();
+          byte[] lang=buf.getString();
+          String message=Util.byte2str(_message);
+          if(userinfo!=null){
+            userinfo.showMessage(message);
+          }
+          continue loop;
+        }
+        if(command==SSH_MSG_USERAUTH_FAILURE){
+          buf.getInt(); buf.getByte(); buf.getByte(); 
+          byte[] foo=buf.getString();
+          int partial_success=buf.getByte();
+//          System.err.println(new String(foo)+
+//                             " partial_success:"+(partial_success!=0));
 
-	  if(partial_success!=0){
-	    throw new JSchPartialAuthException(Util.byte2str(foo));
-	  }
+          if(partial_success!=0){
+            throw new JSchPartialAuthException(Util.byte2str(foo));
+          }
 
-	  if(firsttime){
-	    return false;
-	    //throw new JSchException("USERAUTH KI is not supported");
-	    //cancel=true;  // ??
-	  }
+          if(firsttime){
+            return false;
+            //throw new JSchException("USERAUTH KI is not supported");
+            //cancel=true;  // ??
+          }
           session.auth_failures++;
-	  break;
-	}
-	if(command==SSH_MSG_USERAUTH_INFO_REQUEST){
-	  firsttime=false;
-	  buf.getInt(); buf.getByte(); buf.getByte();
-	  String name=Util.byte2str(buf.getString());
-	  String instruction=Util.byte2str(buf.getString());
-	  String languate_tag=Util.byte2str(buf.getString());
-	  int num=buf.getInt();
-	  String[] prompt=new String[num];
-	  boolean[] echo=new boolean[num];
-	  for(int i=0; i<num; i++){
-	    prompt[i]=Util.byte2str(buf.getString());
-	    echo[i]=(buf.getByte()!=0);
-	  }
+          break;
+        }
+        if(command==SSH_MSG_USERAUTH_INFO_REQUEST){
+          firsttime=false;
+          buf.getInt(); buf.getByte(); buf.getByte();
+          String name=Util.byte2str(buf.getString());
+          String instruction=Util.byte2str(buf.getString());
+          String languate_tag=Util.byte2str(buf.getString());
+          int num=buf.getInt();
+          String[] prompt=new String[num];
+          boolean[] echo=new boolean[num];
+          for(int i=0; i<num; i++){
+            prompt[i]=Util.byte2str(buf.getString());
+            echo[i]=(buf.getByte()!=0);
+          }
 
-	  byte[][] response=null;
+          byte[][] response=null;
 
           if(password!=null && 
              prompt.length==1 &&
@@ -135,9 +135,9 @@ class UserAuthKeyboardInteractive extends UserAuth{
             password=null;
           }
           else if(num>0
-	     ||(name.length()>0 || instruction.length()>0)
-	     ){
-	    if(userinfo!=null){
+             ||(name.length()>0 || instruction.length()>0)
+             ){
+            if(userinfo!=null){
               UIKeyboardInteractive kbi=(UIKeyboardInteractive)userinfo;
               String[] _response=kbi.promptKeyboardInteractive(dest,
                                                                name,
@@ -150,19 +150,19 @@ class UserAuthKeyboardInteractive extends UserAuth{
                   response[i]=Util.str2byte(_response[i]);
                 }
               }
-	    }
-	  }
+            }
+          }
 
-	  // byte      SSH_MSG_USERAUTH_INFO_RESPONSE(61)
-	  // int       num-responses
-	  // string    response[1] (ISO-10646 UTF-8)
-	  // ...
-	  // string    response[num-responses] (ISO-10646 UTF-8)
-	  packet.reset();
-	  buf.putByte((byte)SSH_MSG_USERAUTH_INFO_RESPONSE);
-	  if(num>0 &&
-	     (response==null ||  // cancel
-	      num!=response.length)){
+          // byte      SSH_MSG_USERAUTH_INFO_RESPONSE(61)
+          // int       num-responses
+          // string    response[1] (ISO-10646 UTF-8)
+          // ...
+          // string    response[num-responses] (ISO-10646 UTF-8)
+          packet.reset();
+          buf.putByte((byte)SSH_MSG_USERAUTH_INFO_RESPONSE);
+          if(num>0 &&
+             (response==null ||  // cancel
+              num!=response.length)){
 
             if(response==null){  
               // working around the bug in OpenSSH ;-<
@@ -175,28 +175,28 @@ class UserAuthKeyboardInteractive extends UserAuth{
               buf.putInt(0);
             }
 
-	    if(response==null)
-	      cancel=true;
-	  }
-	  else{
-	    buf.putInt(num);
-	    for(int i=0; i<num; i++){
-	      buf.putString(response[i]);
-	    }
-	  }
-	  session.write(packet);
+            if(response==null)
+              cancel=true;
+          }
+          else{
+            buf.putInt(num);
+            for(int i=0; i<num; i++){
+              buf.putString(response[i]);
+            }
+          }
+          session.write(packet);
           /*
-	  if(cancel)
-	    break;
+          if(cancel)
+            break;
           */
-	  continue loop;
-	}
-	//throw new JSchException("USERAUTH fail ("+command+")");
-	return false;
+          continue loop;
+        }
+        //throw new JSchException("USERAUTH fail ("+command+")");
+        return false;
       }
       if(cancel){
-	throw new JSchAuthCancelException("keyboard-interactive");
-	//break;
+        throw new JSchAuthCancelException("keyboard-interactive");
+        //break;
       }
     }
     //return false;

--- a/src/main/java/com/jcraft/jsch/UserAuthNone.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthNone.java
@@ -87,38 +87,38 @@ class UserAuthNone extends UserAuth{
       command=buf.getCommand()&0xff;
 
       if(command==SSH_MSG_USERAUTH_SUCCESS){
-	return true;
+        return true;
       }
       if(command==SSH_MSG_USERAUTH_BANNER){
-	buf.getInt(); buf.getByte(); buf.getByte();
-	byte[] _message=buf.getString();
-	byte[] lang=buf.getString();
-	String message=Util.byte2str(_message);
-	if(userinfo!=null){
+        buf.getInt(); buf.getByte(); buf.getByte();
+        byte[] _message=buf.getString();
+        byte[] lang=buf.getString();
+        String message=Util.byte2str(_message);
+        if(userinfo!=null){
           try{
             userinfo.showMessage(message);
           }
           catch(RuntimeException ee){
           }
-	}
-	continue loop;
+        }
+        continue loop;
       }
       if(command==SSH_MSG_USERAUTH_FAILURE){
-	buf.getInt(); buf.getByte(); buf.getByte(); 
-	byte[] foo=buf.getString();
-	int partial_success=buf.getByte();
-	methods=Util.byte2str(foo);
+        buf.getInt(); buf.getByte(); buf.getByte(); 
+        byte[] foo=buf.getString();
+        int partial_success=buf.getByte();
+        methods=Util.byte2str(foo);
 //System.err.println("UserAuthNONE: "+methods+
-//		   " partial_success:"+(partial_success!=0));
-//	if(partial_success!=0){
-//	  throw new JSchPartialAuthException(new String(foo));
-//	}
+//                   " partial_success:"+(partial_success!=0));
+//        if(partial_success!=0){
+//          throw new JSchPartialAuthException(new String(foo));
+//        }
 
         break;
       }
       else{
 //      System.err.println("USERAUTH fail ("+command+")");
-	throw new JSchException("USERAUTH fail ("+command+")");
+        throw new JSchException("USERAUTH fail ("+command+")");
       }
     }
    //throw new JSchException("USERAUTH fail");

--- a/src/main/java/com/jcraft/jsch/UserAuthPassword.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthPassword.java
@@ -51,20 +51,20 @@ class UserAuthPassword extends UserAuth{
       }
 
       if(password==null){
-	if(userinfo==null){
-	  //throw new JSchException("USERAUTH fail");
-	  return false;
-	}
-	if(!userinfo.promptPassword("Password for "+dest)){
-	  throw new JSchAuthCancelException("password");
-	  //break;
-	}
+        if(userinfo==null){
+          //throw new JSchException("USERAUTH fail");
+          return false;
+        }
+        if(!userinfo.promptPassword("Password for "+dest)){
+          throw new JSchAuthCancelException("password");
+          //break;
+        }
 
-	String _password=userinfo.getPassword();
-	if(_password==null){
-	  throw new JSchAuthCancelException("password");
-	  //break;
-	}
+        String _password=userinfo.getPassword();
+        if(_password==null){
+          throw new JSchAuthCancelException("password");
+          //break;
+        }
         password=Util.str2byte(_password);
       }
 
@@ -89,27 +89,27 @@ class UserAuthPassword extends UserAuth{
 
       loop:
       while(true){
-	buf=session.read(buf);
+        buf=session.read(buf);
         int command=buf.getCommand()&0xff;
 
-	if(command==SSH_MSG_USERAUTH_SUCCESS){
-	  return true;
-	}
-	if(command==SSH_MSG_USERAUTH_BANNER){
-	  buf.getInt(); buf.getByte(); buf.getByte();
-	  byte[] _message=buf.getString();
-	  byte[] lang=buf.getString();
+        if(command==SSH_MSG_USERAUTH_SUCCESS){
+          return true;
+        }
+        if(command==SSH_MSG_USERAUTH_BANNER){
+          buf.getInt(); buf.getByte(); buf.getByte();
+          byte[] _message=buf.getString();
+          byte[] lang=buf.getString();
           String message=Util.byte2str(_message);
-	  if(userinfo!=null){
-	    userinfo.showMessage(message);
-	  }
-	  continue loop;
-	}
-	if(command==SSH_MSG_USERAUTH_PASSWD_CHANGEREQ){
-	  buf.getInt(); buf.getByte(); buf.getByte(); 
-	  byte[] instruction=buf.getString();
-	  byte[] tag=buf.getString();
-	  if(userinfo==null || 
+          if(userinfo!=null){
+            userinfo.showMessage(message);
+          }
+          continue loop;
+        }
+        if(command==SSH_MSG_USERAUTH_PASSWD_CHANGEREQ){
+          buf.getInt(); buf.getByte(); buf.getByte(); 
+          byte[] instruction=buf.getString();
+          byte[] tag=buf.getString();
+          if(userinfo==null || 
              !(userinfo instanceof UIKeyboardInteractive)){
             if(userinfo!=null){
               userinfo.showMessage("Password must be changed.");
@@ -152,25 +152,25 @@ class UserAuthPassword extends UserAuth{
           Util.bzero(newpassword);
           response=null;
           session.write(packet);
-	  continue loop;
+          continue loop;
         }
-	if(command==SSH_MSG_USERAUTH_FAILURE){
-	  buf.getInt(); buf.getByte(); buf.getByte(); 
-	  byte[] foo=buf.getString();
-	  int partial_success=buf.getByte();
-	  //System.err.println(new String(foo)+
-	  //		 " partial_success:"+(partial_success!=0));
-	  if(partial_success!=0){
-	    throw new JSchPartialAuthException(Util.byte2str(foo));
-	  }
+        if(command==SSH_MSG_USERAUTH_FAILURE){
+          buf.getInt(); buf.getByte(); buf.getByte(); 
+          byte[] foo=buf.getString();
+          int partial_success=buf.getByte();
+          //System.err.println(new String(foo)+
+          //                 " partial_success:"+(partial_success!=0));
+          if(partial_success!=0){
+            throw new JSchPartialAuthException(Util.byte2str(foo));
+          }
           session.auth_failures++;
-	  break;
-	}
-	else{
+          break;
+        }
+        else{
           //System.err.println("USERAUTH fail ("+buf.getCommand()+")");
-//	  throw new JSchException("USERAUTH fail ("+buf.getCommand()+")");
-	  return false;
-	}
+//          throw new JSchException("USERAUTH fail ("+buf.getCommand()+")");
+          return false;
+        }
       }
 
       if(password!=null){

--- a/src/main/java/com/jcraft/jsch/Util.java
+++ b/src/main/java/com/jcraft/jsch/Util.java
@@ -123,9 +123,9 @@ class Util{
     while(true){
       index=foo.indexOf(split, start);
       if(index>=0){
-	bar.addElement(Util.byte2str(buf, start, index-start));
-	start=index+1;
-	continue;
+        bar.addElement(Util.byte2str(buf, start, index-start));
+        start=index+1;
+        continue;
       }
       bar.addElement(Util.byte2str(buf, start, buf.length-start));
       break;
@@ -140,7 +140,7 @@ class Util{
     return glob0(pattern, 0, name, 0);
   }
   static private boolean glob0(byte[] pattern, int pattern_index,
-			      byte[] name, int name_index){
+                              byte[] name, int name_index){
     if(name.length>0 && name[0]=='.'){
       if(pattern.length>0 && pattern[0]=='.'){
         if(pattern.length==2 && pattern[1]=='*') return true;
@@ -151,7 +151,7 @@ class Util{
     return glob(pattern, pattern_index, name, name_index);
   }
   static private boolean glob(byte[] pattern, int pattern_index,
-			      byte[] name, int name_index){
+                              byte[] name, int name_index){
     //System.err.println("glob: "+new String(pattern)+", "+pattern_index+" "+new String(name)+", "+name_index);
 
     int patternlen=pattern.length;
@@ -164,14 +164,14 @@ class Util{
 
     while(i<patternlen && j<namelen){
       if(pattern[i]=='\\'){
-	if(i+1==patternlen)
-	  return false;
-	i++;
-	if(pattern[i]!=name[j]) 
+        if(i+1==patternlen)
+          return false;
+        i++;
+        if(pattern[i]!=name[j]) 
           return false;
         i+=skipUTF8Char(pattern[i]);
         j+=skipUTF8Char(name[j]);
-	continue;
+        continue;
       }
 
       if(pattern[i]=='*'){
@@ -182,14 +182,14 @@ class Util{
           }
           break;
         }
-	if(patternlen==i)
+        if(patternlen==i)
           return true;
 
-	byte foo=pattern[i];
+        byte foo=pattern[i];
         if(foo=='?'){
           while(j<namelen){
-	    if(glob(pattern, i, name, j)){
-	      return true;
+            if(glob(pattern, i, name, j)){
+              return true;
             }
             j+=skipUTF8Char(name[j]);
           }
@@ -212,21 +212,21 @@ class Util{
           return false;
         }
 
-	while(j<namelen){
-	  if(foo==name[j]){
-	    if(glob(pattern, i, name, j)){
-	      return true;
-	    }
-	  }
+        while(j<namelen){
+          if(foo==name[j]){
+            if(glob(pattern, i, name, j)){
+              return true;
+            }
+          }
           j+=skipUTF8Char(name[j]);
-	}
-	return false;
+        }
+        return false;
       }
 
       if(pattern[i]=='?'){
         i++;
         j+=skipUTF8Char(name[j]);
-	continue;
+        continue;
       }
 
       if(pattern[i]!=name[j])
@@ -237,11 +237,11 @@ class Util{
 
       if(!(j<namelen)){         // name is end
         if(!(i<patternlen)){    // pattern is end
-	  return true;
-	}
-	if(pattern[i]=='*'){    
+          return true;
+        }
+        if(pattern[i]=='*'){    
           break;
-	}
+        }
       }
       continue;
     }

--- a/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
@@ -48,20 +48,20 @@ public class SignatureDSA implements com.jcraft.jsch.SignatureDSA{
   @Override
   public void setPubKey(byte[] y, byte[] p, byte[] q, byte[] g) throws Exception{
     DSAPublicKeySpec dsaPubKeySpec = 
-	new DSAPublicKeySpec(new BigInteger(y),
-			     new BigInteger(p),
-			     new BigInteger(q),
-			     new BigInteger(g));
+        new DSAPublicKeySpec(new BigInteger(y),
+                             new BigInteger(p),
+                             new BigInteger(q),
+                             new BigInteger(g));
     PublicKey pubKey=keyFactory.generatePublic(dsaPubKeySpec);
     signature.initVerify(pubKey);
   }
   @Override
   public void setPrvKey(byte[] x, byte[] p, byte[] q, byte[] g) throws Exception{
     DSAPrivateKeySpec dsaPrivKeySpec = 
-	new DSAPrivateKeySpec(new BigInteger(x),
-			      new BigInteger(p),
-			      new BigInteger(q),
-			      new BigInteger(g));
+        new DSAPrivateKeySpec(new BigInteger(x),
+                              new BigInteger(p),
+                              new BigInteger(q),
+                              new BigInteger(g));
     PrivateKey prvKey = keyFactory.generatePrivate(dsaPrivKeySpec);
     signature.initSign(prvKey);
   }
@@ -77,7 +77,7 @@ System.err.println("");
 */
     // sig is in ASN.1
     // SEQUENCE::={ r INTEGER, s INTEGER }
-    int len=0;	
+    int len=0;
     int index=3;
     len=sig[index++]&0xff;
 //System.err.println("! len="+len);
@@ -94,11 +94,11 @@ System.err.println("");
     // result must be 40 bytes, but length of r and s may not be 20 bytes  
 
     System.arraycopy(r, (r.length>20)?1:0,
-		     result, (r.length>20)?0:20-r.length,
-		     (r.length>20)?20:r.length);
+                     result, (r.length>20)?0:20-r.length,
+                     (r.length>20)?20:r.length);
     System.arraycopy(s, (s.length>20)?1:0,
-		     result, (s.length>20)?20:40-s.length,
-		     (s.length>20)?20:s.length);
+                     result, (s.length>20)?20:40-s.length,
+                     (s.length>20)?20:s.length);
  
 //  System.arraycopy(sig, (sig[3]==20?4:5), result, 0, 20);
 //  System.arraycopy(sig, sig.length-20, result, 20, 20);

--- a/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
@@ -56,16 +56,16 @@ public abstract class SignatureRSAN implements com.jcraft.jsch.SignatureRSA{
   @Override
   public void setPubKey(byte[] e, byte[] n) throws Exception{
     RSAPublicKeySpec rsaPubKeySpec = 
-	new RSAPublicKeySpec(new BigInteger(n),
-			     new BigInteger(e));
+        new RSAPublicKeySpec(new BigInteger(n),
+                             new BigInteger(e));
     PublicKey pubKey=keyFactory.generatePublic(rsaPubKeySpec);
     signature.initVerify(pubKey);
   }
   @Override
   public void setPrvKey(byte[] d, byte[] n) throws Exception{
     RSAPrivateKeySpec rsaPrivKeySpec = 
-	new RSAPrivateKeySpec(new BigInteger(n),
-			      new BigInteger(d));
+        new RSAPrivateKeySpec(new BigInteger(n),
+                              new BigInteger(d));
     PrivateKey prvKey = keyFactory.generatePrivate(rsaPrivKeySpec);
     signature.initSign(prvKey);
   }

--- a/src/main/java/com/jcraft/jsch/jzlib/Adler32.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Adler32.java
@@ -77,7 +77,7 @@ final class Adler32 implements Checksum {
       int k=NMAX;
       len-=k;
       while(k-->0){
-	s1+=buf[index++]&0xff; s2+=s1;
+        s1+=buf[index++]&0xff; s2+=s1;
       }
       s1%=BASE;
       s2%=BASE;

--- a/src/main/java/com/jcraft/jsch/jzlib/CRC32.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/CRC32.java
@@ -47,7 +47,7 @@ final class CRC32 implements Checksum {
       int c = n;
       for (int k = 8;  --k >= 0; ) {
         if ((c & 1) != 0)
-	  c = 0xedb88320 ^ (c >>> 1);
+          c = 0xedb88320 ^ (c >>> 1);
         else
           c = c >>> 1;
       }

--- a/src/main/java/com/jcraft/jsch/jzlib/Compression.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Compression.java
@@ -80,7 +80,7 @@ public class Compression implements com.jcraft.jsch.Compression {
           outputlen+=tmp;
           break;
         default:
-	    System.err.println("compress: deflate returnd "+status);
+            System.err.println("compress: deflate returnd "+status);
       }
     }
     while(deflater.avail_out==0);
@@ -104,34 +104,34 @@ public class Compression implements com.jcraft.jsch.Compression {
       int status=inflater.inflate(JZlib.Z_PARTIAL_FLUSH);
       switch(status){
         case JZlib.Z_OK:
-	  if(inflated_buf.length<inflated_end+BUF_SIZE-inflater.avail_out){
+          if(inflated_buf.length<inflated_end+BUF_SIZE-inflater.avail_out){
             int len=inflated_buf.length*2;
             if(len<inflated_end+BUF_SIZE-inflater.avail_out)
               len=inflated_end+BUF_SIZE-inflater.avail_out;
             byte[] foo=new byte[len];
-	    System.arraycopy(inflated_buf, 0, foo, 0, inflated_end);
-	    inflated_buf=foo;
-	  }
-	  System.arraycopy(tmpbuf, 0,
-			   inflated_buf, inflated_end,
-			   BUF_SIZE-inflater.avail_out);
-	  inflated_end+=(BUF_SIZE-inflater.avail_out);
+            System.arraycopy(inflated_buf, 0, foo, 0, inflated_end);
+            inflated_buf=foo;
+          }
+          System.arraycopy(tmpbuf, 0,
+                           inflated_buf, inflated_end,
+                           BUF_SIZE-inflater.avail_out);
+          inflated_end+=(BUF_SIZE-inflater.avail_out);
           length[0]=inflated_end;
-	  break;
+          break;
         case JZlib.Z_BUF_ERROR:
           if(inflated_end>buffer.length-start){
             byte[] foo=new byte[inflated_end+start];
             System.arraycopy(buffer, 0, foo, 0, start);
             System.arraycopy(inflated_buf, 0, foo, start, inflated_end);
-	    buffer=foo;
-	  }
-	  else{
+            buffer=foo;
+          }
+          else{
             System.arraycopy(inflated_buf, 0, buffer, start, inflated_end);
-	  }
+          }
           length[0]=inflated_end;
-	  return buffer;
-	default:
-	  System.err.println("uncompress: inflate returnd "+status);
+          return buffer;
+        default:
+          System.err.println("uncompress: inflate returnd "+status);
           return null;
       }
     }

--- a/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
@@ -50,7 +50,7 @@ final class Deflate implements Cloneable {
     int max_chain;
     int func;
     Config(int good_length, int max_lazy, 
-	   int nice_length, int max_chain, int func){
+           int nice_length, int max_chain, int func){
       this.good_length=good_length;
       this.max_lazy=max_lazy;
       this.nice_length=nice_length;
@@ -385,15 +385,15 @@ final class Deflate implements Cloneable {
   // when the heap property is re-established (each father smaller than its
   // two sons).
   void pqdownheap(short[] tree,  // the tree to restore
-		  int k          // node to move down
-		  ){
+                  int k          // node to move down
+                  ){
     int v = heap[k];
     int j = k << 1;  // left son of k
     while (j <= heap_len) {
       // Set j to the smallest of the two sons:
       if (j < heap_len &&
-	  smaller(tree, heap[j+1], heap[j], depth)){
-	j++;
+          smaller(tree, heap[j+1], heap[j], depth)){
+        j++;
       }
       // Exit if v is smaller than both sons
       if(smaller(tree, v, heap[j], depth)) break;
@@ -410,14 +410,14 @@ final class Deflate implements Cloneable {
     short tn2=tree[n*2];
     short tm2=tree[m*2];
     return (tn2<tm2 ||
-	    (tn2==tm2 && depth[n] <= depth[m]));
+            (tn2==tm2 && depth[n] <= depth[m]));
   }
 
   // Scan a literal or distance tree to determine the frequencies of the codes
   // in the bit length tree.
   void scan_tree (short[] tree,// the tree to be scanned
-		  int max_code // and its largest code of non zero frequency
-		  ){
+                  int max_code // and its largest code of non zero frequency
+                  ){
     int n;                     // iterates over all tree elements
     int prevlen = -1;          // last emitted length
     int curlen;                // length of current code
@@ -432,30 +432,30 @@ final class Deflate implements Cloneable {
     for(n = 0; n <= max_code; n++) {
       curlen = nextlen; nextlen = tree[(n+1)*2+1];
       if(++count < max_count && curlen == nextlen) {
-	continue;
+        continue;
       }
       else if(count < min_count) {
-	bl_tree[curlen*2] += count;
+        bl_tree[curlen*2] += count;
       }
       else if(curlen != 0) {
-	if(curlen != prevlen) bl_tree[curlen*2]++;
-	bl_tree[REP_3_6*2]++;
+        if(curlen != prevlen) bl_tree[curlen*2]++;
+        bl_tree[REP_3_6*2]++;
       }
       else if(count <= 10) {
-	bl_tree[REPZ_3_10*2]++;
+        bl_tree[REPZ_3_10*2]++;
       }
       else{
-	bl_tree[REPZ_11_138*2]++;
+        bl_tree[REPZ_11_138*2]++;
       }
       count = 0; prevlen = curlen;
       if(nextlen == 0) {
-	max_count = 138; min_count = 3;
+        max_count = 138; min_count = 3;
       }
       else if(curlen == nextlen) {
-	max_count = 6; min_count = 3;
+        max_count = 6; min_count = 3;
       }
       else{
-	max_count = 7; min_count = 4;
+        max_count = 7; min_count = 4;
       }
     }
   }
@@ -506,8 +506,8 @@ final class Deflate implements Cloneable {
   // Send a literal or distance tree in compressed form, using the codes in
   // bl_tree.
   void send_tree (short[] tree,// the tree to be sent
-		  int max_code // and its largest code of non zero frequency
-		  ){
+                  int max_code // and its largest code of non zero frequency
+                  ){
     int n;                     // iterates over all tree elements
     int prevlen = -1;          // last emitted length
     int curlen;                // length of current code
@@ -521,35 +521,35 @@ final class Deflate implements Cloneable {
     for (n = 0; n <= max_code; n++) {
       curlen = nextlen; nextlen = tree[(n+1)*2+1];
       if(++count < max_count && curlen == nextlen) {
-	continue;
+        continue;
       }
       else if(count < min_count) {
-	do { send_code(curlen, bl_tree); } while (--count != 0);
+        do { send_code(curlen, bl_tree); } while (--count != 0);
       }
       else if(curlen != 0){
-	if(curlen != prevlen){
-	  send_code(curlen, bl_tree); count--;
-	}
-	send_code(REP_3_6, bl_tree); 
-	send_bits(count-3, 2);
+        if(curlen != prevlen){
+          send_code(curlen, bl_tree); count--;
+        }
+        send_code(REP_3_6, bl_tree); 
+        send_bits(count-3, 2);
       }
       else if(count <= 10){
-	send_code(REPZ_3_10, bl_tree); 
-	send_bits(count-3, 3);
+        send_code(REPZ_3_10, bl_tree); 
+        send_bits(count-3, 3);
       }
       else{
-	send_code(REPZ_11_138, bl_tree);
-	send_bits(count-11, 7);
+        send_code(REPZ_11_138, bl_tree);
+        send_bits(count-11, 7);
       }
       count = 0; prevlen = curlen;
       if(nextlen == 0){
-	max_count = 138; min_count = 3;
+        max_count = 138; min_count = 3;
       }
       else if(curlen == nextlen){
-	max_count = 6; min_count = 3;
+        max_count = 6; min_count = 3;
       }
       else{
-	max_count = 7; min_count = 4;
+        max_count = 7; min_count = 4;
       }
     }
   }
@@ -625,8 +625,8 @@ final class Deflate implements Cloneable {
   // Save the match info and tally the frequency counts. Return true if
   // the current block must be flushed.
   boolean _tr_tally (int dist, // distance of matched string
-		     int lc // match length-MIN_MATCH or unmatched char (if dist==0)
-		     ){
+                     int lc // match length-MIN_MATCH or unmatched char (if dist==0)
+                     ){
 
     pending_buf[d_buf+last_lit*2] = (byte)(dist>>>8);
     pending_buf[d_buf+last_lit*2+1] = (byte)dist;
@@ -651,8 +651,8 @@ final class Deflate implements Cloneable {
       int in_length = strstart - block_start;
       int dcode;
       for (dcode = 0; dcode < D_CODES; dcode++) {
-	out_length += (int)dyn_dtree[dcode*2] *
-	  (5L+Tree.extra_dbits[dcode]);
+        out_length += (int)dyn_dtree[dcode*2] *
+          (5L+Tree.extra_dbits[dcode]);
       }
       out_length >>>= 3;
       if ((matches < (last_lit/2)) && out_length < in_length/2) return true;
@@ -674,35 +674,35 @@ final class Deflate implements Cloneable {
 
     if (last_lit != 0){
       do{
-	dist=((pending_buf[d_buf+lx*2]<<8)&0xff00)|
-	  (pending_buf[d_buf+lx*2+1]&0xff);
-	lc=(l_buf[lx])&0xff; lx++;
+        dist=((pending_buf[d_buf+lx*2]<<8)&0xff00)|
+          (pending_buf[d_buf+lx*2+1]&0xff);
+        lc=(l_buf[lx])&0xff; lx++;
 
-	if(dist == 0){
-	  send_code(lc, ltree); // send a literal byte
-	} 
-	else{
-	  // Here, lc is the match length - MIN_MATCH
-	  code = Tree._length_code[lc];
+        if(dist == 0){
+          send_code(lc, ltree); // send a literal byte
+        } 
+        else{
+          // Here, lc is the match length - MIN_MATCH
+          code = Tree._length_code[lc];
 
-	  send_code(code+LITERALS+1, ltree); // send the length code
-	  extra = Tree.extra_lbits[code];
-	  if(extra != 0){
-	    lc -= Tree.base_length[code];
-	    send_bits(lc, extra);       // send the extra length bits
-	  }
-	  dist--; // dist is now the match distance - 1
-	  code = Tree.d_code(dist);
+          send_code(code+LITERALS+1, ltree); // send the length code
+          extra = Tree.extra_lbits[code];
+          if(extra != 0){
+            lc -= Tree.base_length[code];
+            send_bits(lc, extra);       // send the extra length bits
+          }
+          dist--; // dist is now the match distance - 1
+          code = Tree.d_code(dist);
 
-	  send_code(code, dtree);       // send the distance code
-	  extra = Tree.extra_dbits[code];
-	  if (extra != 0) {
-	    dist -= Tree.base_dist[code];
-	    send_bits(dist, extra);   // send the extra distance bits
-	  }
-	} // literal or match pair ?
+          send_code(code, dtree);       // send the distance code
+          extra = Tree.extra_dbits[code];
+          if (extra != 0) {
+            dist -= Tree.base_dist[code];
+            send_bits(dist, extra);   // send the extra distance bits
+          }
+        } // literal or match pair ?
 
-	// Check that the overlay between pending_buf and d_buf+l_buf is ok:
+        // Check that the overlay between pending_buf and d_buf+l_buf is ok:
       }
       while (lx < last_lit);
     }
@@ -753,9 +753,9 @@ final class Deflate implements Cloneable {
   // Copy a stored block, storing first the length and its
   // one's complement if requested.
   void copy_block(int buf,         // the input data
-		  int len,         // its length
-		  boolean header   // true if block header must be written
-		  ){
+                  int len,         // its length
+                  boolean header   // true if block header must be written
+                  ){
     int index=0;
     bi_windup();      // align on byte boundary
     last_eob_len = 8; // enough lookahead for inflate
@@ -774,8 +774,8 @@ final class Deflate implements Cloneable {
 
   void flush_block_only(boolean eof){
     _tr_flush_block(block_start>=0 ? block_start : -1,
-		    strstart-block_start,
-		    eof);
+                    strstart-block_start,
+                    eof);
     block_start=strstart;
     strm.flush_pending();
   }
@@ -802,9 +802,9 @@ final class Deflate implements Cloneable {
     while(true){
       // Fill the window as much as possible:
       if(lookahead<=1){
-	fill_window();
-	if(lookahead==0 && flush==Z_NO_FLUSH) return NeedMore;
-	if(lookahead==0) break; // flush the current block
+        fill_window();
+        if(lookahead==0 && flush==Z_NO_FLUSH) return NeedMore;
+        if(lookahead==0) break; // flush the current block
       }
 
       strstart+=lookahead;
@@ -813,20 +813,20 @@ final class Deflate implements Cloneable {
       // Emit a stored block if pending_buf will be full:
       max_start=block_start+max_block_size;
       if(strstart==0|| strstart>=max_start) {
-	// strstart == 0 is possible when wraparound on 16-bit machine
-	lookahead = strstart-max_start;
-	strstart = max_start;
+        // strstart == 0 is possible when wraparound on 16-bit machine
+        lookahead = strstart-max_start;
+        strstart = max_start;
       
-	flush_block_only(false);
-	if(strm.avail_out==0) return NeedMore;
+        flush_block_only(false);
+        if(strm.avail_out==0) return NeedMore;
 
       }
 
       // Flush if we may have to slide, otherwise block_start may become
       // negative and the data will be gone:
       if(strstart-block_start >= w_size-MIN_LOOKAHEAD) {
-	flush_block_only(false);
-	if(strm.avail_out==0) return NeedMore;
+        flush_block_only(false);
+        if(strm.avail_out==0) return NeedMore;
       }
     }
 
@@ -839,9 +839,9 @@ final class Deflate implements Cloneable {
 
   // Send a stored block
   void _tr_stored_block(int buf,        // input block
-			int stored_len, // length of input block
-			boolean eof     // true if this is the last block for a file
-			){
+                        int stored_len, // length of input block
+                        boolean eof     // true if this is the last block for a file
+                        ){
     send_bits((STORED_BLOCK<<1)+(eof?1:0), 3);  // send block type
     copy_block(buf, stored_len, true);          // with header
   }
@@ -849,9 +849,9 @@ final class Deflate implements Cloneable {
   // Determine the best encoding for the current block: dynamic trees, static
   // trees or store, and output the encoded block to the zip file.
   void _tr_flush_block(int buf,        // input block, or NULL if too old
-		       int stored_len, // length of input block
-		       boolean eof     // true if this is the last block for a file
-		       ) {
+                       int stored_len, // length of input block
+                       boolean eof     // true if this is the last block for a file
+                       ) {
     int opt_lenb, static_lenb;// opt_len and static_len in bytes
     int max_blindex = 0;      // index of last bit length code of non zero freq
 
@@ -929,46 +929,46 @@ final class Deflate implements Cloneable {
 
       // Deal with !@#$% 64K limit:
       if(more==0 && strstart==0 && lookahead==0){
-	more = w_size;
+        more = w_size;
       } 
       else if(more==-1) {
-	// Very unlikely, but possible on 16 bit machine if strstart == 0
-	// and lookahead == 1 (input done one byte at time)
-	more--;
+        // Very unlikely, but possible on 16 bit machine if strstart == 0
+        // and lookahead == 1 (input done one byte at time)
+        more--;
 
-	// If the window is almost full and there is insufficient lookahead,
-	// move the upper half to the lower one to make room in the upper half.
+        // If the window is almost full and there is insufficient lookahead,
+        // move the upper half to the lower one to make room in the upper half.
       }
       else if(strstart >= w_size+ w_size-MIN_LOOKAHEAD) {
-	System.arraycopy(window, w_size, window, 0, w_size);
-	match_start-=w_size;
-	strstart-=w_size; // we now have strstart >= MAX_DIST
-	block_start-=w_size;
+        System.arraycopy(window, w_size, window, 0, w_size);
+        match_start-=w_size;
+        strstart-=w_size; // we now have strstart >= MAX_DIST
+        block_start-=w_size;
 
-	// Slide the hash table (could be avoided with 32 bit values
-	// at the expense of memory usage). We slide even when level == 0
-	// to keep the hash table consistent if we switch back to level > 0
-	// later. (Using level 0 permanently is not an optimal usage of
-	// zlib, so we don't care about this pathological case.)
+        // Slide the hash table (could be avoided with 32 bit values
+        // at the expense of memory usage). We slide even when level == 0
+        // to keep the hash table consistent if we switch back to level > 0
+        // later. (Using level 0 permanently is not an optimal usage of
+        // zlib, so we don't care about this pathological case.)
 
-	n = hash_size;
-	p=n;
-	do {
-	  m = (head[--p]&0xffff);
-	  head[p]=(m>=w_size ? (short)(m-w_size) : 0);
-	}
-	while (--n != 0);
+        n = hash_size;
+        p=n;
+        do {
+          m = (head[--p]&0xffff);
+          head[p]=(m>=w_size ? (short)(m-w_size) : 0);
+        }
+        while (--n != 0);
 
-	n = w_size;
-	p = n;
-	do {
-	  m = (prev[--p]&0xffff);
-	  prev[p] = (m >= w_size ? (short)(m-w_size) : 0);
-	  // If n is not on any hash chain, prev[n] is garbage but
-	  // its value will never be used.
-	}
-	while (--n!=0);
-	more += w_size;
+        n = w_size;
+        p = n;
+        do {
+          m = (prev[--p]&0xffff);
+          prev[p] = (m >= w_size ? (short)(m-w_size) : 0);
+          // If n is not on any hash chain, prev[n] is garbage but
+          // its value will never be used.
+        }
+        while (--n!=0);
+        more += w_size;
       }
 
       if (strm.avail_in == 0) return;
@@ -989,8 +989,8 @@ final class Deflate implements Cloneable {
 
       // Initialize the hash value now that we have some input:
       if(lookahead >= MIN_MATCH) {
-	ins_h = window[strstart]&0xff;
-	ins_h=(((ins_h)<<hash_shift)^(window[strstart+1]&0xff))&hash_mask;
+        ins_h = window[strstart]&0xff;
+        ins_h=(((ins_h)<<hash_shift)^(window[strstart+1]&0xff))&hash_mask;
       }
       // If the whole input has less than MIN_MATCH bytes, ins_h is garbage,
       // but this is not important since only literal bytes will be emitted.
@@ -1014,86 +1014,86 @@ final class Deflate implements Cloneable {
       // for the next match, plus MIN_MATCH bytes to insert the
       // string following the next match.
       if(lookahead < MIN_LOOKAHEAD){
-	fill_window();
-	if(lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH){
-	  return NeedMore;
-	}
-	if(lookahead == 0) break; // flush the current block
+        fill_window();
+        if(lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH){
+          return NeedMore;
+        }
+        if(lookahead == 0) break; // flush the current block
       }
 
       // Insert the string window[strstart .. strstart+2] in the
       // dictionary, and set hash_head to the head of the hash chain:
       if(lookahead >= MIN_MATCH){
-	ins_h=(((ins_h)<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff))&hash_mask;
+        ins_h=(((ins_h)<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff))&hash_mask;
 
-//	prev[strstart&w_mask]=hash_head=head[ins_h];
+//        prev[strstart&w_mask]=hash_head=head[ins_h];
         hash_head=(head[ins_h]&0xffff);
-	prev[strstart&w_mask]=head[ins_h];
-	head[ins_h]=(short)strstart;
+        prev[strstart&w_mask]=head[ins_h];
+        head[ins_h]=(short)strstart;
       }
 
       // Find the longest match, discarding those <= prev_length.
       // At this point we have always match_length < MIN_MATCH
 
       if(hash_head!=0L && 
-	 ((strstart-hash_head)&0xffff) <= w_size-MIN_LOOKAHEAD
-	 ){
-	// To simplify the code, we prevent matches with the string
-	// of window index 0 (in particular we have to avoid a match
-	// of the string with itself at the start of the input file).
-	if(strategy != Z_HUFFMAN_ONLY){
-	  match_length=longest_match (hash_head);
-	}
-	// longest_match() sets match_start
+         ((strstart-hash_head)&0xffff) <= w_size-MIN_LOOKAHEAD
+         ){
+        // To simplify the code, we prevent matches with the string
+        // of window index 0 (in particular we have to avoid a match
+        // of the string with itself at the start of the input file).
+        if(strategy != Z_HUFFMAN_ONLY){
+          match_length=longest_match (hash_head);
+        }
+        // longest_match() sets match_start
       }
       if(match_length>=MIN_MATCH){
-	//        check_match(strstart, match_start, match_length);
+        //        check_match(strstart, match_start, match_length);
 
-	bflush=_tr_tally(strstart-match_start, match_length-MIN_MATCH);
+        bflush=_tr_tally(strstart-match_start, match_length-MIN_MATCH);
 
-	lookahead -= match_length;
+        lookahead -= match_length;
 
-	// Insert new strings in the hash table only if the match length
-	// is not too large. This saves time but degrades compression.
-	if(match_length <= max_lazy_match &&
-	   lookahead >= MIN_MATCH) {
-	  match_length--; // string at strstart already in hash table
-	  do{
-	    strstart++;
+        // Insert new strings in the hash table only if the match length
+        // is not too large. This saves time but degrades compression.
+        if(match_length <= max_lazy_match &&
+           lookahead >= MIN_MATCH) {
+          match_length--; // string at strstart already in hash table
+          do{
+            strstart++;
 
-	    ins_h=((ins_h<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff))&hash_mask;
-//	    prev[strstart&w_mask]=hash_head=head[ins_h];
-	    hash_head=(head[ins_h]&0xffff);
-	    prev[strstart&w_mask]=head[ins_h];
-	    head[ins_h]=(short)strstart;
+            ins_h=((ins_h<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff))&hash_mask;
+//            prev[strstart&w_mask]=hash_head=head[ins_h];
+            hash_head=(head[ins_h]&0xffff);
+            prev[strstart&w_mask]=head[ins_h];
+            head[ins_h]=(short)strstart;
 
-	    // strstart never exceeds WSIZE-MAX_MATCH, so there are
-	    // always MIN_MATCH bytes ahead.
-	  }
-	  while (--match_length != 0);
-	  strstart++; 
-	}
-	else{
-	  strstart += match_length;
-	  match_length = 0;
-	  ins_h = window[strstart]&0xff;
+            // strstart never exceeds WSIZE-MAX_MATCH, so there are
+            // always MIN_MATCH bytes ahead.
+          }
+          while (--match_length != 0);
+          strstart++; 
+        }
+        else{
+          strstart += match_length;
+          match_length = 0;
+          ins_h = window[strstart]&0xff;
 
-	  ins_h=(((ins_h)<<hash_shift)^(window[strstart+1]&0xff))&hash_mask;
-	  // If lookahead < MIN_MATCH, ins_h is garbage, but it does not
-	  // matter since it will be recomputed at next deflate call.
-	}
+          ins_h=(((ins_h)<<hash_shift)^(window[strstart+1]&0xff))&hash_mask;
+          // If lookahead < MIN_MATCH, ins_h is garbage, but it does not
+          // matter since it will be recomputed at next deflate call.
+        }
       }
       else {
-	// No match, output a literal byte
+        // No match, output a literal byte
 
-	bflush=_tr_tally(0, window[strstart]&0xff);
-	lookahead--;
-	strstart++; 
+        bflush=_tr_tally(0, window[strstart]&0xff);
+        lookahead--;
+        strstart++; 
       }
       if (bflush){
 
-	flush_block_only(false);
-	if(strm.avail_out==0) return NeedMore;
+        flush_block_only(false);
+        if(strm.avail_out==0) return NeedMore;
       }
     }
 
@@ -1121,22 +1121,22 @@ final class Deflate implements Cloneable {
       // string following the next match.
 
       if (lookahead < MIN_LOOKAHEAD) {
-	fill_window();
-	if(lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
-	  return NeedMore;
-	}
-	if(lookahead == 0) break; // flush the current block
+        fill_window();
+        if(lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
+          return NeedMore;
+        }
+        if(lookahead == 0) break; // flush the current block
       }
 
       // Insert the string window[strstart .. strstart+2] in the
       // dictionary, and set hash_head to the head of the hash chain:
 
       if(lookahead >= MIN_MATCH) {
-	ins_h=(((ins_h)<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff)) & hash_mask;
-//	prev[strstart&w_mask]=hash_head=head[ins_h];
-	hash_head=(head[ins_h]&0xffff);
-	prev[strstart&w_mask]=head[ins_h];
-	head[ins_h]=(short)strstart;
+        ins_h=(((ins_h)<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff)) & hash_mask;
+//        prev[strstart&w_mask]=hash_head=head[ins_h];
+        hash_head=(head[ins_h]&0xffff);
+        prev[strstart&w_mask]=head[ins_h];
+        head[ins_h]=(short)strstart;
       }
 
       // Find the longest match, discarding those <= prev_length.
@@ -1144,82 +1144,82 @@ final class Deflate implements Cloneable {
       match_length = MIN_MATCH-1;
 
       if (hash_head != 0 && prev_length < max_lazy_match &&
-	  ((strstart-hash_head)&0xffff) <= w_size-MIN_LOOKAHEAD
-	  ){
-	// To simplify the code, we prevent matches with the string
-	// of window index 0 (in particular we have to avoid a match
-	// of the string with itself at the start of the input file).
+          ((strstart-hash_head)&0xffff) <= w_size-MIN_LOOKAHEAD
+          ){
+        // To simplify the code, we prevent matches with the string
+        // of window index 0 (in particular we have to avoid a match
+        // of the string with itself at the start of the input file).
 
-	if(strategy != Z_HUFFMAN_ONLY) {
-	  match_length = longest_match(hash_head);
-	}
-	// longest_match() sets match_start
+        if(strategy != Z_HUFFMAN_ONLY) {
+          match_length = longest_match(hash_head);
+        }
+        // longest_match() sets match_start
 
-	if (match_length <= 5 && (strategy == Z_FILTERED ||
-				  (match_length == MIN_MATCH &&
-				   strstart - match_start > 4096))) {
+        if (match_length <= 5 && (strategy == Z_FILTERED ||
+                                  (match_length == MIN_MATCH &&
+                                   strstart - match_start > 4096))) {
 
-	  // If prev_match is also MIN_MATCH, match_start is garbage
-	  // but we will ignore the current match anyway.
-	  match_length = MIN_MATCH-1;
-	}
+          // If prev_match is also MIN_MATCH, match_start is garbage
+          // but we will ignore the current match anyway.
+          match_length = MIN_MATCH-1;
+        }
       }
 
       // If there was a match at the previous step and the current
       // match is not better, output the previous match:
       if(prev_length >= MIN_MATCH && match_length <= prev_length) {
-	int max_insert = strstart + lookahead - MIN_MATCH;
-	// Do not insert strings in hash table beyond this.
+        int max_insert = strstart + lookahead - MIN_MATCH;
+        // Do not insert strings in hash table beyond this.
 
-	//          check_match(strstart-1, prev_match, prev_length);
+        //          check_match(strstart-1, prev_match, prev_length);
 
-	bflush=_tr_tally(strstart-1-prev_match, prev_length - MIN_MATCH);
+        bflush=_tr_tally(strstart-1-prev_match, prev_length - MIN_MATCH);
 
-	// Insert in hash table all strings up to the end of the match.
-	// strstart-1 and strstart are already inserted. If there is not
-	// enough lookahead, the last two strings are not inserted in
-	// the hash table.
-	lookahead -= prev_length-1;
-	prev_length -= 2;
-	do{
-	  if(++strstart <= max_insert) {
-	    ins_h=(((ins_h)<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff))&hash_mask;
-	    //prev[strstart&w_mask]=hash_head=head[ins_h];
-	    hash_head=(head[ins_h]&0xffff);
-	    prev[strstart&w_mask]=head[ins_h];
-	    head[ins_h]=(short)strstart;
-	  }
-	}
-	while(--prev_length != 0);
-	match_available = 0;
-	match_length = MIN_MATCH-1;
-	strstart++;
+        // Insert in hash table all strings up to the end of the match.
+        // strstart-1 and strstart are already inserted. If there is not
+        // enough lookahead, the last two strings are not inserted in
+        // the hash table.
+        lookahead -= prev_length-1;
+        prev_length -= 2;
+        do{
+          if(++strstart <= max_insert) {
+            ins_h=(((ins_h)<<hash_shift)^(window[(strstart)+(MIN_MATCH-1)]&0xff))&hash_mask;
+            //prev[strstart&w_mask]=hash_head=head[ins_h];
+            hash_head=(head[ins_h]&0xffff);
+            prev[strstart&w_mask]=head[ins_h];
+            head[ins_h]=(short)strstart;
+          }
+        }
+        while(--prev_length != 0);
+        match_available = 0;
+        match_length = MIN_MATCH-1;
+        strstart++;
 
-	if (bflush){
-	  flush_block_only(false);
-	  if(strm.avail_out==0) return NeedMore;
-	}
+        if (bflush){
+          flush_block_only(false);
+          if(strm.avail_out==0) return NeedMore;
+        }
       } else if (match_available!=0) {
 
-	// If there was no match at the previous position, output a
-	// single literal. If there was a match but the current match
-	// is longer, truncate the previous match to a single literal.
+        // If there was no match at the previous position, output a
+        // single literal. If there was a match but the current match
+        // is longer, truncate the previous match to a single literal.
 
-	bflush=_tr_tally(0, window[strstart-1]&0xff);
+        bflush=_tr_tally(0, window[strstart-1]&0xff);
 
-	if (bflush) {
-	  flush_block_only(false);
-	}
-	strstart++;
-	lookahead--;
-	if(strm.avail_out == 0) return NeedMore;
+        if (bflush) {
+          flush_block_only(false);
+        }
+        strstart++;
+        lookahead--;
+        if(strm.avail_out == 0) return NeedMore;
       } else {
-	// There is no previous match to compare with, wait for
-	// the next step to decide.
+        // There is no previous match to compare with, wait for
+        // the next step to decide.
 
-	match_available = 1;
-	strstart++;
-	lookahead--;
+        match_available = 1;
+        strstart++;
+        lookahead--;
       }
     }
 
@@ -1274,9 +1274,9 @@ final class Deflate implements Cloneable {
       // Skip to next match if the match length cannot increase
       // or if the match length is less than 2:
       if (window[match+best_len]   != scan_end  ||
-	  window[match+best_len-1] != scan_end1 ||
-	  window[match]       != window[scan]     ||
-	  window[++match]     != window[scan+1])      continue;
+          window[match+best_len-1] != scan_end1 ||
+          window[match]       != window[scan]     ||
+          window[++match]     != window[scan+1])      continue;
 
       // The check at best_len-1 can be removed because it will be made
       // again later. (This heuristic is not always a win.)
@@ -1289,28 +1289,28 @@ final class Deflate implements Cloneable {
       // the 256th check will be made at strstart+258.
       do {
       } while (window[++scan] == window[++match] &&
-	       window[++scan] == window[++match] &&
-	       window[++scan] == window[++match] &&
-	       window[++scan] == window[++match] &&
-	       window[++scan] == window[++match] &&
-	       window[++scan] == window[++match] &&
-	       window[++scan] == window[++match] &&
-	       window[++scan] == window[++match] &&
-	       scan < strend);
+               window[++scan] == window[++match] &&
+               window[++scan] == window[++match] &&
+               window[++scan] == window[++match] &&
+               window[++scan] == window[++match] &&
+               window[++scan] == window[++match] &&
+               window[++scan] == window[++match] &&
+               window[++scan] == window[++match] &&
+               scan < strend);
 
       len = MAX_MATCH - strend - scan;
       scan = strend - MAX_MATCH;
 
       if(len>best_len) {
-	match_start = cur_match;
-	best_len = len;
-	if (len >= nice_match) break;
-	scan_end1  = window[scan+best_len-1];
-	scan_end   = window[scan+best_len];
+        match_start = cur_match;
+        best_len = len;
+        if (len >= nice_match) break;
+        scan_end1  = window[scan+best_len-1];
+        scan_end   = window[scan+best_len];
       }
 
     } while ((cur_match = (prev[cur_match & wmask]&0xffff)) > limit
-	     && --chain_length != 0);
+             && --chain_length != 0);
 
     if (best_len <= lookahead) return best_len;
     return lookahead;
@@ -1318,18 +1318,18 @@ final class Deflate implements Cloneable {
 
   int deflateInit(int level, int bits, int memlevel){
     return deflateInit(level, Z_DEFLATED, bits, memlevel,
-			Z_DEFAULT_STRATEGY);
+                        Z_DEFAULT_STRATEGY);
   }
     
   int deflateInit(int level, int bits){
     return deflateInit(level, Z_DEFLATED, bits, DEF_MEM_LEVEL,
-			Z_DEFAULT_STRATEGY);
+                        Z_DEFAULT_STRATEGY);
   }
   int deflateInit(int level){
     return deflateInit(level, MAX_WBITS);
   }
   private int deflateInit(int level, int method,  int windowBits,
-			  int memLevel, int strategy){
+                          int memLevel, int strategy){
     int wrap = 1;
     //    byte[] my_version=ZLIB_VERSION;
 
@@ -1354,8 +1354,8 @@ final class Deflate implements Cloneable {
     }
 
     if (memLevel < 1 || memLevel > MAX_MEM_LEVEL || 
-	method != Z_DEFLATED ||
-	windowBits < 9 || windowBits > 15 || level < 0 || level > 9 ||
+        method != Z_DEFLATED ||
+        windowBits < 9 || windowBits > 15 || level < 0 || level > 9 ||
         strategy < 0 || strategy > Z_HUFFMAN_ONLY) {
       return Z_STREAM_ERROR;
     }
@@ -1546,13 +1546,13 @@ final class Deflate implements Cloneable {
     if(pending != 0) {
       strm.flush_pending();
       if(strm.avail_out == 0) {
-	// Since avail_out is 0, deflate will be called again with
-	// more output space, but possibly with both pending and
-	// avail_in equal to zero. There won't be anything to do,
-	// but this is not an error situation so make sure we
-	// return OK instead of BUF_ERROR at next call of deflate:
-	last_flush = -1;
-	return Z_OK;
+        // Since avail_out is 0, deflate will be called again with
+        // more output space, but possibly with both pending and
+        // avail_in equal to zero. There won't be anything to do,
+        // but this is not an error situation so make sure we
+        // return OK instead of BUF_ERROR at next call of deflate:
+        last_flush = -1;
+        return Z_OK;
       }
 
       // Make sure there is something to do and avoid duplicate consecutive
@@ -1560,7 +1560,7 @@ final class Deflate implements Cloneable {
       // returning Z_STREAM_END instead of Z_BUFF_ERROR.
     }
     else if(strm.avail_in==0 && flush <= old_flush &&
-	    flush != Z_FINISH) {
+            flush != Z_FINISH) {
       strm.msg=z_errmsg[Z_NEED_DICT-(Z_BUF_ERROR)];
       return Z_BUF_ERROR;
     }
@@ -1577,52 +1577,52 @@ final class Deflate implements Cloneable {
       int bstate=-1;
       switch(config_table[level].func){
       case STORED: 
-	bstate = deflate_stored(flush);
-	break;
+        bstate = deflate_stored(flush);
+        break;
       case FAST: 
-	bstate = deflate_fast(flush);
-	break;
+        bstate = deflate_fast(flush);
+        break;
       case SLOW: 
-	bstate = deflate_slow(flush);
-	break;
+        bstate = deflate_slow(flush);
+        break;
       default:
       }
 
       if (bstate==FinishStarted || bstate==FinishDone) {
-	status = FINISH_STATE;
+        status = FINISH_STATE;
       }
       if (bstate==NeedMore || bstate==FinishStarted) {
-	if(strm.avail_out == 0) {
-	  last_flush = -1; // avoid BUF_ERROR next call, see above
-	}
-	return Z_OK;
-	// If flush != Z_NO_FLUSH && avail_out == 0, the next call
-	// of deflate should use the same flush parameter to make sure
-	// that the flush is complete. So we don't have to output an
-	// empty block here, this will be done at next call. This also
-	// ensures that for a very small output buffer, we emit at most
-	// one empty block.
+        if(strm.avail_out == 0) {
+          last_flush = -1; // avoid BUF_ERROR next call, see above
+        }
+        return Z_OK;
+        // If flush != Z_NO_FLUSH && avail_out == 0, the next call
+        // of deflate should use the same flush parameter to make sure
+        // that the flush is complete. So we don't have to output an
+        // empty block here, this will be done at next call. This also
+        // ensures that for a very small output buffer, we emit at most
+        // one empty block.
       }
 
       if (bstate==BlockDone) {
-	if(flush == Z_PARTIAL_FLUSH) {
-	  _tr_align();
-	} 
-	else { // FULL_FLUSH or SYNC_FLUSH
-	  _tr_stored_block(0, 0, false);
-	  // For a full flush, this empty block will be recognized
-	  // as a special marker by inflate_sync().
-	  if(flush == Z_FULL_FLUSH) {
-	    //state.head[s.hash_size-1]=0;
-	    for(int i=0; i<hash_size/*-1*/; i++)  // forget history
-	      head[i]=0;
-	  }
-	}
-	strm.flush_pending();
-	if(strm.avail_out == 0) {
-	  last_flush = -1; // avoid BUF_ERROR at next call, see above
-	  return Z_OK;
-	}
+        if(flush == Z_PARTIAL_FLUSH) {
+          _tr_align();
+        } 
+        else { // FULL_FLUSH or SYNC_FLUSH
+          _tr_stored_block(0, 0, false);
+          // For a full flush, this empty block will be recognized
+          // as a special marker by inflate_sync().
+          if(flush == Z_FULL_FLUSH) {
+            //state.head[s.hash_size-1]=0;
+            for(int i=0; i<hash_size/*-1*/; i++)  // forget history
+              head[i]=0;
+          }
+        }
+        strm.flush_pending();
+        if(strm.avail_out == 0) {
+          last_flush = -1; // avoid BUF_ERROR at next call, see above
+          return Z_OK;
+        }
       }
     }
 

--- a/src/main/java/com/jcraft/jsch/jzlib/InfBlocks.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InfBlocks.java
@@ -152,25 +152,25 @@ final class InfBlocks{
       switch (mode){
       case TYPE:
 
-	while(k<(3)){
-	  if(n!=0){
-	    r=Z_OK;
-	  }
-	  else{
-	    bitb=b; bitk=k; 
-	    z.avail_in=n;
-	    z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    write=q;
-	    return inflate_flush(r);
-	  };
-	  n--;
-	  b|=(z.next_in[p++]&0xff)<<k;
-	  k+=8;
-	}
-	t = b & 7;
-	last = t & 1;
+        while(k<(3)){
+          if(n!=0){
+            r=Z_OK;
+          }
+          else{
+            bitb=b; bitk=k; 
+            z.avail_in=n;
+            z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            write=q;
+            return inflate_flush(r);
+          };
+          n--;
+          b|=(z.next_in[p++]&0xff)<<k;
+          k+=8;
+        }
+        t = b & 7;
+        last = t & 1;
 
-	switch (t >>> 1){
+        switch (t >>> 1){
         case 0:                         // stored 
           {b>>>=(3);k-=(3);}
           t = k & 7;                    // go to byte boundary
@@ -199,334 +199,334 @@ final class InfBlocks{
           z.msg = "invalid block type";
           r = Z_DATA_ERROR;
 
-	  bitb=b; bitk=k; 
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  write=q;
-	  return inflate_flush(r);
-	}
-	break;
+          bitb=b; bitk=k; 
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          write=q;
+          return inflate_flush(r);
+        }
+        break;
       case LENS:
 
-	while(k<(32)){
-	  if(n!=0){
-	    r=Z_OK;
-	  }
-	  else{
-	    bitb=b; bitk=k; 
-	    z.avail_in=n;
-	    z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    write=q;
-	    return inflate_flush(r);
-	  };
-	  n--;
-	  b|=(z.next_in[p++]&0xff)<<k;
-	  k+=8;
-	}
+        while(k<(32)){
+          if(n!=0){
+            r=Z_OK;
+          }
+          else{
+            bitb=b; bitk=k; 
+            z.avail_in=n;
+            z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            write=q;
+            return inflate_flush(r);
+          };
+          n--;
+          b|=(z.next_in[p++]&0xff)<<k;
+          k+=8;
+        }
 
-	if ((((~b) >>> 16) & 0xffff) != (b & 0xffff)){
-	  mode = BAD;
-	  z.msg = "invalid stored block lengths";
-	  r = Z_DATA_ERROR;
+        if ((((~b) >>> 16) & 0xffff) != (b & 0xffff)){
+          mode = BAD;
+          z.msg = "invalid stored block lengths";
+          r = Z_DATA_ERROR;
 
-	  bitb=b; bitk=k; 
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  write=q;
-	  return inflate_flush(r);
-	}
-	left = (b & 0xffff);
-	b = k = 0;                       // dump bits
-	mode = left!=0 ? STORED : (last!=0 ? DRY : TYPE);
-	break;
+          bitb=b; bitk=k; 
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          write=q;
+          return inflate_flush(r);
+        }
+        left = (b & 0xffff);
+        b = k = 0;                       // dump bits
+        mode = left!=0 ? STORED : (last!=0 ? DRY : TYPE);
+        break;
       case STORED:
-	if (n == 0){
-	  bitb=b; bitk=k; 
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  write=q;
-	  return inflate_flush(r);
-	}
+        if (n == 0){
+          bitb=b; bitk=k; 
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          write=q;
+          return inflate_flush(r);
+        }
 
-	if(m==0){
-	  if(q==end&&read!=0){
-	    q=0; m=(q<read?read-q-1:end-q);
-	  }
-	  if(m==0){
-	    write=q; 
-	    r=inflate_flush(r);
-	    q=write;m=(q<read?read-q-1:end-q);
-	    if(q==end&&read!=0){
-	      q=0; m=(q<read?read-q-1:end-q);
-	    }
-	    if(m==0){
-	      bitb=b; bitk=k; 
-	      z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	      write=q;
-	      return inflate_flush(r);
-	    }
-	  }
-	}
-	r=Z_OK;
+        if(m==0){
+          if(q==end&&read!=0){
+            q=0; m=(q<read?read-q-1:end-q);
+          }
+          if(m==0){
+            write=q; 
+            r=inflate_flush(r);
+            q=write;m=(q<read?read-q-1:end-q);
+            if(q==end&&read!=0){
+              q=0; m=(q<read?read-q-1:end-q);
+            }
+            if(m==0){
+              bitb=b; bitk=k; 
+              z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+              write=q;
+              return inflate_flush(r);
+            }
+          }
+        }
+        r=Z_OK;
 
-	t = left;
-	if(t>n) t = n;
-	if(t>m) t = m;
-	System.arraycopy(z.next_in, p, window, q, t);
-	p += t;  n -= t;
-	q += t;  m -= t;
-	if ((left -= t) != 0)
-	  break;
-	mode = last!=0 ? DRY : TYPE;
-	break;
+        t = left;
+        if(t>n) t = n;
+        if(t>m) t = m;
+        System.arraycopy(z.next_in, p, window, q, t);
+        p += t;  n -= t;
+        q += t;  m -= t;
+        if ((left -= t) != 0)
+          break;
+        mode = last!=0 ? DRY : TYPE;
+        break;
       case TABLE:
 
-	while(k<(14)){
-	  if(n!=0){
-	    r=Z_OK;
-	  }
-	  else{
-	    bitb=b; bitk=k; 
-	    z.avail_in=n;
-	    z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    write=q;
-	    return inflate_flush(r);
-	  };
-	  n--;
-	  b|=(z.next_in[p++]&0xff)<<k;
-	  k+=8;
-	}
+        while(k<(14)){
+          if(n!=0){
+            r=Z_OK;
+          }
+          else{
+            bitb=b; bitk=k; 
+            z.avail_in=n;
+            z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            write=q;
+            return inflate_flush(r);
+          };
+          n--;
+          b|=(z.next_in[p++]&0xff)<<k;
+          k+=8;
+        }
 
-	table = t = (b & 0x3fff);
-	if ((t & 0x1f) > 29 || ((t >> 5) & 0x1f) > 29)
-	  {
-	    mode = BAD;
-	    z.msg = "too many length or distance symbols";
-	    r = Z_DATA_ERROR;
+        table = t = (b & 0x3fff);
+        if ((t & 0x1f) > 29 || ((t >> 5) & 0x1f) > 29)
+          {
+            mode = BAD;
+            z.msg = "too many length or distance symbols";
+            r = Z_DATA_ERROR;
 
-	    bitb=b; bitk=k; 
-	    z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    write=q;
-	    return inflate_flush(r);
-	  }
-	t = 258 + (t & 0x1f) + ((t >> 5) & 0x1f);
-	if(blens==null || blens.length<t){
-	  blens=new int[t];
-	}
-	else{
-	  for(int i=0; i<t; i++){blens[i]=0;}
-	}
+            bitb=b; bitk=k; 
+            z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            write=q;
+            return inflate_flush(r);
+          }
+        t = 258 + (t & 0x1f) + ((t >> 5) & 0x1f);
+        if(blens==null || blens.length<t){
+          blens=new int[t];
+        }
+        else{
+          for(int i=0; i<t; i++){blens[i]=0;}
+        }
 
-	{b>>>=(14);k-=(14);}
+        {b>>>=(14);k-=(14);}
 
-	index = 0;
-	mode = BTREE;
+        index = 0;
+        mode = BTREE;
       case BTREE:
-	while (index < 4 + (table >>> 10)){
-	  while(k<(3)){
-	    if(n!=0){
-	      r=Z_OK;
-	    }
-	    else{
-	      bitb=b; bitk=k; 
-	      z.avail_in=n;
-	      z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	      write=q;
-	      return inflate_flush(r);
-	    };
-	    n--;
-	    b|=(z.next_in[p++]&0xff)<<k;
-	    k+=8;
-	  }
+        while (index < 4 + (table >>> 10)){
+          while(k<(3)){
+            if(n!=0){
+              r=Z_OK;
+            }
+            else{
+              bitb=b; bitk=k; 
+              z.avail_in=n;
+              z.total_in+=p-z.next_in_index;z.next_in_index=p;
+              write=q;
+              return inflate_flush(r);
+            };
+            n--;
+            b|=(z.next_in[p++]&0xff)<<k;
+            k+=8;
+          }
 
-	  blens[border[index++]] = b&7;
+          blens[border[index++]] = b&7;
 
-	  {b>>>=(3);k-=(3);}
-	}
+          {b>>>=(3);k-=(3);}
+        }
 
-	while(index < 19){
-	  blens[border[index++]] = 0;
-	}
+        while(index < 19){
+          blens[border[index++]] = 0;
+        }
 
-	bb[0] = 7;
-	t = inftree.inflate_trees_bits(blens, bb, tb, hufts, z);
-	if (t != Z_OK){
-	  r = t;
-	  if (r == Z_DATA_ERROR){
-	    blens=null;
-	    mode = BAD;
-	  }
+        bb[0] = 7;
+        t = inftree.inflate_trees_bits(blens, bb, tb, hufts, z);
+        if (t != Z_OK){
+          r = t;
+          if (r == Z_DATA_ERROR){
+            blens=null;
+            mode = BAD;
+          }
 
-	  bitb=b; bitk=k; 
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  write=q;
-	  return inflate_flush(r);
-	}
+          bitb=b; bitk=k; 
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          write=q;
+          return inflate_flush(r);
+        }
 
-	index = 0;
-	mode = DTREE;
+        index = 0;
+        mode = DTREE;
       case DTREE:
-	while (true){
-	  t = table;
-	  if(!(index < 258 + (t & 0x1f) + ((t >> 5) & 0x1f))){
-	    break;
-	  }
+        while (true){
+          t = table;
+          if(!(index < 258 + (t & 0x1f) + ((t >> 5) & 0x1f))){
+            break;
+          }
 
-	  int[] h;
-	  int i, j, c;
+          int[] h;
+          int i, j, c;
 
-	  t = bb[0];
+          t = bb[0];
 
-	  while(k<(t)){
-	    if(n!=0){
-	      r=Z_OK;
-	    }
-	    else{
-	      bitb=b; bitk=k; 
-	      z.avail_in=n;
-	      z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	      write=q;
-	      return inflate_flush(r);
-	    };
-	    n--;
-	    b|=(z.next_in[p++]&0xff)<<k;
-	    k+=8;
-	  }
+          while(k<(t)){
+            if(n!=0){
+              r=Z_OK;
+            }
+            else{
+              bitb=b; bitk=k; 
+              z.avail_in=n;
+              z.total_in+=p-z.next_in_index;z.next_in_index=p;
+              write=q;
+              return inflate_flush(r);
+            };
+            n--;
+            b|=(z.next_in[p++]&0xff)<<k;
+            k+=8;
+          }
 
-	  if(tb[0]==-1){
+          if(tb[0]==-1){
             //System.err.println("null...");
-	  }
+          }
 
-	  t=hufts[(tb[0]+(b&inflate_mask[t]))*3+1];
-	  c=hufts[(tb[0]+(b&inflate_mask[t]))*3+2];
+          t=hufts[(tb[0]+(b&inflate_mask[t]))*3+1];
+          c=hufts[(tb[0]+(b&inflate_mask[t]))*3+2];
 
-	  if (c < 16){
-	    b>>>=(t);k-=(t);
-	    blens[index++] = c;
-	  }
-	  else { // c == 16..18
-	    i = c == 18 ? 7 : c - 14;
-	    j = c == 18 ? 11 : 3;
+          if (c < 16){
+            b>>>=(t);k-=(t);
+            blens[index++] = c;
+          }
+          else { // c == 16..18
+            i = c == 18 ? 7 : c - 14;
+            j = c == 18 ? 11 : 3;
 
-	    while(k<(t+i)){
-	      if(n!=0){
-		r=Z_OK;
-	      }
-	      else{
-		bitb=b; bitk=k; 
-		z.avail_in=n;
-		z.total_in+=p-z.next_in_index;z.next_in_index=p;
-		write=q;
-		return inflate_flush(r);
-	      };
-	      n--;
-	      b|=(z.next_in[p++]&0xff)<<k;
-	      k+=8;
-	    }
+            while(k<(t+i)){
+              if(n!=0){
+                r=Z_OK;
+              }
+              else{
+                bitb=b; bitk=k; 
+                z.avail_in=n;
+                z.total_in+=p-z.next_in_index;z.next_in_index=p;
+                write=q;
+                return inflate_flush(r);
+              };
+              n--;
+              b|=(z.next_in[p++]&0xff)<<k;
+              k+=8;
+            }
 
-	    b>>>=(t);k-=(t);
+            b>>>=(t);k-=(t);
 
-	    j += (b & inflate_mask[i]);
+            j += (b & inflate_mask[i]);
 
-	    b>>>=(i);k-=(i);
+            b>>>=(i);k-=(i);
 
-	    i = index;
-	    t = table;
-	    if (i + j > 258 + (t & 0x1f) + ((t >> 5) & 0x1f) ||
-		(c == 16 && i < 1)){
-	      blens=null;
-	      mode = BAD;
-	      z.msg = "invalid bit length repeat";
-	      r = Z_DATA_ERROR;
+            i = index;
+            t = table;
+            if (i + j > 258 + (t & 0x1f) + ((t >> 5) & 0x1f) ||
+                (c == 16 && i < 1)){
+              blens=null;
+              mode = BAD;
+              z.msg = "invalid bit length repeat";
+              r = Z_DATA_ERROR;
 
-	      bitb=b; bitk=k; 
-	      z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	      write=q;
-	      return inflate_flush(r);
-	    }
+              bitb=b; bitk=k; 
+              z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+              write=q;
+              return inflate_flush(r);
+            }
 
-	    c = c == 16 ? blens[i-1] : 0;
-	    do{
-	      blens[i++] = c;
-	    }
-	    while (--j!=0);
-	    index = i;
-	  }
-	}
+            c = c == 16 ? blens[i-1] : 0;
+            do{
+              blens[i++] = c;
+            }
+            while (--j!=0);
+            index = i;
+          }
+        }
 
-	tb[0]=-1;
-	{
-	  bl[0] = 9;         // must be <= 9 for lookahead assumptions
-	  bd[0] = 6;         // must be <= 9 for lookahead assumptions
-	  t = table;
-	  t = inftree.inflate_trees_dynamic(257 + (t & 0x1f), 
-					    1 + ((t >> 5) & 0x1f),
-					    blens, bl, bd, tli, tdi, hufts, z);
+        tb[0]=-1;
+        {
+          bl[0] = 9;         // must be <= 9 for lookahead assumptions
+          bd[0] = 6;         // must be <= 9 for lookahead assumptions
+          t = table;
+          t = inftree.inflate_trees_dynamic(257 + (t & 0x1f), 
+                                            1 + ((t >> 5) & 0x1f),
+                                            blens, bl, bd, tli, tdi, hufts, z);
 
-	  if (t != Z_OK){
-	    if (t == Z_DATA_ERROR){
-	      blens=null;
-	      mode = BAD;
-	    }
-	    r = t;
+          if (t != Z_OK){
+            if (t == Z_DATA_ERROR){
+              blens=null;
+              mode = BAD;
+            }
+            r = t;
 
-	    bitb=b; bitk=k; 
-	    z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    write=q;
-	    return inflate_flush(r);
-	  }
-	  codes.init(bl[0], bd[0], hufts, tli[0], hufts, tdi[0]);
-	}
-	mode = CODES;
+            bitb=b; bitk=k; 
+            z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            write=q;
+            return inflate_flush(r);
+          }
+          codes.init(bl[0], bd[0], hufts, tli[0], hufts, tdi[0]);
+        }
+        mode = CODES;
       case CODES:
-	bitb=b; bitk=k;
-	z.avail_in=n; z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	write=q;
+        bitb=b; bitk=k;
+        z.avail_in=n; z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        write=q;
 
-	if ((r = codes.proc(r)) != Z_STREAM_END){
-	  return inflate_flush(r);
-	}
-	r = Z_OK;
-	codes.free(z);
+        if ((r = codes.proc(r)) != Z_STREAM_END){
+          return inflate_flush(r);
+        }
+        r = Z_OK;
+        codes.free(z);
 
-	p=z.next_in_index; n=z.avail_in;b=bitb;k=bitk;
-	q=write;m=(q<read?read-q-1:end-q);
+        p=z.next_in_index; n=z.avail_in;b=bitb;k=bitk;
+        q=write;m=(q<read?read-q-1:end-q);
 
-	if (last==0){
-	  mode = TYPE;
-	  break;
-	}
-	mode = DRY;
+        if (last==0){
+          mode = TYPE;
+          break;
+        }
+        mode = DRY;
       case DRY:
-	write=q; 
-	r=inflate_flush(r); 
-	q=write; m=(q<read?read-q-1:end-q);
-	if (read != write){
-	  bitb=b; bitk=k; 
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  write=q;
-	  return inflate_flush(r);
-	}
-	mode = DONE;
+        write=q; 
+        r=inflate_flush(r); 
+        q=write; m=(q<read?read-q-1:end-q);
+        if (read != write){
+          bitb=b; bitk=k; 
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          write=q;
+          return inflate_flush(r);
+        }
+        mode = DONE;
       case DONE:
-	r = Z_STREAM_END;
+        r = Z_STREAM_END;
 
-	bitb=b; bitk=k; 
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	write=q;
-	return inflate_flush(r);
+        bitb=b; bitk=k; 
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        write=q;
+        return inflate_flush(r);
       case BAD:
-	r = Z_DATA_ERROR;
+        r = Z_DATA_ERROR;
 
-	bitb=b; bitk=k; 
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	write=q;
-	return inflate_flush(r);
+        bitb=b; bitk=k; 
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        write=q;
+        return inflate_flush(r);
 
       default:
-	r = Z_STREAM_ERROR;
+        r = Z_STREAM_ERROR;
 
-	bitb=b; bitk=k; 
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	write=q;
-	return inflate_flush(r);
+        bitb=b; bitk=k; 
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        write=q;
+        return inflate_flush(r);
       }
     }
   }
@@ -596,7 +596,7 @@ final class InfBlocks{
 
       // update check information
       if(check && n>0){
-	z.adler.update(window, q, n);
+        z.adler.update(window, q, n);
       }
 
       // copy

--- a/src/main/java/com/jcraft/jsch/jzlib/InfCodes.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InfCodes.java
@@ -97,8 +97,8 @@ final class InfCodes{
   }
 
   void init(int bl, int bd,
-	   int[] tl, int tl_index,
-	   int[] td, int td_index){
+           int[] tl, int tl_index,
+           int[] td, int td_index){
     mode=START;
     lbits=(byte)bl;
     dbits=(byte)bd;
@@ -130,267 +130,267 @@ final class InfCodes{
     // process input and output based on current state
     while (true){
       switch (mode){
-	// waiting for "i:"=input, "o:"=output, "x:"=nothing
+        // waiting for "i:"=input, "o:"=output, "x:"=nothing
       case START:         // x: set up for LEN
-	if (m >= 258 && n >= 10){
+        if (m >= 258 && n >= 10){
 
-	  s.bitb=b;s.bitk=k;
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  s.write=q;
-	  r = inflate_fast(lbits, dbits, 
-			   ltree, ltree_index, 
-			   dtree, dtree_index,
-			   s, z);
+          s.bitb=b;s.bitk=k;
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          s.write=q;
+          r = inflate_fast(lbits, dbits, 
+                           ltree, ltree_index, 
+                           dtree, dtree_index,
+                           s, z);
 
-	  p=z.next_in_index;n=z.avail_in;b=s.bitb;k=s.bitk;
-	  q=s.write;m=q<s.read?s.read-q-1:s.end-q;
+          p=z.next_in_index;n=z.avail_in;b=s.bitb;k=s.bitk;
+          q=s.write;m=q<s.read?s.read-q-1:s.end-q;
 
-	  if (r != Z_OK){
-	    mode = r == Z_STREAM_END ? WASH : BADCODE;
-	    break;
-	  }
-	}
-	need = lbits;
-	tree = ltree;
-	tree_index=ltree_index;
+          if (r != Z_OK){
+            mode = r == Z_STREAM_END ? WASH : BADCODE;
+            break;
+          }
+        }
+        need = lbits;
+        tree = ltree;
+        tree_index=ltree_index;
 
-	mode = LEN;
+        mode = LEN;
       case LEN:           // i: get length/literal/eob next
-	j = need;
+        j = need;
 
-	while(k<(j)){
-	  if(n!=0)r=Z_OK;
-	  else{
+        while(k<(j)){
+          if(n!=0)r=Z_OK;
+          else{
 
-	    s.bitb=b;s.bitk=k;
-	    z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    s.write=q;
-	    return s.inflate_flush(r);
-	  }
-	  n--;
-	  b|=(z.next_in[p++]&0xff)<<k;
-	  k+=8;
-	}
+            s.bitb=b;s.bitk=k;
+            z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            s.write=q;
+            return s.inflate_flush(r);
+          }
+          n--;
+          b|=(z.next_in[p++]&0xff)<<k;
+          k+=8;
+        }
 
-	tindex=(tree_index+(b&inflate_mask[j]))*3;
+        tindex=(tree_index+(b&inflate_mask[j]))*3;
 
-	b>>>=(tree[tindex+1]);
-	k-=(tree[tindex+1]);
+        b>>>=(tree[tindex+1]);
+        k-=(tree[tindex+1]);
 
-	e=tree[tindex];
+        e=tree[tindex];
 
-	if(e == 0){               // literal
-	  lit = tree[tindex+2];
-	  mode = LIT;
-	  break;
-	}
-	if((e & 16)!=0 ){          // length
-	  get = e & 15;
-	  len = tree[tindex+2];
-	  mode = LENEXT;
-	  break;
-	}
-	if ((e & 64) == 0){        // next table
-	  need = e;
-	  tree_index = tindex/3+tree[tindex+2];
-	  break;
-	}
-	if ((e & 32)!=0){               // end of block
-	  mode = WASH;
-	  break;
-	}
-	mode = BADCODE;        // invalid code
-	z.msg = "invalid literal/length code";
-	r = Z_DATA_ERROR;
+        if(e == 0){               // literal
+          lit = tree[tindex+2];
+          mode = LIT;
+          break;
+        }
+        if((e & 16)!=0 ){          // length
+          get = e & 15;
+          len = tree[tindex+2];
+          mode = LENEXT;
+          break;
+        }
+        if ((e & 64) == 0){        // next table
+          need = e;
+          tree_index = tindex/3+tree[tindex+2];
+          break;
+        }
+        if ((e & 32)!=0){               // end of block
+          mode = WASH;
+          break;
+        }
+        mode = BADCODE;        // invalid code
+        z.msg = "invalid literal/length code";
+        r = Z_DATA_ERROR;
 
-	s.bitb=b;s.bitk=k;
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	s.write=q;
-	return s.inflate_flush(r);
+        s.bitb=b;s.bitk=k;
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        s.write=q;
+        return s.inflate_flush(r);
 
       case LENEXT:        // i: getting length extra (have base)
-	j = get;
+        j = get;
 
-	while(k<(j)){
-	  if(n!=0)r=Z_OK;
-	  else{
+        while(k<(j)){
+          if(n!=0)r=Z_OK;
+          else{
 
-	    s.bitb=b;s.bitk=k;
-	    z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    s.write=q;
-	    return s.inflate_flush(r);
-	  }
-	  n--; b|=(z.next_in[p++]&0xff)<<k;
-	  k+=8;
-	}
+            s.bitb=b;s.bitk=k;
+            z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            s.write=q;
+            return s.inflate_flush(r);
+          }
+          n--; b|=(z.next_in[p++]&0xff)<<k;
+          k+=8;
+        }
 
-	len += (b & inflate_mask[j]);
+        len += (b & inflate_mask[j]);
 
-	b>>=j;
-	k-=j;
+        b>>=j;
+        k-=j;
 
-	need = dbits;
-	tree = dtree;
-	tree_index=dtree_index;
-	mode = DIST;
+        need = dbits;
+        tree = dtree;
+        tree_index=dtree_index;
+        mode = DIST;
       case DIST:          // i: get distance next
-	j = need;
+        j = need;
 
-	while(k<(j)){
-	  if(n!=0)r=Z_OK;
-	  else{
+        while(k<(j)){
+          if(n!=0)r=Z_OK;
+          else{
 
-	    s.bitb=b;s.bitk=k;
-	    z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    s.write=q;
-	    return s.inflate_flush(r);
-	  }
-	  n--; b|=(z.next_in[p++]&0xff)<<k;
-	  k+=8;
-	}
+            s.bitb=b;s.bitk=k;
+            z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            s.write=q;
+            return s.inflate_flush(r);
+          }
+          n--; b|=(z.next_in[p++]&0xff)<<k;
+          k+=8;
+        }
 
-	tindex=(tree_index+(b & inflate_mask[j]))*3;
+        tindex=(tree_index+(b & inflate_mask[j]))*3;
 
-	b>>=tree[tindex+1];
-	k-=tree[tindex+1];
+        b>>=tree[tindex+1];
+        k-=tree[tindex+1];
 
-	e = (tree[tindex]);
-	if((e & 16)!=0){               // distance
-	  get = e & 15;
-	  dist = tree[tindex+2];
-	  mode = DISTEXT;
-	  break;
-	}
-	if ((e & 64) == 0){        // next table
-	  need = e;
-	  tree_index = tindex/3 + tree[tindex+2];
-	  break;
-	}
-	mode = BADCODE;        // invalid code
-	z.msg = "invalid distance code";
-	r = Z_DATA_ERROR;
+        e = (tree[tindex]);
+        if((e & 16)!=0){               // distance
+          get = e & 15;
+          dist = tree[tindex+2];
+          mode = DISTEXT;
+          break;
+        }
+        if ((e & 64) == 0){        // next table
+          need = e;
+          tree_index = tindex/3 + tree[tindex+2];
+          break;
+        }
+        mode = BADCODE;        // invalid code
+        z.msg = "invalid distance code";
+        r = Z_DATA_ERROR;
 
-	s.bitb=b;s.bitk=k;
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	s.write=q;
-	return s.inflate_flush(r);
+        s.bitb=b;s.bitk=k;
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        s.write=q;
+        return s.inflate_flush(r);
 
       case DISTEXT:       // i: getting distance extra
-	j = get;
+        j = get;
 
-	while(k<(j)){
-	  if(n!=0)r=Z_OK;
-	  else{
+        while(k<(j)){
+          if(n!=0)r=Z_OK;
+          else{
 
-	    s.bitb=b;s.bitk=k;
-	    z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	    s.write=q;
-	    return s.inflate_flush(r);
-	  }
-	  n--; b|=(z.next_in[p++]&0xff)<<k;
-	  k+=8;
-	}
+            s.bitb=b;s.bitk=k;
+            z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+            s.write=q;
+            return s.inflate_flush(r);
+          }
+          n--; b|=(z.next_in[p++]&0xff)<<k;
+          k+=8;
+        }
 
-	dist += (b & inflate_mask[j]);
+        dist += (b & inflate_mask[j]);
 
-	b>>=j;
-	k-=j;
+        b>>=j;
+        k-=j;
 
-	mode = COPY;
+        mode = COPY;
       case COPY:          // o: copying bytes in window, waiting for space
         f = q - dist;
         while(f < 0){     // modulo window size-"while" instead
           f += s.end;     // of "if" handles invalid distances
-	}
-	while (len!=0){
+        }
+        while (len!=0){
 
-	  if(m==0){
-	    if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
-	    if(m==0){
-	      s.write=q; r=s.inflate_flush(r);
-	      q=s.write;m=q<s.read?s.read-q-1:s.end-q;
+          if(m==0){
+            if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
+            if(m==0){
+              s.write=q; r=s.inflate_flush(r);
+              q=s.write;m=q<s.read?s.read-q-1:s.end-q;
 
-	      if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
+              if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
 
-	      if(m==0){
-		s.bitb=b;s.bitk=k;
-		z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-		s.write=q;
-		return s.inflate_flush(r);
-	      }  
-	    }
-	  }
+              if(m==0){
+                s.bitb=b;s.bitk=k;
+                z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+                s.write=q;
+                return s.inflate_flush(r);
+              }  
+            }
+          }
 
-	  s.window[q++]=s.window[f++]; m--;
+          s.window[q++]=s.window[f++]; m--;
 
-	  if (f == s.end)
+          if (f == s.end)
             f = 0;
-	  len--;
-	}
-	mode = START;
-	break;
+          len--;
+        }
+        mode = START;
+        break;
       case LIT:           // o: got literal, waiting for output space
-	if(m==0){
-	  if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
-	  if(m==0){
-	    s.write=q; r=s.inflate_flush(r);
-	    q=s.write;m=q<s.read?s.read-q-1:s.end-q;
+        if(m==0){
+          if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
+          if(m==0){
+            s.write=q; r=s.inflate_flush(r);
+            q=s.write;m=q<s.read?s.read-q-1:s.end-q;
 
-	    if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
-	    if(m==0){
-	      s.bitb=b;s.bitk=k;
-	      z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	      s.write=q;
-	      return s.inflate_flush(r);
-	    }
-	  }
-	}
-	r=Z_OK;
+            if(q==s.end&&s.read!=0){q=0;m=q<s.read?s.read-q-1:s.end-q;}
+            if(m==0){
+              s.bitb=b;s.bitk=k;
+              z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+              s.write=q;
+              return s.inflate_flush(r);
+            }
+          }
+        }
+        r=Z_OK;
 
-	s.window[q++]=(byte)lit; m--;
+        s.window[q++]=(byte)lit; m--;
 
-	mode = START;
-	break;
+        mode = START;
+        break;
       case WASH:           // o: got eob, possibly more output
-	if (k > 7){        // return unused byte, if any
-	  k -= 8;
-	  n++;
-	  p--;             // can always return one
-	}
+        if (k > 7){        // return unused byte, if any
+          k -= 8;
+          n++;
+          p--;             // can always return one
+        }
 
-	s.write=q; r=s.inflate_flush(r);
-	q=s.write;m=q<s.read?s.read-q-1:s.end-q;
+        s.write=q; r=s.inflate_flush(r);
+        q=s.write;m=q<s.read?s.read-q-1:s.end-q;
 
-	if (s.read != s.write){
-	  s.bitb=b;s.bitk=k;
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  s.write=q;
-	  return s.inflate_flush(r);
-	}
-	mode = END;
+        if (s.read != s.write){
+          s.bitb=b;s.bitk=k;
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          s.write=q;
+          return s.inflate_flush(r);
+        }
+        mode = END;
       case END:
-	r = Z_STREAM_END;
-	s.bitb=b;s.bitk=k;
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	s.write=q;
-	return s.inflate_flush(r);
+        r = Z_STREAM_END;
+        s.bitb=b;s.bitk=k;
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        s.write=q;
+        return s.inflate_flush(r);
 
       case BADCODE:       // x: got error
 
-	r = Z_DATA_ERROR;
+        r = Z_DATA_ERROR;
 
-	s.bitb=b;s.bitk=k;
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	s.write=q;
-	return s.inflate_flush(r);
+        s.bitb=b;s.bitk=k;
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        s.write=q;
+        return s.inflate_flush(r);
 
       default:
-	r = Z_STREAM_ERROR;
+        r = Z_STREAM_ERROR;
 
-	s.bitb=b;s.bitk=k;
-	z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	s.write=q;
-	return s.inflate_flush(r);
+        s.bitb=b;s.bitk=k;
+        z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+        s.write=q;
+        return s.inflate_flush(r);
       }
     }
   }
@@ -405,9 +405,9 @@ final class InfCodes{
   // distance pair plus four bytes for overloading the bit buffer.
 
   int inflate_fast(int bl, int bd, 
-		   int[] tl, int tl_index,
-		   int[] td, int td_index,
-		   InfBlocks s, ZStream z){
+                   int[] tl, int tl_index,
+                   int[] td, int td_index,
+                   InfBlocks s, ZStream z){
     int t;                // temporary pointer
     int[] tp;             // temporary pointer
     int tp_index;         // temporary pointer
@@ -438,8 +438,8 @@ final class InfCodes{
     do {                          // assume called with m >= 258 && n >= 10
       // get literal/length code
       while(k<(20)){              // max bits for literal/length code
-	n--;
-	b|=(z.next_in[p++]&0xff)<<k;k+=8;
+        n--;
+        b|=(z.next_in[p++]&0xff)<<k;k+=8;
       }
 
       t= b&ml;
@@ -447,153 +447,153 @@ final class InfCodes{
       tp_index=tl_index;
       tp_index_t_3=(tp_index+t)*3;
       if ((e = tp[tp_index_t_3]) == 0){
-	b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
+        b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
 
-	s.window[q++] = (byte)tp[tp_index_t_3+2];
-	m--;
-	continue;
+        s.window[q++] = (byte)tp[tp_index_t_3+2];
+        m--;
+        continue;
       }
       do {
 
-	b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
+        b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
 
-	if((e&16)!=0){
-	  e &= 15;
-	  c = tp[tp_index_t_3+2] + (b & inflate_mask[e]);
+        if((e&16)!=0){
+          e &= 15;
+          c = tp[tp_index_t_3+2] + (b & inflate_mask[e]);
 
-	  b>>=e; k-=e;
+          b>>=e; k-=e;
 
-	  // decode distance base of block to copy
-	  while(k<(15)){           // max bits for distance code
-	    n--;
-	    b|=(z.next_in[p++]&0xff)<<k;k+=8;
-	  }
+          // decode distance base of block to copy
+          while(k<(15)){           // max bits for distance code
+            n--;
+            b|=(z.next_in[p++]&0xff)<<k;k+=8;
+          }
 
-	  t= b&md;
-	  tp=td;
-	  tp_index=td_index;
+          t= b&md;
+          tp=td;
+          tp_index=td_index;
           tp_index_t_3=(tp_index+t)*3;
-	  e = tp[tp_index_t_3];
+          e = tp[tp_index_t_3];
 
-	  do {
+          do {
 
-	    b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
+            b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
 
-	    if((e&16)!=0){
-	      // get extra bits to add to distance base
-	      e &= 15;
-	      while(k<(e)){         // get extra bits (up to 13)
-		n--;
-		b|=(z.next_in[p++]&0xff)<<k;k+=8;
-	      }
+            if((e&16)!=0){
+              // get extra bits to add to distance base
+              e &= 15;
+              while(k<(e)){         // get extra bits (up to 13)
+                n--;
+                b|=(z.next_in[p++]&0xff)<<k;k+=8;
+              }
 
-	      d = tp[tp_index_t_3+2] + (b&inflate_mask[e]);
+              d = tp[tp_index_t_3+2] + (b&inflate_mask[e]);
 
-	      b>>=(e); k-=(e);
+              b>>=(e); k-=(e);
 
-	      // do the copy
-	      m -= c;
-	      if (q >= d){                // offset before dest
-		//  just copy
-		r=q-d;
-		if(q-r>0 && 2>(q-r)){           
-		  s.window[q++]=s.window[r++]; // minimum count is three,
-		  s.window[q++]=s.window[r++]; // so unroll loop a little
-		  c-=2;
-		}
-		else{
-		  System.arraycopy(s.window, r, s.window, q, 2);
-		  q+=2; r+=2; c-=2;
-		}
-	      }
-	      else{                  // else offset after destination
+              // do the copy
+              m -= c;
+              if (q >= d){                // offset before dest
+                //  just copy
+                r=q-d;
+                if(q-r>0 && 2>(q-r)){           
+                  s.window[q++]=s.window[r++]; // minimum count is three,
+                  s.window[q++]=s.window[r++]; // so unroll loop a little
+                  c-=2;
+                }
+                else{
+                  System.arraycopy(s.window, r, s.window, q, 2);
+                  q+=2; r+=2; c-=2;
+                }
+              }
+              else{                  // else offset after destination
                 r=q-d;
                 do{
                   r+=s.end;          // force pointer in window
                 }while(r<0);         // covers invalid distances
-		e=s.end-r;
-		if(c>e){             // if source crosses,
-		  c-=e;              // wrapped copy
-		  if(q-r>0 && e>(q-r)){           
-		    do{s.window[q++] = s.window[r++];}
-		    while(--e!=0);
-		  }
-		  else{
-		    System.arraycopy(s.window, r, s.window, q, e);
-		    q+=e; r+=e; e=0;
-		  }
-		  r = 0;                  // copy rest from start of window
-		}
+                e=s.end-r;
+                if(c>e){             // if source crosses,
+                  c-=e;              // wrapped copy
+                  if(q-r>0 && e>(q-r)){           
+                    do{s.window[q++] = s.window[r++];}
+                    while(--e!=0);
+                  }
+                  else{
+                    System.arraycopy(s.window, r, s.window, q, e);
+                    q+=e; r+=e; e=0;
+                  }
+                  r = 0;                  // copy rest from start of window
+                }
 
-	      }
+              }
 
-	      // copy all or what's left
-	      if(q-r>0 && c>(q-r)){           
-		do{s.window[q++] = s.window[r++];}
-		while(--c!=0);
-	      }
-	      else{
-		System.arraycopy(s.window, r, s.window, q, c);
-		q+=c; r+=c; c=0;
-	      }
-	      break;
-	    }
-	    else if((e&64)==0){
-	      t+=tp[tp_index_t_3+2];
-	      t+=(b&inflate_mask[e]);
-	      tp_index_t_3=(tp_index+t)*3;
-	      e=tp[tp_index_t_3];
-	    }
-	    else{
-	      z.msg = "invalid distance code";
+              // copy all or what's left
+              if(q-r>0 && c>(q-r)){           
+                do{s.window[q++] = s.window[r++];}
+                while(--c!=0);
+              }
+              else{
+                System.arraycopy(s.window, r, s.window, q, c);
+                q+=c; r+=c; c=0;
+              }
+              break;
+            }
+            else if((e&64)==0){
+              t+=tp[tp_index_t_3+2];
+              t+=(b&inflate_mask[e]);
+              tp_index_t_3=(tp_index+t)*3;
+              e=tp[tp_index_t_3];
+            }
+            else{
+              z.msg = "invalid distance code";
 
-	      c=z.avail_in-n;c=(k>>3)<c?k>>3:c;n+=c;p-=c;k-=c<<3;
+              c=z.avail_in-n;c=(k>>3)<c?k>>3:c;n+=c;p-=c;k-=c<<3;
 
-	      s.bitb=b;s.bitk=k;
-	      z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	      s.write=q;
+              s.bitb=b;s.bitk=k;
+              z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+              s.write=q;
 
-	      return Z_DATA_ERROR;
-	    }
-	  }
-	  while(true);
-	  break;
-	}
+              return Z_DATA_ERROR;
+            }
+          }
+          while(true);
+          break;
+        }
 
-	if((e&64)==0){
-	  t+=tp[tp_index_t_3+2];
-	  t+=(b&inflate_mask[e]);
-	  tp_index_t_3=(tp_index+t)*3;
-	  if((e=tp[tp_index_t_3])==0){
+        if((e&64)==0){
+          t+=tp[tp_index_t_3+2];
+          t+=(b&inflate_mask[e]);
+          tp_index_t_3=(tp_index+t)*3;
+          if((e=tp[tp_index_t_3])==0){
 
-	    b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
+            b>>=(tp[tp_index_t_3+1]); k-=(tp[tp_index_t_3+1]);
 
-	    s.window[q++]=(byte)tp[tp_index_t_3+2];
-	    m--;
-	    break;
-	  }
-	}
-	else if((e&32)!=0){
+            s.window[q++]=(byte)tp[tp_index_t_3+2];
+            m--;
+            break;
+          }
+        }
+        else if((e&32)!=0){
 
-	  c=z.avail_in-n;c=(k>>3)<c?k>>3:c;n+=c;p-=c;k-=c<<3;
+          c=z.avail_in-n;c=(k>>3)<c?k>>3:c;n+=c;p-=c;k-=c<<3;
  
-	  s.bitb=b;s.bitk=k;
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  s.write=q;
+          s.bitb=b;s.bitk=k;
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          s.write=q;
 
-	  return Z_STREAM_END;
-	}
-	else{
-	  z.msg="invalid literal/length code";
+          return Z_STREAM_END;
+        }
+        else{
+          z.msg="invalid literal/length code";
 
-	  c=z.avail_in-n;c=(k>>3)<c?k>>3:c;n+=c;p-=c;k-=c<<3;
+          c=z.avail_in-n;c=(k>>3)<c?k>>3:c;n+=c;p-=c;k-=c<<3;
 
-	  s.bitb=b;s.bitk=k;
-	  z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
-	  s.write=q;
+          s.bitb=b;s.bitk=k;
+          z.avail_in=n;z.total_in+=p-z.next_in_index;z.next_in_index=p;
+          s.write=q;
 
-	  return Z_DATA_ERROR;
-	}
+          return Z_DATA_ERROR;
+        }
       } 
       while(true);
     } 

--- a/src/main/java/com/jcraft/jsch/jzlib/InfTree.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InfTree.java
@@ -334,12 +334,12 @@ final class InfTree{
     for (; k <= g; k++){
       a = c[k];
       while (a--!=0){
-	// here i is the Huffman code of length k bits for value *p
-	// make tables up to required level
+        // here i is the Huffman code of length k bits for value *p
+        // make tables up to required level
         while (k > w + l){
           h++;
           w += l;                 // previous table always l bits
-	  // compute minimum size table less than or equal to l bits
+          // compute minimum size table less than or equal to l bits
           z = g - w;
           z = (z > l) ? l : z;        // table size upper limit
           if((f=1<<(j=k-w))>a+1){     // try a k-w bit table
@@ -352,19 +352,19 @@ final class InfTree{
                   break;              // enough codes to use up j bits
                 f -= c[xp];           // else deduct codes from patterns
               }
-	    }
+            }
           }
           z = 1 << j;                 // table entries for j-bit table
 
-	  // allocate new table
+          // allocate new table
           if (hn[0] + z > MANY){       // (note: doesn't matter for fixed)
             return Z_DATA_ERROR;       // overflow of MANY
           }
           u[h] = q = /*hp+*/ hn[0];   // DEBUG
           hn[0] += z;
  
-	  // connect to last table, if there is one
-	  if(h!=0){
+          // connect to last table, if there is one
+          if(h!=0){
             x[h]=i;           // save pattern for backing up
             r[0]=(byte)j;     // bits in this table
             r[1]=(byte)l;     // bits to dump before this table
@@ -374,14 +374,14 @@ final class InfTree{
           }
           else{
             t[0] = q;               // first table is returned result
-	  }
+          }
         }
 
-	// set up table entry in r
+        // set up table entry in r
         r[1] = (byte)(k - w);
         if (p >= n){
           r[0] = 128 + 64;      // out of values--invalid code
-	}
+        }
         else if (v[p] < s){
           r[0] = (byte)(v[p] < 256 ? 0 : 32 + 64);  // 256 is end-of-block
           r[2] = v[p++];          // simple code is just the value
@@ -395,15 +395,15 @@ final class InfTree{
         f=1<<(k-w);
         for (j=i>>>w;j<z;j+=f){
           System.arraycopy(r, 0, hp, (q+j)*3, 3);
-	}
+        }
 
-	// backwards increment the k-bit code i
+        // backwards increment the k-bit code i
         for (j = 1 << (k - 1); (i & j)!=0; j >>>= 1){
           i ^= j;
-	}
+        }
         i ^= j;
 
-	// backup over finished tables
+        // backup over finished tables
         mask = (1 << w) - 1;      // needed on HP, cc -O bug
         while ((i & mask) != x[h]){
           h--;                    // don't need to update q
@@ -491,7 +491,7 @@ final class InfTree{
                                  int[][] tl,//literal/length tree result
                                  int[][] td,//distance tree result 
                                  ZStream z  //for memory allocation
-				 ){
+                                 ){
     bl[0]=fixed_bl;
     bd[0]=fixed_bd;
     tl[0]=fixed_tl;

--- a/src/main/java/com/jcraft/jsch/jzlib/Inflate.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Inflate.java
@@ -208,7 +208,7 @@ final class Inflate{
       switch (this.mode){
       case HEAD:
         if(wrap==0){
-	  this.mode = BLOCKS;
+          this.mode = BLOCKS;
           break;
         } 
 
@@ -220,7 +220,7 @@ final class Inflate{
           if(wrap == 4){
             wrap = 2;
           }
-	  z.adler=new CRC32();
+          z.adler=new CRC32();
           checksum(2, this.need);
 
           if(gheader==null) 
@@ -265,9 +265,9 @@ final class Inflate{
           this.mode = BAD;
           z.msg="unknown compression method";
           // since zlib 1.2, it is allowted to inflateSync for this case.
-	  /*
+          /*
           this.marker = 5;       // can't try inflateSync
-	  */
+          */
           break;
         }
   
@@ -279,9 +279,9 @@ final class Inflate{
           this.mode = BAD;
           z.msg="invalid window size";
           // since zlib 1.2, it is allowted to inflateSync for this case.
-	  /*
+          /*
           this.marker = 5;       // can't try inflateSync
-	  */
+          */
           break;
         }
 
@@ -390,7 +390,7 @@ final class Inflate{
           this.mode = BAD;
           this.marker = 5;       // can't try inflateSync
           break;
-	  */
+          */
         }
         else if(flags!=0 && gheader!=null){
           gheader.crc = this.need; 
@@ -500,22 +500,22 @@ final class Inflate{
               tmp_string=null;
               if(foo.length == gheader.extra.length){
                 System.arraycopy(foo, 0, gheader.extra, 0, foo.length);
-	      }
+              }
               else{
                 z.msg = "bad extra field length";
                 this.mode = BAD; 
                 break;
-	      }
+              }
             }
           }
           catch(Return e){ return e.r; }
         }
         else if(gheader!=null){
           gheader.extra=null;
-	}
-	this.mode = NAME;
+        }
+        this.mode = NAME;
       case NAME:
-	if ((flags & 0x0800)!=0) {
+        if ((flags & 0x0800)!=0) {
           try { 
             r=readString(r, f);
             if(gheader!=null){
@@ -527,7 +527,7 @@ final class Inflate{
         }
         else if(gheader!=null){
           gheader.name=null;
-	}
+        }
         this.mode = COMMENT;
       case COMMENT:
         if ((flags & 0x1000)!=0) {
@@ -542,10 +542,10 @@ final class Inflate{
         }
         else if(gheader!=null){
           gheader.comment=null;
-	}
+        }
         this.mode = HCRC;
       case HCRC:
-	if ((flags & 0x0200)!=0) {
+        if ((flags & 0x0200)!=0) {
           try { r=readBytes(2, r, f); }
           catch(Return e){ return e.r; }
           if(gheader!=null){
@@ -669,7 +669,7 @@ final class Inflate{
       if(z.avail_in==0){ throw new Return(r); }; r=f;
       z.avail_in--; z.total_in++;
       this.need = this.need | 
-	((z.next_in[z.next_in_index++]&0xff)<<((n-need_bytes)*8));
+        ((z.next_in[z.next_in_index++]&0xff)<<((n-need_bytes)*8));
       need_bytes--;
     }
     if(n==2){
@@ -748,9 +748,9 @@ final class Inflate{
       case NAME:
       case COMMENT:
       case HCRC:
-	return true;
+        return true;
       default:
-	return false;
+        return false;
     }
   }
 }

--- a/src/main/java/com/jcraft/jsch/jzlib/StaticTree.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/StaticTree.java
@@ -118,15 +118,15 @@ final class StaticTree{
 
   static StaticTree static_l_desc =
     new StaticTree(static_ltree, Tree.extra_lbits,
-		   LITERALS+1, L_CODES, MAX_BITS);
+                   LITERALS+1, L_CODES, MAX_BITS);
 
   static StaticTree static_d_desc =
     new StaticTree(static_dtree, Tree.extra_dbits,
-		   0,  D_CODES, MAX_BITS);
+                   0,  D_CODES, MAX_BITS);
 
   static StaticTree static_bl_desc =
     new StaticTree(null, Tree.extra_blbits,
-		   0, BL_CODES, MAX_BL_BITS);
+                   0, BL_CODES, MAX_BL_BITS);
 
   short[] static_tree;     // static tree or null
   int[] extra_bits;        // extra bits for each code or null

--- a/src/main/java/com/jcraft/jsch/jzlib/Tree.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Tree.java
@@ -215,13 +215,13 @@ final class Tree{
     for (bits = max_length; bits != 0; bits--) {
       n = s.bl_count[bits];
       while (n != 0) {
-	m = s.heap[--h];
-	if (m > max_code) continue;
-	if (tree[m*2+1] != bits) {
-	  s.opt_len += ((long)bits - (long)tree[m*2+1])*(long)tree[m*2];
-	  tree[m*2+1] = (short)bits;
-	}
-	n--;
+        m = s.heap[--h];
+        if (m > max_code) continue;
+        if (tree[m*2+1] != bits) {
+          s.opt_len += ((long)bits - (long)tree[m*2+1])*(long)tree[m*2];
+          tree[m*2+1] = (short)bits;
+        }
+        n--;
       }
     }
   }
@@ -248,11 +248,11 @@ final class Tree{
 
     for(n=0; n<elems; n++) {
       if(tree[n*2] != 0) {
-	s.heap[++s.heap_len] = max_code = n;
-	s.depth[n] = 0;
+        s.heap[++s.heap_len] = max_code = n;
+        s.depth[n] = 0;
       }
       else{
-	tree[n*2+1] = 0;
+        tree[n*2+1] = 0;
       }
     }
 
@@ -352,8 +352,8 @@ final class Tree{
   // IN assertion: 1 <= len <= 15
   private final static int bi_reverse(
                         int code, // the value to invert
-			int len   // its bit length
-			){
+                        int len   // its bit length
+                        ){
     int res = 0;
     do{
       res|=code&1;

--- a/src/main/java/com/jcraft/jsch/jzlib/ZStream.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/ZStream.java
@@ -216,12 +216,12 @@ class ZStream{
        dstate.pending_buf.length<(dstate.pending_out+len) ||
        next_out.length<(next_out_index+len)){
       //System.out.println(dstate.pending_buf.length+", "+dstate.pending_out+
-      //		 ", "+next_out.length+", "+next_out_index+", "+len);
+      //                 ", "+next_out.length+", "+next_out_index+", "+len);
       //System.out.println("avail_out="+avail_out);
     }
 
     System.arraycopy(dstate.pending_buf, dstate.pending_out,
-		     next_out, next_out_index, len);
+                     next_out, next_out_index, len);
 
     next_out_index+=len;
     dstate.pending_out+=len;


### PR DESCRIPTION
Jsch code uses Tabs/Spaces inconsistently. It's a pain to read source code, when indentations symbols are mixed: some editors have default Tab size to 4 symbols, some are to 8.
I propose to replaces Tabs with Spaces as indentation character.

No code/semantic change in proposed changes.
To minimize scope of changes, I focused only on indentations in this PR. There are still some Tabs left which are used in the middle of lines or in comments. I will create a separate PR to cleanup this, if this PR will be merged.