### PR TITLE
Get rid of tabs in the code

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -142,12 +142,12 @@ if exist %WRAPPER_JAR% (
     )
 
     powershell -Command "&{"^
-		"$webclient = new-object System.Net.WebClient;"^
-		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
-		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
-		"}"^
-		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
-		"}"
+        "$webclient = new-object System.Net.WebClient;"^
+        "if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+        "$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+        "}"^
+        "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
+        "}"
     if "%MVNW_VERBOSE%" == "true" (
         echo Finished downloading %WRAPPER_JAR%
     )

--- a/src/main/java/com/jcraft/jsch/Buffer.java
+++ b/src/main/java/com/jcraft/jsch/Buffer.java
@@ -271,15 +271,15 @@ public class Buffer{
     int foo;
     for(int i=0; i<tmp_buffer_index; i++){
         foo=tmp_buffer[i]&0xff;
-	System.err.print(chars[(foo>>>4)&0xf]);
-	System.err.print(chars[foo&0xf]);
+        System.err.print(chars[(foo>>>4)&0xf]);
+        System.err.print(chars[foo&0xf]);
         if(i%16==15){
           System.err.println("");
-	  continue;
-	}
+          continue;
+        }
         if(i>0 && i%2==1){
           System.err.print(" ");
-	}
+        }
     }
     System.err.println("");
   }

--- a/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
+++ b/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
@@ -44,7 +44,7 @@ class ChannelAgentForwarding extends Channel{
   static private final byte SSH_AGENT_RSA_RESPONSE = 4;
   static private final byte SSH_AGENT_FAILURE = 5;
   static private final byte SSH_AGENT_SUCCESS = 6;
-  static private final byte SSH_AGENTC_ADD_RSA_IDENTITY	= 7;
+  static private final byte SSH_AGENTC_ADD_RSA_IDENTITY = 7;
   static private final byte SSH_AGENTC_REMOVE_RSA_IDENTITY = 8;
   static private final byte SSH_AGENTC_REMOVE_ALL_RSA_IDENTITIES = 9;
 

--- a/src/main/java/com/jcraft/jsch/ChannelDirectStreamLocal.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectStreamLocal.java
@@ -35,14 +35,14 @@ public class ChannelDirectStreamLocal extends ChannelDirectTCPIP {
         Similar to direct-tcpip, direct-streamlocal is sent by the client
         to request that the server make a connection to a Unix domain socket.
 
-            byte		SSH_MSG_CHANNEL_OPEN
-            string		"direct-streamlocal@openssh.com"
-            uint32		sender channel
-            uint32		initial window size
-            uint32		maximum packet size
-            string		socket path
-            string		reserved
-            uint32		reserved
+            byte      SSH_MSG_CHANNEL_OPEN
+            string    "direct-streamlocal@openssh.com"
+            uint32    sender channel
+            uint32    initial window size
+            uint32    maximum packet size
+            string    socket path
+            string    reserved
+            uint32    reserved
          */
 
         Buffer buf = new Buffer(50 +

--- a/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
@@ -267,7 +267,7 @@ public class ChannelForwardedTCPIP extends Channel{
       pool.removeElement(foo);
       if(address_to_bind==null){
         address_to_bind=foo.address_to_bind;
-      }	
+      }
       if(address_to_bind==null){
         address_to_bind="0.0.0.0";
       }

--- a/src/main/java/com/jcraft/jsch/UserAuthGSSAPIWithMIC.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthGSSAPIWithMIC.java
@@ -216,7 +216,7 @@ class UserAuthGSSAPIWithMIC extends UserAuth {
       byte[] foo=buf.getString();
       int partial_success=buf.getByte();
       //System.err.println(new String(foo)+
-      //		 " partial_success:"+(partial_success!=0));
+      //                 " partial_success:"+(partial_success!=0));
       if(partial_success!=0){
         throw new JSchPartialAuthException(Util.byte2str(foo));
       }

--- a/src/main/java/com/jcraft/jsch/bc/HMAC.java
+++ b/src/main/java/com/jcraft/jsch/bc/HMAC.java
@@ -50,7 +50,7 @@ abstract class HMAC implements MAC {
   public void init(byte[] key) throws Exception {
     if(key.length>bsize){
       byte[] tmp = new byte[bsize];
-      System.arraycopy(key, 0, tmp, 0, bsize);	  
+      System.arraycopy(key, 0, tmp, 0, bsize);
       key = tmp;
     }
     KeyParameter skey = new KeyParameter(key, 0, key.length);

--- a/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
+++ b/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
@@ -388,9 +388,9 @@ public class BCrypt {
      * encoding scheme. Note that this is *not* compatible with
      * the standard MIME-base64 encoding.
      *
-     * @param d	the byte array to encode
-     * @param len	the number of bytes to encode
-     * @return	base64-encoded string
+     * @param d the byte array to encode
+     * @param len the number of bytes to encode
+     * @return base64-encoded string
      * @exception IllegalArgumentException if the length is invalid
      */
     private static String encode_base64(byte d[], int len)
@@ -429,8 +429,8 @@ public class BCrypt {
     /**
      * Look up the 3 bits base64-encoded by the specified character,
      * range-checking againt conversion table
-     * @param x	the base64-encoded value
-     * @return	the decoded value of x
+     * @param x the base64-encoded value
+     * @return the decoded value of x
      */
     private static byte char64(char x) {
         if ((int)x < 0 || (int)x > index_64.length)
@@ -442,9 +442,9 @@ public class BCrypt {
      * Decode a string encoded using bcrypt's base64 scheme to a
      * byte array. Note that this is *not* compatible with
      * the standard MIME-base64 encoding.
-     * @param s	the string to decode
-     * @param maxolen	the maximum number of bytes to decode
-     * @return	an array containing the decoded bytes
+     * @param s the string to decode
+     * @param maxolen the maximum number of bytes to decode
+     * @return an array containing the decoded bytes
      * @throws IllegalArgumentException if maxolen is invalid
      */
     private static byte[] decode_base64(String s, int maxolen)
@@ -491,8 +491,8 @@ public class BCrypt {
     /**
      * Blowfish encipher a single 64-bit block encoded as
      * two 32-bit halves
-     * @param lr	an array containing the two 32-bit half blocks
-     * @param off	the position in the array of the blocks
+     * @param lr an array containing the two 32-bit half blocks
+     * @param off the position in the array of the blocks
      */
     private final void encipher(int lr[], int off) {
         int i, n, l = lr[off], r = lr[off + 1];
@@ -519,10 +519,10 @@ public class BCrypt {
 
     /**
      * Cycically extract a word of key material
-     * @param data	the string to extract the data from
-     * @param offp	a "pointer" (as a one-entry array) to the
+     * @param data the string to extract the data from
+     * @param offp a "pointer" (as a one-entry array) to the
      * current offset into data
-     * @return	the next word of material from data
+     * @return the next word of material from data
      */
     private static int streamtoword(byte data[], int offp[]) {
         int i;
@@ -548,7 +548,7 @@ public class BCrypt {
 
     /**
      * Key the Blowfish cipher
-     * @param key	an array containing the key
+     * @param key an array containing the key
      */
     private void key(byte key[]) {
         int i;
@@ -576,8 +576,8 @@ public class BCrypt {
      * Perform the "enhanced key schedule" step described by
      * Provos and Mazieres in "A Future-Adaptable Password Scheme"
      * http://www.openbsd.org/papers/bcrypt-paper.ps
-     * @param data	salt information
-     * @param key	password information
+     * @param data salt information
+     * @param key password information
      */
     private void ekskey(byte data[], byte key[]) {
         int i;
@@ -691,12 +691,12 @@ public class BCrypt {
     /**
      * Perform the central password hashing step in the
      * bcrypt scheme
-     * @param password	the password to hash
-     * @param salt	the binary salt to hash with the password
-     * @param log_rounds	the binary logarithm of the number
+     * @param password the password to hash
+     * @param salt the binary salt to hash with the password
+     * @param log_rounds the binary logarithm of the number
      * of rounds of hashing to apply
      * @param cdata         the plaintext to encrypt
-     * @return	an array containing the binary hashed password
+     * @return an array containing the binary hashed password
      */
     public byte[] crypt_raw(byte password[], byte salt[], int log_rounds,
                             int cdata[]) {
@@ -734,10 +734,10 @@ public class BCrypt {
 
     /**
      * Hash a password using the OpenBSD bcrypt scheme
-     * @param password	the password to hash
-     * @param salt	the salt to hash with (perhaps generated
+     * @param password the password to hash
+     * @param salt the salt to hash with (perhaps generated
      * using BCrypt.gensalt)
-     * @return	the hashed password
+     * @return the hashed password
      */
     public static String hashpw(String password, String salt) {
         BCrypt B;
@@ -792,11 +792,11 @@ public class BCrypt {
 
     /**
      * Generate a salt for use with the BCrypt.hashpw() method
-     * @param log_rounds	the log2 of the number of rounds of
+     * @param log_rounds the log2 of the number of rounds of
      * hashing to apply - the work factor therefore increases as
      * 2**log_rounds.
-     * @param random		an instance of SecureRandom to use
-     * @return	an encoded salt value
+     * @param random an instance of SecureRandom to use
+     * @return an encoded salt value
      */
     public static String gensalt(int log_rounds, SecureRandom random) {
         StringBuilder rs = new StringBuilder();
@@ -819,10 +819,10 @@ public class BCrypt {
 
     /**
      * Generate a salt for use with the BCrypt.hashpw() method
-     * @param log_rounds	the log2 of the number of rounds of
+     * @param log_rounds the log2 of the number of rounds of
      * hashing to apply - the work factor therefore increases as
      * 2**log_rounds.
-     * @return	an encoded salt value
+     * @return an encoded salt value
      */
     public static String gensalt(int log_rounds) {
         return gensalt(log_rounds, new SecureRandom());
@@ -832,7 +832,7 @@ public class BCrypt {
      * Generate a salt for use with the BCrypt.hashpw() method,
      * selecting a reasonable default for the number of hashing
      * rounds to apply
-     * @return	an encoded salt value
+     * @return an encoded salt value
      */
     public static String gensalt() {
         return gensalt(GENSALT_DEFAULT_LOG2_ROUNDS);
@@ -841,9 +841,9 @@ public class BCrypt {
     /**
      * Check that a plaintext password matches a previously hashed
      * one
-     * @param plaintext	the plaintext password to verify
-     * @param hashed	the previously-hashed password
-     * @return	true if the passwords match, false otherwise
+     * @param plaintext the plaintext password to verify
+     * @param hashed the previously-hashed password
+     * @return true if the passwords match, false otherwise
      */
     public static boolean checkpw(String plaintext, String hashed) {
         String try_pw = hashpw(plaintext, hashed);

--- a/src/main/java/com/jcraft/jsch/jce/HMAC.java
+++ b/src/main/java/com/jcraft/jsch/jce/HMAC.java
@@ -49,7 +49,7 @@ abstract class HMAC implements MAC {
   public void init(byte[] key) throws Exception {
     if(key.length>bsize){
       byte[] tmp = new byte[bsize];
-      System.arraycopy(key, 0, tmp, 0, bsize);	  
+      System.arraycopy(key, 0, tmp, 0, bsize);
       key = tmp;
     }
     SecretKeySpec skey = new SecretKeySpec(key, algorithm);

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
@@ -65,9 +65,9 @@ public class TripleDESCBC implements Cipher{
       // The following code does not work on IBM's JDK 1.4.1
       SecretKeySpec skeySpec = new SecretKeySpec(key, "DESede");
       cipher.init((mode==ENCRYPT_MODE?
-		   javax.crypto.Cipher.ENCRYPT_MODE:
-		   javax.crypto.Cipher.DECRYPT_MODE),
-		  skeySpec, new IvParameterSpec(iv));
+                   javax.crypto.Cipher.ENCRYPT_MODE:
+                   javax.crypto.Cipher.DECRYPT_MODE),
+                   skeySpec, new IvParameterSpec(iv));
 */
       DESedeKeySpec keyspec=new DESedeKeySpec(key);
       SecretKeyFactory keyfactory=SecretKeyFactory.getInstance("DESede");

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
@@ -65,9 +65,9 @@ public class TripleDESCTR implements Cipher{
       // The following code does not work on IBM's JDK 1.4.1
       SecretKeySpec skeySpec = new SecretKeySpec(key, "DESede");
       cipher.init((mode==ENCRYPT_MODE?
-		   javax.crypto.Cipher.ENCRYPT_MODE:
-		   javax.crypto.Cipher.DECRYPT_MODE),
-		  skeySpec, new IvParameterSpec(iv));
+                   javax.crypto.Cipher.ENCRYPT_MODE:
+                   javax.crypto.Cipher.DECRYPT_MODE),
+                   skeySpec, new IvParameterSpec(iv));
 */
       DESedeKeySpec keyspec=new DESedeKeySpec(key);
       SecretKeyFactory keyfactory=SecretKeyFactory.getInstance("DESede");

--- a/src/main/java/com/jcraft/jsch/jzlib/Compression.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Compression.java
@@ -136,8 +136,8 @@ public class Compression implements com.jcraft.jsch.Compression {
             System.arraycopy(inflated_buf, 0, buffer, start, inflated_end);
           }
           length[0]=inflated_end;
-	  return buffer;
-	default:
+          return buffer;
+         default:
           if(JSch.getLogger().isEnabled(Logger.WARN)){
             JSch.getLogger().log(Logger.WARN,
                                  "uncompress: inflate returnd "+status);


### PR DESCRIPTION
Some editors have default Tab size to 4 symbols, some are to 8. It's hard to read/modify source code, when tabs are involved.
I propose to get rid of Tabs usages in the code.
It's continuation of #108