### PR TITLE
setClientVersion-implementation as discussed in #129

### DIFF
--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -32,6 +32,7 @@ package com.jcraft.jsch;
 import java.io.InputStream;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Vector;
 
 public class JSch{
@@ -42,7 +43,12 @@ public class JSch{
 
   static Hashtable<String, String> config=new Hashtable<>();
   static{
+    fillConfig(config, JavaVersion.getVersion());
+  }
+
+  static void fillConfig(Map<String, String> config, int javaVersion) {
     config.put("kex", Util.getSystemProperty("jsch.kex", "curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256"));
+    config.put("client_version", Util.getSystemProperty("jsch.client_version", "SSH-2.0-JSCH_" + VERSION));
     config.put("server_host_key", Util.getSystemProperty("jsch.server_host_key", "ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256"));
     config.put("prefer_known_host_key_types", Util.getSystemProperty("jsch.prefer_known_host_key_types", "yes"));
     config.put("enable_server_sig_algs", Util.getSystemProperty("jsch.enable_server_sig_algs", "yes"));
@@ -286,6 +292,7 @@ public class JSch{
       @Override
       public void log(int level, String message){}
     };
+  String clientVersion;
   static Logger logger=DEVNULL;
   private Logger instLogger;
 
@@ -712,5 +719,26 @@ public class JSch{
    */
   public static Logger getLogger(){
     return logger;
+  }
+
+  /**
+   * Returns the client version to be used when connecting to a peer
+   * @return the client version
+   */
+  public String getClientVersion() {
+    return clientVersion == null ? getConfig("client_version") : clientVersion;
+  }
+
+  /**
+   * Sets the client version to be used when connecting to a peer. If
+   * <code>null</code> is provided, the version string being set with the
+   * system property <code>jsch.client_version</code> is used. If that
+   * isn't set the default text <code>SSH-2.0-JSCH_[version]</code>
+   * is used. The set text is used as is, i.e. no <code>SSH-2.0-</code>
+   * is prefixed if that part is missing.
+   * @param clientVersion the client version to set
+   */
+  public void setClientVersion(String clientVersion) {
+    this.clientVersion = clientVersion;
   }
 }

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -211,14 +211,14 @@ public class JSch{
 
     config.put("pbkdf", "com.jcraft.jsch.jce.PBKDF");
 
-    if(JavaVersion.getVersion()>=11){
+    if(javaVersion>=11){
       config.put("xdh", "com.jcraft.jsch.jce.XDH");
     }
     else{
       config.put("xdh", "com.jcraft.jsch.bc.XDH");
     }
 
-    if(JavaVersion.getVersion()>=15){
+    if(javaVersion>=15){
       config.put("keypairgen.eddsa", "com.jcraft.jsch.jce.KeyPairGenEdDSA");
       config.put("ssh-ed25519", "com.jcraft.jsch.jce.SignatureEd25519");
       config.put("ssh-ed448", "com.jcraft.jsch.jce.SignatureEd448");

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -81,7 +81,7 @@ public class Session{
   private static final int PACKET_MAX_SIZE = 256 * 1024;
 
   private byte[] V_S;                                 // server version
-  private byte[] V_C; //=Util.str2byte("SSH-2.0-JSCH_"+Version.getVersion()); // client version
+  private String V_C; //=Util.str2byte("SSH-2.0-JSCH_"+Version.getVersion()); // client version
 
   private byte[] I_C; // the payload of the client's SSH_MSG_KEXINIT
   private byte[] I_S; // the payload of the server's SSH_MSG_KEXINIT
@@ -259,10 +259,11 @@ public class Session{
 
       jsch.addSession(this);
 
+      byte[] clientVersion = Util.str2byte(getClientVersion());
       {
         // Some Cisco devices will miss to read '\n' if it is sent separately.
-        byte[] foo=new byte[V_C.length+2];
-        System.arraycopy(V_C, 0, foo, 0, V_C.length);
+        byte[] foo=new byte[clientVersion.length+2];
+        System.arraycopy(clientVersion, 0, foo, 0, clientVersion.length);
         foo[foo.length-2]=(byte)'\r';
         foo[foo.length-1]=(byte)'\n';
         io.put(foo, 0, foo.length);
@@ -315,7 +316,7 @@ public class Session{
         getLogger().log(Logger.INFO,
                              "Remote version string: "+_v_s);
         getLogger().log(Logger.INFO,
-                             "Local version string: "+Util.byte2str(V_C));
+                             "Local version string: "+Util.byte2str(clientVersion));
       }
 
       send_kexinit();
@@ -624,7 +625,7 @@ public class Session{
       throw new JSchException(e.toString(), e);
     }
 
-    kex.doInit(this, V_S, V_C, I_S, I_C);
+    kex.doInit(this, V_S, Util.str2byte(getClientVersion()), I_S, I_C);
     return kex;
   }
 
@@ -2716,14 +2717,14 @@ break;
     return Util.byte2str(V_S);
   }
   public String getClientVersion(){
-    return V_C == null ? jsch.getClientVersion() : Util.byte2str(V_C);
+    return V_C == null ? jsch.getClientVersion() : V_C;
   }
   public void setClientVersion(String cv){
     V_C = null;
     if (cv == null) {
       return;
     }
-    V_C=Util.str2byte(cv);
+    V_C=cv;
   }
 
   public void sendIgnore() throws Exception{

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -81,7 +81,7 @@ public class Session{
   private static final int PACKET_MAX_SIZE = 256 * 1024;
 
   private byte[] V_S;                                 // server version
-  private byte[] V_C=Util.str2byte("SSH-2.0-JSCH_"+JSch.VERSION); // client version
+  private byte[] V_C; //=Util.str2byte("SSH-2.0-JSCH_"+Version.getVersion()); // client version
 
   private byte[] I_C; // the payload of the client's SSH_MSG_KEXINIT
   private byte[] I_S; // the payload of the server's SSH_MSG_KEXINIT
@@ -2716,9 +2716,13 @@ break;
     return Util.byte2str(V_S);
   }
   public String getClientVersion(){
-    return Util.byte2str(V_C);
+    return V_C == null ? jsch.getClientVersion() : Util.byte2str(V_C);
   }
   public void setClientVersion(String cv){
+    V_C = null;
+    if (cv == null) {
+      return;
+    }
     V_C=Util.str2byte(cv);
   }
 

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -2721,19 +2721,6 @@ break;
   }
   
   /**
-   * Returns the client version string used during an active connection.
-   * If no connection is active <code>null</code> is returned.
-   * @return The used version string or <code>null</code> if no
-   * connection is active.
-   */
-  public String getUsedClientVersion() {
-    if (V_C == null) {
-      return null;
-    }
-    return Util.byte2str(V_C);
-  }
-  
-  /**
    * Returns the client version that is used for the next connection.
    * This value might be different from the version string used in a
    * currently active connection if <code>setClientVersion</code> has

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -81,7 +81,8 @@ public class Session{
   private static final int PACKET_MAX_SIZE = 256 * 1024;
 
   private byte[] V_S;                                 // server version
-  private String V_C; //=Util.str2byte("SSH-2.0-JSCH_"+Version.getVersion()); // client version
+  private byte[] V_C; // will be set during connect so that the client version
+                      // can be changed without affecting active sessions
 
   private byte[] I_C; // the payload of the client's SSH_MSG_KEXINIT
   private byte[] I_S; // the payload of the server's SSH_MSG_KEXINIT
@@ -169,6 +170,7 @@ public class Session{
 
   JSch jsch;
   Logger logger;
+  String clientVersion; //=Util.str2byte("SSH-2.0-JSCH_"+Version.getVersion()); // client version
 
   Session(JSch jsch, String username, String host, int port) throws JSchException{
     super();
@@ -199,6 +201,7 @@ public class Session{
       throw new JSchException("session is already connected");
     }
 
+    V_C = Util.str2byte(getClientVersion());
     io=new IO();
     if(random==null){
       try{
@@ -259,11 +262,10 @@ public class Session{
 
       jsch.addSession(this);
 
-      byte[] clientVersion = Util.str2byte(getClientVersion());
       {
         // Some Cisco devices will miss to read '\n' if it is sent separately.
-        byte[] foo=new byte[clientVersion.length+2];
-        System.arraycopy(clientVersion, 0, foo, 0, clientVersion.length);
+        byte[] foo=new byte[V_C.length+2];
+        System.arraycopy(V_C, 0, foo, 0, V_C.length);
         foo[foo.length-2]=(byte)'\r';
         foo[foo.length-1]=(byte)'\n';
         io.put(foo, 0, foo.length);
@@ -316,7 +318,7 @@ public class Session{
         getLogger().log(Logger.INFO,
                              "Remote version string: "+_v_s);
         getLogger().log(Logger.INFO,
-                             "Local version string: "+Util.byte2str(clientVersion));
+                             "Local version string: "+Util.byte2str(V_C));
       }
 
       send_kexinit();
@@ -625,7 +627,7 @@ public class Session{
       throw new JSchException(e.toString(), e);
     }
 
-    kex.doInit(this, V_S, Util.str2byte(getClientVersion()), I_S, I_C);
+    kex.doInit(this, V_S, V_C, I_S, I_C);
     return kex;
   }
 
@@ -2717,14 +2719,14 @@ break;
     return Util.byte2str(V_S);
   }
   public String getClientVersion(){
-    return V_C == null ? jsch.getClientVersion() : V_C;
+    return clientVersion == null ? jsch.getClientVersion() : clientVersion;
   }
   public void setClientVersion(String cv){
-    V_C = null;
+    clientVersion = null;
     if (cv == null) {
       return;
     }
-    V_C=cv;
+    clientVersion=cv;
   }
 
   public void sendIgnore() throws Exception{

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -2105,6 +2105,7 @@ break;
 //    }
 
     jsch.removeSession(this);
+    clientVersion = null;
 
     //System.gc();
   }
@@ -2718,15 +2719,45 @@ break;
   public String getServerVersion(){
     return Util.byte2str(V_S);
   }
+  
+  /**
+   * Returns the client version string used during an active connection.
+   * If no connection is active <code>null</code> is returned.
+   * @return The used version string or <code>null</code> if no
+   * connection is active.
+   */
+  public String getUsedClientVersion() {
+    if (V_C == null) {
+      return null;
+    }
+    return Util.byte2str(V_C);
+  }
+  
+  /**
+   * Returns the client version that is used for the next connection.
+   * This value might be different from the version string used in a
+   * currently active connection if <code>setClientVersion</code> has
+   * been called since then.
+   * @return The version string
+   */
   public String getClientVersion(){
     return clientVersion == null ? jsch.getClientVersion() : clientVersion;
   }
+  
+  /**
+   * Sets the client version that is used for the next connection.
+   * If a connection is already active this has no effect on the
+   * current connection (e.g. during a rekeying process). If
+   * <code>null</code> is set, the value of the JSch-instance the
+   * session belongs to is used.
+   * @param cv The version string or <code>null</code> if JSch's
+   * value should be used.
+   */
   public void setClientVersion(String cv){
-    clientVersion = null;
+    clientVersion = cv;
     if (cv == null) {
       return;
     }
-    clientVersion=cv;
   }
 
   public void sendIgnore() throws Exception{

--- a/src/test/java/com/jcraft/jsch/JSchTest.java
+++ b/src/test/java/com/jcraft/jsch/JSchTest.java
@@ -3,9 +3,9 @@ package com.jcraft.jsch;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
+import java.util.HashMap;
 import java.util.Hashtable;
-
+import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.*;
 
 class JSchTest {
@@ -95,6 +95,44 @@ class JSchTest {
         JSch.setLogger(null);
         assertSame(JSch.DEVNULL, JSch.logger, "static logger should be DEVNULL");
         assertSame(JSch.DEVNULL, jsch.getInstanceLogger(), "instance logger should be DEVNULL");
+    }
+    
+    @Test
+    void checkFillConfig() throws Exception {
+      // TODO add more tests, this rudimentary implementation shows the
+      // reason for the javaVersion-parameter discussed in #130
+      
+      Properties orgProps = System.getProperties();
+      Properties props = new Properties();
+      try {
+        System.setProperties(props);
+        
+        HashMap<String, String> map = new HashMap<>();
+        
+        JSch.fillConfig(map, 10);
+        assertEquals("com.jcraft.jsch.bc.XDH", map.get("xdh"), "check of xdh failed");
+        JSch.fillConfig(map, 11);
+        assertEquals("com.jcraft.jsch.jce.XDH", map.get("xdh"), "check of xdh failed");
+        JSch.fillConfig(map, 12);
+        assertEquals("com.jcraft.jsch.jce.XDH", map.get("xdh"), "check of xdh failed");
+        
+        JSch.fillConfig(map, 14);
+        assertEquals("com.jcraft.jsch.bc.KeyPairGenEdDSA", map.get("keypairgen.eddsa"), "check of keypairgen.eddsa failed");
+        assertEquals("com.jcraft.jsch.bc.SignatureEd25519", map.get("ssh-ed25519"), "check of ssh-ed25519 failed");
+        assertEquals("com.jcraft.jsch.bc.SignatureEd448", map.get("ssh-ed448"), "check of ssh-ed448 failed");
+        JSch.fillConfig(map, 15);
+        assertEquals("com.jcraft.jsch.jce.KeyPairGenEdDSA", map.get("keypairgen.eddsa"), "check of keypairgen.eddsa failed");
+        assertEquals("com.jcraft.jsch.jce.SignatureEd25519", map.get("ssh-ed25519"), "check of ssh-ed25519 failed");
+        assertEquals("com.jcraft.jsch.jce.SignatureEd448", map.get("ssh-ed448"), "check of ssh-ed448 failed");
+        JSch.fillConfig(map, 16);
+        assertEquals("com.jcraft.jsch.jce.KeyPairGenEdDSA", map.get("keypairgen.eddsa"), "check of keypairgen.eddsa failed");
+        assertEquals("com.jcraft.jsch.jce.SignatureEd25519", map.get("ssh-ed25519"), "check of ssh-ed25519 failed");
+        assertEquals("com.jcraft.jsch.jce.SignatureEd448", map.get("ssh-ed448"), "check of ssh-ed448 failed");
+      }
+      finally {
+        System.setProperties(orgProps);
+      }
+      
     }
     
     final static class TestLogger implements Logger {

--- a/src/test/java/com/jcraft/jsch/JSchTest.java
+++ b/src/test/java/com/jcraft/jsch/JSchTest.java
@@ -13,9 +13,8 @@ class JSchTest {
     private Logger orgLogger;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     void resetJsch() {
-      orgConfig = (Hashtable<String, String>) JSch.config.clone();
+      orgConfig = new Hashtable<>(JSch.config);
       orgLogger = JSch.getLogger();
       JSch.setLogger(null);
     }
@@ -100,7 +99,7 @@ class JSchTest {
     @Test
     void checkFillConfig() throws Exception {
       // TODO add more tests, this rudimentary implementation shows the
-      // reason for the javaVersion-parameter discussed in #130
+      // reason for the javaVersion-parameter discussed in PR #130
       
       Properties orgProps = System.getProperties();
       Properties props = new Properties();

--- a/src/test/java/com/jcraft/jsch/SessionTest.java
+++ b/src/test/java/com/jcraft/jsch/SessionTest.java
@@ -58,6 +58,26 @@ class SessionTest {
     }
     
     @Test
+    void setClientVersion() throws Exception {
+      JSch jsch = new JSch();
+      
+      Session session1 = new Session(jsch, null, null, 0);
+      Session session2 = new Session(jsch, null, null, 0);
+      String jschClientVersion = jsch.getClientVersion();
+      
+      assertEquals(jschClientVersion, session1.getClientVersion(), "client version should be equal to JSch's instance");
+      session1.setClientVersion("Session_Client");
+      assertEquals(jschClientVersion, jsch.getClientVersion(), "client version in jsch changed when setting in session");
+      assertEquals("Session_Client", session1.getClientVersion(), "Unexpected version in session");
+      
+      assertEquals(jschClientVersion, session2.getClientVersion(), "Version of session2 changed without setting it");
+      jsch.setClientVersion("New_Client_Version");
+      assertEquals("New_Client_Version", session2.getClientVersion(), "Change of version in jsch not 'copied' in session");
+      session1.setClientVersion(null);
+      assertEquals("New_Client_Version", session1.getClientVersion(), "Change of version in jsch not 'copied' in session");
+    }
+    
+    @Test
     void checkLoggerFunctionality() throws Exception {
       Logger orgLogger = JSch.getLogger();
       try {


### PR DESCRIPTION
Compared to the logger issue this is a more simple change. I've added a system-property that allows to set the client version that way as well and added tests to check the behavior. This required the setup of the config-hashtable to be in a dedicated method.