### PR TITLE
Using correct line ending CRLF instead of \n (LF)

### DIFF
--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -263,7 +263,7 @@ public class Session{
         // Some Cisco devices will miss to read '\n' if it is sent separately.
         byte[] foo=new byte[V_C.length+2];
         System.arraycopy(V_C, 0, foo, 0, V_C.length);
-        foo[foo.length-2]=(byte)'\r';
+        foo[foo.length-2]=(byte)0x0D;
         foo[foo.length-1]=(byte)'\n';
         io.put(foo, 0, foo.length);
       }


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc4253#section-4.2 line must end by using CRLF not \n. 
Missing that creates connection issues e.g. https://docs.microsoft.com/en-us/answers/questions/713024/connection-to-azure-sftp-doesnt-work-using-jsch.html