### PR TITLE
fix StandardCharsets NoClassDefFoundError

### DIFF
--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -31,7 +31,6 @@ package com.jcraft.jsch;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Hashtable;
 import java.util.Vector;
 
@@ -180,7 +179,7 @@ public class ChannelSftp extends ChannelSession{
   private String home;
   private String lcwd;
 
-  private Charset fEncoding=StandardCharsets.UTF_8;
+  private Charset fEncoding=CharsetUtil.UTF_8;
   private boolean fEncoding_is_utf8=true;
 
   private RequestQueue rq = new RequestQueue(16);
@@ -1692,7 +1691,7 @@ public class ChannelSftp extends ChannelSession{
              byte[] _filename=filename;
              if(!fEncoding_is_utf8){
                f=Util.byte2str(_filename, fEncoding);
-               _filename=Util.str2byte(f, StandardCharsets.UTF_8);
+               _filename=Util.str2byte(f, CharsetUtil.UTF_8);
              }
              find=Util.glob(pattern, _filename);
            }
@@ -2722,7 +2721,7 @@ public class ChannelSftp extends ChannelSession{
 
         if(!fEncoding_is_utf8){
           f=Util.byte2str(filename, fEncoding);
-          _filename=Util.str2byte(f, StandardCharsets.UTF_8);
+          _filename=Util.str2byte(f, CharsetUtil.UTF_8);
         }
         found=Util.glob(pattern, _filename);
 
@@ -2762,7 +2761,7 @@ public class ChannelSftp extends ChannelSession{
   private Vector<String> glob_local(String _path) throws Exception{
 //System.err.println("glob_local: "+_path);
     Vector<String> v=new Vector<>();
-    byte[] path=Util.str2byte(_path, StandardCharsets.UTF_8);
+    byte[] path=Util.str2byte(_path, CharsetUtil.UTF_8);
     int i=path.length-1;
     while(i>=0){
       if(path[i]!='*' && path[i]!='?'){
@@ -2805,11 +2804,11 @@ public class ChannelSftp extends ChannelSession{
 
 //System.err.println("dir: "+new String(dir)+" pattern: "+new String(pattern));
     try{
-      String[] children=(new File(Util.byte2str(dir, StandardCharsets.UTF_8))).list();
+      String[] children=(new File(Util.byte2str(dir, CharsetUtil.UTF_8))).list();
       String pdir=Util.byte2str(dir)+file_separator;
       for(int j=0; j<children.length; j++){
 //System.err.println("children: "+children[j]);
-        if(Util.glob(pattern, Util.str2byte(children[j], StandardCharsets.UTF_8))){
+        if(Util.glob(pattern, Util.str2byte(children[j], CharsetUtil.UTF_8))){
           v.addElement(pdir+children[j]);
         }
       }
@@ -2824,7 +2823,7 @@ public class ChannelSftp extends ChannelSession{
        buf.getLength()>=4){   // SSH_FXP_STATUS packet.
       byte[] str=buf.getString();
       //byte[] tag=buf.getString();
-      throw new SftpException(i, Util.byte2str(str, StandardCharsets.UTF_8));
+      throw new SftpException(i, Util.byte2str(str, CharsetUtil.UTF_8));
     }
     else{
       throw new SftpException(i, "Failure");
@@ -2841,7 +2840,7 @@ public class ChannelSftp extends ChannelSession{
   }
 
   private boolean isPattern(String path, byte[][] utf8){
-    byte[] _path=Util.str2byte(path, StandardCharsets.UTF_8);
+    byte[] _path=Util.str2byte(path, CharsetUtil.UTF_8);
     if(utf8!=null)
       utf8[0]=_path;
     return isPattern(_path);
@@ -2942,7 +2941,7 @@ public class ChannelSftp extends ChannelSession{
 
   public void setFilenameEncoding(Charset encoding){
     fEncoding=encoding;
-    fEncoding_is_utf8=fEncoding.equals(StandardCharsets.UTF_8);
+    fEncoding_is_utf8=fEncoding.equals(CharsetUtil.UTF_8);
   }
 
   public String getExtension(String key){

--- a/src/main/java/com/jcraft/jsch/CharsetUtil.java
+++ b/src/main/java/com/jcraft/jsch/CharsetUtil.java
@@ -1,0 +1,7 @@
+package com.jcraft.jsch;
+
+import java.nio.charset.Charset;
+
+public class CharsetUtil {
+    public static Charset UTF_8 = Charset.forName("UTF-8");
+}

--- a/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
+++ b/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
@@ -33,7 +33,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -103,7 +102,7 @@ public class OpenSSHConfig implements ConfigRepository {
    * @return an instanceof OpenSSHConfig
    */
   public static OpenSSHConfig parseFile(String file) throws IOException {
-    try(BufferedReader br = Files.newBufferedReader(Paths.get(Util.checkTilde(file)), StandardCharsets.UTF_8)) {
+    try(BufferedReader br = Files.newBufferedReader(Paths.get(Util.checkTilde(file)), CharsetUtil.UTF_8)) {
       return new OpenSSHConfig(br);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Util.java
+++ b/src/main/java/com/jcraft/jsch/Util.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Vector;
 
 class Util{
@@ -416,7 +415,7 @@ class Util{
   }
 
   static byte[] str2byte(String str){
-    return str2byte(str, StandardCharsets.UTF_8);
+    return str2byte(str, CharsetUtil.UTF_8);
   }
 
   static String byte2str(byte[] str, Charset encoding){
@@ -428,11 +427,11 @@ class Util{
   }
 
   static String byte2str(byte[] str){
-    return byte2str(str, 0, str.length, StandardCharsets.UTF_8);
+    return byte2str(str, 0, str.length, CharsetUtil.UTF_8);
   }
 
   static String byte2str(byte[] str, int s, int l){
-    return byte2str(str, s, l, StandardCharsets.UTF_8);
+    return byte2str(str, s, l, CharsetUtil.UTF_8);
   }
 
   static String toHex(byte[] str){

--- a/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
@@ -29,9 +29,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.jcraft.jsch.bc;
 
-import java.nio.charset.StandardCharsets;
 import java.security.*;
-import java.util.Arrays;
+
+import com.jcraft.jsch.CharsetUtil;
 import org.bouncycastle.crypto.Signer;
 import org.bouncycastle.crypto.params.*;
 import org.bouncycastle.crypto.signers.*;
@@ -120,7 +120,7 @@ abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
     byte[] tmp;
     Buffer buf = new Buffer(sig);
 
-    String foo = new String(buf.getString(), StandardCharsets.UTF_8);
+    String foo = new String(buf.getString(), CharsetUtil.UTF_8);
     if(foo.equals(getName())){
       j = buf.getInt();
       i = buf.getOffSet();

--- a/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
+++ b/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
@@ -14,7 +14,8 @@
 
 package com.jcraft.jsch.jbcrypt;
 
-import java.nio.charset.StandardCharsets;
+import com.jcraft.jsch.CharsetUtil;
+
 import java.security.DigestException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -764,7 +765,7 @@ public class BCrypt {
         rounds = Integer.parseInt(salt.substring(off, off + 2));
 
         real_salt = salt.substring(off + 3, off + 25);
-        passwordb = (password + (minor >= 'a' ? "\000" : "")).getBytes(StandardCharsets.UTF_8);
+        passwordb = (password + (minor >= 'a' ? "\000" : "")).getBytes(CharsetUtil.UTF_8);
 
         saltb = decode_base64(real_salt, BCRYPT_SALT_LEN);
 
@@ -847,8 +848,8 @@ public class BCrypt {
      */
     public static boolean checkpw(String plaintext, String hashed) {
         String try_pw = hashpw(plaintext, hashed);
-        byte hashed_bytes[] = hashed.getBytes(StandardCharsets.UTF_8);
-        byte try_bytes[] = try_pw.getBytes(StandardCharsets.UTF_8);
+        byte hashed_bytes[] = hashed.getBytes(CharsetUtil.UTF_8);
+        byte try_bytes[] = try_pw.getBytes(CharsetUtil.UTF_8);
         if (hashed_bytes.length != try_bytes.length)
             return false;
         byte ret = 0;

--- a/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
@@ -30,10 +30,10 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.jcraft.jsch.jce;
 
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.*;
 import com.jcraft.jsch.Buffer;
+import com.jcraft.jsch.CharsetUtil;
 
 public class SignatureDSA implements com.jcraft.jsch.SignatureDSA{
 
@@ -116,7 +116,7 @@ System.err.println("");
     byte[] tmp;
     Buffer buf=new Buffer(sig);
 
-    if(new String(buf.getString(), StandardCharsets.UTF_8).equals("ssh-dss")){
+    if(new String(buf.getString(), CharsetUtil.UTF_8).equals("ssh-dss")){
       j=buf.getInt();
       i=buf.getOffSet();
       tmp=new byte[j];

--- a/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
@@ -30,10 +30,10 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.jcraft.jsch.jce;
 
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.*;
 import com.jcraft.jsch.Buffer;
+import com.jcraft.jsch.CharsetUtil;
 
 abstract class SignatureRSAN implements com.jcraft.jsch.SignatureRSA{
 
@@ -85,7 +85,7 @@ abstract class SignatureRSAN implements com.jcraft.jsch.SignatureRSA{
     byte[] tmp;
     Buffer buf=new Buffer(sig);
 
-    String foo=new String(buf.getString(), StandardCharsets.UTF_8);
+    String foo=new String(buf.getString(), CharsetUtil.UTF_8);
     if(foo.equals("ssh-rsa") || foo.equals("rsa-sha2-256") || foo.equals("rsa-sha2-512") ||
        foo.equals("ssh-rsa-sha224@ssh.com") || foo.equals("ssh-rsa-sha256@ssh.com") ||
        foo.equals("ssh-rsa-sha384@ssh.com") || foo.equals("ssh-rsa-sha512@ssh.com")){

--- a/src/main/java15/com/jcraft/jsch/jce/SignatureEdDSA.java
+++ b/src/main/java15/com/jcraft/jsch/jce/SignatureEdDSA.java
@@ -30,7 +30,6 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.jcraft.jsch.jce;
 
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.*;
 import java.util.Arrays;
@@ -114,7 +113,7 @@ abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
     byte[] tmp;
     Buffer buf = new Buffer(sig);
 
-    String foo = new String(buf.getString(), StandardCharsets.UTF_8);
+    String foo = new String(buf.getString(), CharsetUtil.UTF_8);
     if(foo.equals(getName())){
       j = buf.getInt();
       i = buf.getOffSet();

--- a/src/test/java/com/jcraft/jsch/Algorithms2IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms2IT.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.jcraft.jsch.CharsetUtil.UTF_8;
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/jcraft/jsch/Algorithms3IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms3IT.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.jcraft.jsch.CharsetUtil.UTF_8;
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.jcraft.jsch.CharsetUtil.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/jcraft/jsch/KeyPairTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairTest.java
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.jcraft.jsch.CharsetUtil.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
 class KeyPairTest {

--- a/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.jcraft.jsch.CharsetUtil.UTF_8;
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/jcraft/jsch/SSHAgentIT.java
+++ b/src/test/java/com/jcraft/jsch/SSHAgentIT.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.jcraft.jsch.CharsetUtil.UTF_8;
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.jcraft.jsch.CharsetUtil.UTF_8;
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
StandardCharsets api was added in android API Level 19, so it will cause some old device crash. so i direct use Charset API.