### PR TITLE
Update link to bcrypt

### DIFF
--- a/opensshFormat.md
+++ b/opensshFormat.md
@@ -6,4 +6,4 @@
 <https://bugs.eclipse.org/bugs/show_bug.cgi?id=541703>
 
 * implementation of bcrypt_pbkdf:
-<https://github.com/kruton/jbcrypt/blob/master/jbcrypt/src/main/java/org/mindrot/jbcrypt/BCrypt.java>
+<https://github.com/kruton/jbcrypt/blob/master/src/main/java/org/mindrot/jbcrypt/BCrypt.java>


### PR DESCRIPTION
Old link doesn't work
![изображение](https://user-images.githubusercontent.com/741251/172018950-5e200e99-d906-4113-891c-54e7b2ce012d.png)
