### PR TITLE
0.2.5 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -29,6 +30,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@EnabledOnOs(architectures = "x86_64")
 @Testcontainers
 public class OpenSSH74ServerSigAlgsIT {
 


### PR DESCRIPTION
- Update dependencies.
- Fix integration test failures on Apple Silicon by skipping OpenSSH 7.4 tests.
-- The docker image used for OpenSSH 7.4 is only available for x86_64.