### PR TITLE
stick to runner image ubuntu 20.04

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         java: ['8', '11', '17']


### PR DESCRIPTION
since ubuntu-latest is pointing to ubuntu-22.04 CI is failing