### PR TITLE
Fix missing keySize set when loading V1 RSA keys

### DIFF
--- a/src/main/java/com/jcraft/jsch/KeyPairRSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairRSA.java
@@ -190,6 +190,9 @@ class KeyPairRSA extends KeyPair{
                 c_array= prvKEyBuffer.getMPInt(); // iqmp (q^-1 mod p)
                 p_array=prvKEyBuffer.getMPInt(); // p (Prime 1)
                 q_array=prvKEyBuffer.getMPInt(); // q (Prime 2)
+                if(n_array!=null){
+                  key_size = (new BigInteger(n_array)).bitLength();
+                }
 
                 getEPArray();
                 getEQArray();


### PR DESCRIPTION
When loading a RSA key from an OPENSSH V1 file content the keySize was left at the default value 1024 instead of the actual key size from the loaded key material. This change makes the value correct if possible.