### PR TITLE
Enhancement to present KeyPair.getKeyTypeString() method

### DIFF
--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -177,6 +177,15 @@ public abstract class KeyPair{
   public abstract int getKeyType();
 
   /**
+   * Wrapper to provide the String representation of {@code #getKeyTypeName()}.
+   *
+   * @return the standard SSH key type string
+   */
+  public String getKeyTypeString() {
+    return Util.byte2str(getKeyTypeName());
+  }
+
+  /**
    * Returns the blob of the public key.
    * @return blob of the public key
    */


### PR DESCRIPTION
The getSshName() method was available for most KeyPair implementations but inconsistently and not as part of the KeyPair class interface. This makes the method part of the KeyPair class interface and makes each implementation provide the correct value to the caller. I found this to be useful when importing keys from unknown files and expecting the KeyPair class to provide a hint as to the loaded key type in a way that can be used by code logic. I prefer this to doing class type inspection as it is much easier to get it right expecially for the ECDSA KeyPair which can have different SshName based on the key size.