### PR TITLE
0.2.8 changes

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '17'
           check-latest: true
       - name: Build Javadoc
-        run: mvn javadoc:javadoc
+        run: mvn -B -V javadoc:javadoc --file pom.xml
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,7 @@ jobs:
         name: java-${{ matrix.java }}-jars
         path: |
           **/target/*.jar
+          **/target/bom.*
       if: always()
     - name: Set up test JDK ${{ matrix.java }}
       uses: actions/setup-java@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,7 @@
 name: Java CI with Maven
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
     paths-ignore: 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         java: ['8', '11', '17']

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         java-version: '17'
         check-latest: true
     - name: Build with Maven
-      run: mvn -B -DskipTests=true package --file pom.xml
+      run: mvn -B -V -DskipTests=true package --file pom.xml
     - uses: actions/upload-artifact@v3
       with:
         name: java-${{ matrix.java }}-jars
@@ -49,7 +49,7 @@ jobs:
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Test with Maven
-      run: mvn -B -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dmaven.main.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -DskipITs=false --file pom.xml
+      run: mvn -B -V -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dmaven.main.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -DskipITs=false --file pom.xml
     - uses: actions/upload-artifact@v3
       with:
         name: java-${{ matrix.java }}-testresults

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.7/apache-maven-3.8.7-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.0/apache-maven-3.9.0-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
             <groupId>com.kohlschutter</groupId>
             <artifactId>compiler-annotations</artifactId>
             <version>1.5.2</version>
+            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -479,6 +480,21 @@
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.7.4</version>
+                <configuration>
+                    <includeProvidedScope>false</includeProvidedScope>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>makeBom</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <url>https://github.com/mwiede/jsch/blob/master/LICENSE.txt</url>
         </license>
         <license>
-            <name>BSD</name>
+            <name>Revised BSD</name>
             <url>https://github.com/mwiede/jsch/blob/master/LICENSE.JZlib.txt</url>
         </license>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,7 @@
                                 <path>
                                     <groupId>com.google.errorprone</groupId>
                                     <artifactId>error_prone_core</artifactId>
-                                    <version>2.17.0</version>
+                                    <version>2.18.0</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.kohlschutter.junixsocket</groupId>
-            <artifactId>junixsocket-native-common</artifactId>
-            <version>${junixsocket.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.kohlschutter</groupId>
             <artifactId>compiler-annotations</artifactId>
             <version>1.5.2</version>
@@ -161,6 +155,12 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.kohlschutter.junixsocket</groupId>
+            <artifactId>junixsocket-native-common</artifactId>
+            <version>${junixsocket.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <fork>true</fork>
                     <release>8</release>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
@@ -626,6 +625,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
+                            <fork>true</fork>
                             <compilerArgs combine.children="append">
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>-Xplugin:ErrorProne</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -509,6 +509,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.0.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.1.0</version>
             </plugin>
@@ -526,6 +531,28 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.5.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <failOnViolation>true</failOnViolation>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <violationSeverity>warning</violationSeverity>
+                    <configLocation>google_checks.xml</configLocation>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/examples</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java9</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java10</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java11</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java15</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java16</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java-templates</sourceDirectory>
+                    </sourceDirectories>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
@@ -547,6 +574,19 @@
                     </directories>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <configuration>
+                    <excludes>
+                        <exclude>com/jcraft/jsch/JavaVersion.class</exclude>
+                        <exclude>com/jcraft/jsch/UnixDomainSocketFactory.class</exclude>
+                        <exclude>META-INF/versions/9/com/jcraft/jsch/JavaVersion.class</exclude>
+                        <exclude>META-INF/versions/10/com/jcraft/jsch/JavaVersion.class</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -557,7 +597,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -578,15 +617,6 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.8</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>com/jcraft/jsch/JavaVersion.class</exclude>
-                                <exclude>com/jcraft/jsch/UnixDomainSocketFactory.class</exclude>
-                                <exclude>META-INF/versions/9/com/jcraft/jsch/JavaVersion.class</exclude>
-                                <exclude>META-INF/versions/10/com/jcraft/jsch/JavaVersion.class</exclude>
-                            </excludes>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>default-prepare-agent</id>
@@ -699,25 +729,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
-                        <version>3.2.1</version>
-                        <configuration>
-                            <encoding>UTF-8</encoding>
-                            <failOnViolation>true</failOnViolation>
-                            <logViolationsToConsole>true</logViolationsToConsole>
-                            <violationSeverity>warning</violationSeverity>
-                            <configLocation>google_checks.xml</configLocation>
-                            <sourceDirectories>
-                                <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-                                <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
-                                <sourceDirectory>${project.basedir}/examples</sourceDirectory>
-                                <sourceDirectory>${project.basedir}/src/main/java9</sourceDirectory>
-                                <sourceDirectory>${project.basedir}/src/main/java10</sourceDirectory>
-                                <sourceDirectory>${project.basedir}/src/main/java11</sourceDirectory>
-                                <sourceDirectory>${project.basedir}/src/main/java15</sourceDirectory>
-                                <sourceDirectory>${project.basedir}/src/main/java16</sourceDirectory>
-                                <sourceDirectory>${project.basedir}/src/main/java-templates</sourceDirectory>
-                            </sourceDirectories>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,9 @@
                                     <version>16</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
+                                <banDuplicatePomDependencyVersions />
+                                <reactorModuleConvergence />
+                                <requireUpperBoundDeps />
                             </rules>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -486,9 +486,9 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.4</version>
+                <version>2.7.5</version>
                 <configuration>
-                    <includeProvidedScope>false</includeProvidedScope>
+                    <includeCompileScope>false</includeCompileScope>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -93,13 +93,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.kohlschutter</groupId>
-            <artifactId>compiler-annotations</artifactId>
-            <version>1.5.2</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-jpms</artifactId>
             <version>${jna.version}</version>
@@ -281,7 +274,7 @@
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
-                        <arg>-Xlint:all,-processing</arg>
+                        <arg>-Xlint:all,-processing,-classfile</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
@@ -487,9 +480,6 @@
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>2.7.5</version>
-                <configuration>
-                    <includeCompileScope>false</includeCompileScope>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -7,7 +7,6 @@ module com.jcraft.jsch {
     requires static org.slf4j;
     requires static org.bouncycastle.provider;
     requires static org.newsclub.net.unix;
-    requires static com.kohlschutter.junixsocket.nativecommon;
     requires static com.sun.jna;
     requires static com.sun.jna.platform;
 }

--- a/src/test/resources/docker/Dockerfile.sshagent
+++ b/src/test/resources/docker/Dockerfile.sshagent
@@ -5,6 +5,9 @@ RUN apk update && \
     apk upgrade && \
     apk add openssh su-exec && \
     rm /var/cache/apk/* && \
+    if [ "$testuid" -gt 0 ]; then if egrep "^[^:]+:x:$testuid:" /etc/passwd; then deluser "$(egrep "^[^:]+:x:$testuid:" /etc/passwd | cut -d: -f1)"; fi; fi && \
+    if [ "$testgid" -gt 0 ]; then if egrep "^[^:]+:x:[^:]+:$testgid:" /etc/passwd; then deluser "$(egrep "^[^:]+:x:[^:]+:$testgid:" /etc/passwd | cut -d: -f1)"; fi; fi && \
+    if [ "$testgid" -gt 0 ]; then if egrep "^[^:]+:x:$testgid:" /etc/group; then delgroup "$(egrep "^[^:]+:x:$testgid:" /etc/group | cut -d: -f1)"; fi; fi && \
     addgroup -g $testgid testuser && \
     adduser -Du $testuid -G testuser -Hh /testuser -s /bin/sh -g testuser testuser && \
     mkdir /testuser && \


### PR DESCRIPTION
- Update dependencies.
- Add additional enforcer rules.
- Remove unneeded junixsocket-native-common dependency.
- Generate CycloneDX SBOM.
- Allow manual dispatch of CI builds.
- Fix CI builds with ubuntu-latest by deleting conflicting users & groups from container.
- Capture maven version info during CI builds.
- Only fork for error-prone where it's needed.
- Define plugin verions and configuration in default build instead within profiles.
  - This will help dependabot, as I don't believe it will generate PRs for items that have their versions' only defined within a profile.
- Drop compiler-annotations dependency by disabling classfile warnings.
- Correct license name for JZlib so that it isn't misidentified in SBOM.