### PR TITLE
0.2.9 changes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+* [0.2.9](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.9)
+  * [#293](https://github.com/mwiede/jsch/issues/293) allow UserAuthNone to be extended.
 * [0.2.8](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.8)
   * [#287](https://github.com/mwiede/jsch/issues/287) add algorithm type information to algorithm negotiation logs.
   * [#289](https://github.com/mwiede/jsch/issues/289) wrap NoClassDefFoundError's for invalid private keys.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 * [0.2.9](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.9)
   * [#293](https://github.com/mwiede/jsch/issues/293) allow UserAuthNone to be extended.
+  * Make JGSS module optional.
 * [0.2.8](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.8)
   * [#287](https://github.com/mwiede/jsch/issues/287) add algorithm type information to algorithm negotiation logs.
   * [#289](https://github.com/mwiede/jsch/issues/289) wrap NoClassDefFoundError's for invalid private keys.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 * [0.2.9](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.9)
   * [#293](https://github.com/mwiede/jsch/issues/293) allow UserAuthNone to be extended.
   * Make JGSS module optional.
+  * Tweak OSGi bundle manifest:
+    * Avoid self-import.
+    * Avoid `uses:="com.sun.jna"` on export.
+    * Mark JGSS as optional.
+    * Loosen import versions of dependencies.
 * [0.2.8](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.8)
   * [#287](https://github.com/mwiede/jsch/issues/287) add algorithm type information to algorithm negotiation logs.
   * [#289](https://github.com/mwiede/jsch/issues/289) wrap NoClassDefFoundError's for invalid private keys.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
     * Mark JGSS as optional.
     * Loosen import versions of dependencies.
   * Correctly adhere to the Multi-release JAR spec by ensuring all public classes under versioned directories preside over classes present in the top-level directory.
+  * Eliminate stray `System.err.println()` calls.
 * [0.2.8](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.8)
   * [#287](https://github.com/mwiede/jsch/issues/287) add algorithm type information to algorithm negotiation logs.
   * [#289](https://github.com/mwiede/jsch/issues/289) wrap NoClassDefFoundError's for invalid private keys.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
     * Loosen import versions of dependencies.
   * Correctly adhere to the Multi-release JAR spec by ensuring all public classes under versioned directories preside over classes present in the top-level directory.
   * Eliminate stray `System.err.println()` calls.
+  * Change PageantConnector to use JNA's built-in support for `User32.SendMessage()`.
 * [0.2.8](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.8)
   * [#287](https://github.com/mwiede/jsch/issues/287) add algorithm type information to algorithm negotiation logs.
   * [#289](https://github.com/mwiede/jsch/issues/289) wrap NoClassDefFoundError's for invalid private keys.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,6 @@
   * Make JGSS module optional.
   * Tweak OSGi bundle manifest:
     * Avoid self-import.
-    * Avoid `uses:="com.sun.jna"` on export.
     * Mark JGSS as optional.
     * Loosen import versions of dependencies.
   * Correctly adhere to the Multi-release JAR spec by ensuring all public classes under versioned directories preside over classes present in the top-level directory.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
     * Avoid `uses:="com.sun.jna"` on export.
     * Mark JGSS as optional.
     * Loosen import versions of dependencies.
+  * Correctly adhere to the Multi-release JAR spec by ensuring all public classes under versioned directories preside over classes present in the top-level directory.
 * [0.2.8](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.8)
   * [#287](https://github.com/mwiede/jsch/issues/287) add algorithm type information to algorithm negotiation logs.
   * [#289](https://github.com/mwiede/jsch/issues/289) wrap NoClassDefFoundError's for invalid private keys.

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <dependency>
             <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
-            <version>2.8.1</version>
+            <version>2.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -436,7 +436,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-licenses</id>
@@ -544,12 +544,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -312,9 +312,9 @@
                     <release>8</release>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
+                    <failOnWarning>true</failOnWarning>
                     <compilerArgs>
                         <arg>-Xlint:all,-processing,-classfile</arg>
-                        <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,17 @@
                 <version>5.1.8</version>
                 <configuration>
                     <instructions>
-                        <Export-Package>com.jcraft.jsch</Export-Package>
+                        <Export-Package>com.jcraft.jsch;-noimport:=true</Export-Package>
+                        <!-- Avoid uses:="com.sun.jna" on export -->
+                        <_nouses>true</_nouses>
+                        <Import-Package><![CDATA[
+                            com.sun.jna*;version="${range;[=0,+)}",
+                            org.apache.logging.log4j*;version="${range;[=0,+)}",
+                            org.bouncycastle*;version="[1.69,${versionmask;+})",
+                            org.slf4j*;version="[1.7,${versionmask;+})",
+                            org.ietf.jgss;resolution:=optional,
+                            *
+                            ]]></Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -392,8 +392,6 @@
                 <configuration>
                     <instructions>
                         <Export-Package>com.jcraft.jsch;-noimport:=true</Export-Package>
-                        <!-- Avoid uses:="com.sun.jna" on export -->
-                        <_nouses>true</_nouses>
                         <Import-Package><![CDATA[
                             com.sun.jna*;version="${range;[=0,+)}",
                             org.apache.logging.log4j*;version="${range;[=0,+)}",

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
                     <doclint>none</doclint>
                     <subpackages>com.jcraft.jsch</subpackages>
                     <excludePackageNames>com.jcraft.jsch.*</excludePackageNames>
-                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16</sourcepath>
+                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java10:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16</sourcepath>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -620,7 +620,12 @@
                 <configuration>
                     <excludes>
                         <exclude>com/jcraft/jsch/JavaVersion.class</exclude>
+                        <exclude>com/jcraft/jsch/JplLogger.class</exclude>
                         <exclude>com/jcraft/jsch/UnixDomainSocketFactory.class</exclude>
+                        <exclude>com/jcraft/jsch/jce/KeyPairGenEdDSA.class</exclude>
+                        <exclude>com/jcraft/jsch/jce/SignatureEd25519.class</exclude>
+                        <exclude>com/jcraft/jsch/jce/SignatureEd448.class</exclude>
+                        <exclude>com/jcraft/jsch/jce/XDH.class</exclude>
                         <exclude>META-INF/versions/9/com/jcraft/jsch/JavaVersion.class</exclude>
                         <exclude>META-INF/versions/10/com/jcraft/jsch/JavaVersion.class</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
                     <showWarnings>true</showWarnings>
                     <failOnWarning>true</failOnWarning>
                     <compilerArgs>
-                        <arg>-Xlint:all,-processing,-classfile</arg>
+                        <arg>-Xlint:all,-processing,-classfile,-options</arg>
                     </compilerArgs>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <junixsocket.version>2.6.2</junixsocket.version>
         <jna.version>5.13.0</jna.version>
         <log4j.version>2.20.0</log4j.version>
+        <errorprone.version>2.18.0</errorprone.version>
         <surefire.version>3.0.0</surefire.version>
     </properties>
     <dependencies>
@@ -222,6 +223,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${errorprone.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
@@ -715,7 +725,7 @@
                                 <path>
                                     <groupId>com.google.errorprone</groupId>
                                     <artifactId>error_prone_core</artifactId>
-                                    <version>2.18.0</version>
+                                    <version>${errorprone.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -432,14 +432,8 @@ public class ChannelSftp extends ChannelSession {
             monitor.count(size_of_dst);
           }
         }
-        FileInputStream fis = null;
-        try {
-          fis = new FileInputStream(_src);
+        try (InputStream fis = new FileInputStream(_src)) {
           _put(fis, _dst, monitor, mode);
-        } finally {
-          if (fis != null) {
-            fis.close();
-          }
         }
       }
     } catch (Exception e) {
@@ -931,20 +925,11 @@ public class ChannelSftp extends ChannelSession {
           }
         }
 
-        FileOutputStream fos = null;
         _dstExist = _dstFile.exists();
-        try {
-          if (mode == OVERWRITE) {
-            fos = new FileOutputStream(_dst);
-          } else {
-            fos = new FileOutputStream(_dst, true); // append
-          }
+        try (OutputStream fos = mode == OVERWRITE ? new FileOutputStream(_dst)
+            : new FileOutputStream(_dst, true) /* append */) {
           // System.err.println("_get: "+_src+", "+_dst);
           _get(_src, fos, monitor, mode, new File(_dst).length());
-        } finally {
-          if (fos != null) {
-            fos.close();
-          }
         }
       }
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -604,8 +604,10 @@ public class ChannelSftp extends ChannelSession {
                 int _ackid = ackid[0];
                 if (startid > _ackid || _ackid > seq - 1) {
                   if (_ackid == seq) {
-                    System.err.println(
-                        "ack error: startid=" + startid + " seq=" + seq + " _ackid=" + _ackid);
+                    if (getSession().getLogger().isEnabled(Logger.ERROR)) {
+                      getSession().getLogger().log(Logger.ERROR,
+                          "ack error: startid=" + startid + " seq=" + seq + " _ackid=" + _ackid);
+                    }
                   } else {
                     throw new SftpException(SSH_FX_FAILURE,
                         "ack error: startid=" + startid + " seq=" + seq + " _ackid=" + _ackid);

--- a/src/main/java/com/jcraft/jsch/DHECN.java
+++ b/src/main/java/com/jcraft/jsch/DHECN.java
@@ -62,7 +62,7 @@ abstract class DHECN extends KeyExchange {
       sha = c.getDeclaredConstructor().newInstance();
       sha.init();
     } catch (Exception e) {
-      System.err.println(e);
+      throw new JSchException(e.toString(), e);
     }
 
     buf = new Buffer();
@@ -111,7 +111,9 @@ abstract class DHECN extends KeyExchange {
         j = _buf.getByte();
         j = _buf.getByte();
         if (j != SSH_MSG_KEX_ECDH_REPLY) {
-          System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY " + j);
+          if (session.getLogger().isEnabled(Logger.ERROR)) {
+            session.getLogger().log(Logger.ERROR, "type: must be SSH_MSG_KEX_ECDH_REPLY " + j);
+          }
           return false;
         }
 

--- a/src/main/java/com/jcraft/jsch/DHGEX.java
+++ b/src/main/java/com/jcraft/jsch/DHGEX.java
@@ -68,7 +68,7 @@ abstract class DHGEX extends KeyExchange {
       sha = c.getDeclaredConstructor().newInstance();
       sha.init();
     } catch (Exception e) {
-      System.err.println(e);
+      throw new JSchException(e.toString(), e);
     }
 
     buf = new Buffer();
@@ -87,7 +87,7 @@ abstract class DHGEX extends KeyExchange {
       dh = c.getDeclaredConstructor().newInstance();
       dh.init();
     } catch (Exception e) {
-      throw e;
+      throw new JSchException(e.toString(), e);
     }
 
     packet.reset();
@@ -118,7 +118,9 @@ abstract class DHGEX extends KeyExchange {
         _buf.getByte();
         j = _buf.getByte();
         if (j != SSH_MSG_KEX_DH_GEX_GROUP) {
-          System.err.println("type: must be SSH_MSG_KEX_DH_GEX_GROUP " + j);
+          if (session.getLogger().isEnabled(Logger.ERROR)) {
+            session.getLogger().log(Logger.ERROR, "type: must be SSH_MSG_KEX_DH_GEX_GROUP " + j);
+          }
           return false;
         }
 
@@ -158,7 +160,9 @@ abstract class DHGEX extends KeyExchange {
         j = _buf.getByte();
         j = _buf.getByte();
         if (j != SSH_MSG_KEX_DH_GEX_REPLY) {
-          System.err.println("type: must be SSH_MSG_KEX_DH_GEX_REPLY " + j);
+          if (session.getLogger().isEnabled(Logger.ERROR)) {
+            session.getLogger().log(Logger.ERROR, "type: must be SSH_MSG_KEX_DH_GEX_REPLY " + j);
+          }
           return false;
         }
 

--- a/src/main/java/com/jcraft/jsch/DHGN.java
+++ b/src/main/java/com/jcraft/jsch/DHGN.java
@@ -64,7 +64,7 @@ abstract class DHGN extends KeyExchange {
       sha = c.getDeclaredConstructor().newInstance();
       sha.init();
     } catch (Exception e) {
-      System.err.println(e);
+      throw new JSchException(e.toString(), e);
     }
 
     buf = new Buffer();
@@ -75,8 +75,7 @@ abstract class DHGN extends KeyExchange {
       dh = c.getDeclaredConstructor().newInstance();
       dh.init();
     } catch (Exception e) {
-      // System.err.println(e);
-      throw e;
+      throw new JSchException(e.toString(), e);
     }
 
     dh.setP(P());
@@ -119,8 +118,10 @@ abstract class DHGN extends KeyExchange {
         j = _buf.getInt();
         j = _buf.getByte();
         j = _buf.getByte();
-        if (j != 31) {
-          System.err.println("type: must be 31 " + j);
+        if (j != SSH_MSG_KEXDH_REPLY) {
+          if (session.getLogger().isEnabled(Logger.ERROR)) {
+            session.getLogger().log(Logger.ERROR, "type: must be SSH_MSG_KEXDH_REPLY " + j);
+          }
           return false;
         }
 

--- a/src/main/java/com/jcraft/jsch/DHXEC.java
+++ b/src/main/java/com/jcraft/jsch/DHXEC.java
@@ -63,7 +63,7 @@ abstract class DHXEC extends KeyExchange {
       sha = c.getDeclaredConstructor().newInstance();
       sha.init();
     } catch (Exception e) {
-      System.err.println(e);
+      throw new JSchException(e.toString(), e);
     }
 
     buf = new Buffer();
@@ -111,7 +111,9 @@ abstract class DHXEC extends KeyExchange {
         j = _buf.getByte();
         j = _buf.getByte();
         if (j != SSH_MSG_KEX_ECDH_REPLY) {
-          System.err.println("type: must be SSH_MSG_KEX_ECDH_REPLY " + j);
+          if (session.getLogger().isEnabled(Logger.ERROR)) {
+            session.getLogger().log(Logger.ERROR, "type: must be SSH_MSG_KEX_ECDH_REPLY " + j);
+          }
           return false;
         }
 

--- a/src/main/java/com/jcraft/jsch/HostKey.java
+++ b/src/main/java/com/jcraft/jsch/HostKey.java
@@ -122,7 +122,9 @@ public class HostKey {
       Class<? extends HASH> c = Class.forName(JSch.getConfig(_c)).asSubclass(HASH.class);
       hash = c.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
-      System.err.println("getFingerPrint: " + e);
+      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
+        jsch.getInstanceLogger().log(Logger.ERROR, "getFingerPrint: " + e.getMessage(), e);
+      }
     }
     return Util.getFingerPrint(hash, key, false, true);
   }

--- a/src/main/java/com/jcraft/jsch/JplLogger.java
+++ b/src/main/java/com/jcraft/jsch/JplLogger.java
@@ -1,0 +1,23 @@
+package com.jcraft.jsch;
+
+public class JplLogger implements com.jcraft.jsch.Logger {
+
+  public JplLogger() {
+    throw new UnsupportedOperationException("JplLogger requires Java9+.");
+  }
+
+  @Override
+  public boolean isEnabled(int level) {
+    throw new UnsupportedOperationException("JplLogger requires Java9+.");
+  }
+
+  @Override
+  public void log(int level, String message) {
+    throw new UnsupportedOperationException("JplLogger requires Java9+.");
+  }
+
+  @Override
+  public void log(int level, String message, Throwable cause) {
+    throw new UnsupportedOperationException("JplLogger requires Java9+.");
+  }
+}

--- a/src/main/java/com/jcraft/jsch/KeyExchange.java
+++ b/src/main/java/com/jcraft/jsch/KeyExchange.java
@@ -202,7 +202,9 @@ public abstract class KeyExchange {
       Class<? extends HASH> c = Class.forName(session.getConfig(_c)).asSubclass(HASH.class);
       hash = c.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
-      System.err.println("getFingerPrint: " + e);
+      if (session.getLogger().isEnabled(Logger.ERROR)) {
+        session.getLogger().log(Logger.ERROR, "getFingerPrint: " + e.getMessage(), e);
+      }
     }
     return Util.getFingerPrint(hash, getHostKey(), true, false);
   }
@@ -274,7 +276,7 @@ public abstract class KeyExchange {
         sig = c.getDeclaredConstructor().newInstance();
         sig.init();
       } catch (Exception e) {
-        System.err.println(e);
+        throw new JSchException(e.toString(), e);
       }
       sig.setPubKey(ee, n);
       sig.update(H);
@@ -325,7 +327,7 @@ public abstract class KeyExchange {
         sig = c.getDeclaredConstructor().newInstance();
         sig.init();
       } catch (Exception e) {
-        System.err.println(e);
+        throw new JSchException(e.toString(), e);
       }
       sig.setPubKey(f, p, q, g);
       sig.update(H);
@@ -368,7 +370,7 @@ public abstract class KeyExchange {
         sig = c.getDeclaredConstructor().newInstance();
         sig.init();
       } catch (Exception e) {
-        System.err.println(e);
+        throw new JSchException(e.toString(), e);
       }
 
       sig.setPubKey(r, s);
@@ -400,7 +402,7 @@ public abstract class KeyExchange {
         sig = c.getDeclaredConstructor().newInstance();
         sig.init();
       } catch (Exception | NoClassDefFoundError e) {
-        System.err.println(e);
+        throw new JSchException(e.toString(), e);
       }
 
       sig.setPubKey(tmp);
@@ -413,7 +415,9 @@ public abstract class KeyExchange {
         session.getLogger().log(Logger.INFO, "ssh_eddsa_verify: " + alg + " signature " + result);
       }
     } else {
-      System.err.println("unknown alg");
+      if (session.getLogger().isEnabled(Logger.ERROR)) {
+        session.getLogger().log(Logger.ERROR, "unknown alg: " + alg);
+      }
     }
 
     return result;

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -249,9 +249,9 @@ public abstract class KeyPair {
    */
   public void writePublicKey(String name, String comment)
       throws FileNotFoundException, IOException {
-    FileOutputStream fos = new FileOutputStream(name);
-    writePublicKey(fos, comment);
-    fos.close();
+    try (OutputStream fos = new FileOutputStream(name)) {
+      writePublicKey(fos, comment);
+    }
   }
 
   /**
@@ -297,9 +297,9 @@ public abstract class KeyPair {
    */
   public void writeSECSHPublicKey(String name, String comment)
       throws FileNotFoundException, IOException {
-    FileOutputStream fos = new FileOutputStream(name);
-    writeSECSHPublicKey(fos, comment);
-    fos.close();
+    try (OutputStream fos = new FileOutputStream(name)) {
+      writeSECSHPublicKey(fos, comment);
+    }
   }
 
   /**
@@ -321,9 +321,9 @@ public abstract class KeyPair {
    */
   public void writePrivateKey(String name, byte[] passphrase)
       throws FileNotFoundException, IOException {
-    FileOutputStream fos = new FileOutputStream(name);
-    writePrivateKey(fos, passphrase);
-    fos.close();
+    try (OutputStream fos = new FileOutputStream(name)) {
+      writePrivateKey(fos, passphrase);
+    }
   }
 
   /**

--- a/src/main/java/com/jcraft/jsch/KnownHosts.java
+++ b/src/main/java/com/jcraft/jsch/KnownHosts.java
@@ -54,7 +54,7 @@ class KnownHosts implements HostKeyRepository {
   void setKnownHosts(String filename) throws JSchException {
     try {
       known_hosts = filename;
-      FileInputStream fis = new FileInputStream(Util.checkTilde(filename));
+      InputStream fis = new FileInputStream(Util.checkTilde(filename));
       setKnownHosts(fis);
     } catch (FileNotFoundException e) {
       // The non-existing file should be allowed.
@@ -67,8 +67,7 @@ class KnownHosts implements HostKeyRepository {
     byte i;
     int j;
     boolean error = false;
-    try {
-      InputStream fis = input;
+    try (InputStream fis = input) {
       String host;
       String key = null;
       int type;
@@ -265,12 +264,6 @@ class KnownHosts implements HostKeyRepository {
       if (e instanceof JSchException)
         throw (JSchException) e;
       throw new JSchException(e.toString(), e);
-    } finally {
-      try {
-        input.close();
-      } catch (IOException e) {
-        throw new JSchException(e.toString(), e);
-      }
     }
   }
 

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -1554,7 +1554,7 @@ public class Session {
           }
           command = packet.buffer.getCommand();
           recipient = c.getRecipient();
-          length -= len;
+          length -= (int) len;
           c.rwsize -= len;
           sendit = true;
         }

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -379,16 +379,16 @@ public class Session {
       boolean auth = false;
       boolean auth_cancel = false;
 
-      UserAuth ua = null;
+      UserAuthNone uan = null;
       try {
-        Class<? extends UserAuth> c =
-            Class.forName(getConfig("userauth.none")).asSubclass(UserAuth.class);
-        ua = c.getDeclaredConstructor().newInstance();
+        Class<? extends UserAuthNone> c =
+            Class.forName(getConfig("userauth.none")).asSubclass(UserAuthNone.class);
+        uan = c.getDeclaredConstructor().newInstance();
       } catch (Exception e) {
         throw new JSchException(e.toString(), e);
       }
 
-      auth = ua.start(this);
+      auth = uan.start(this);
 
       String cmethods = getConfig("PreferredAuthentications");
 
@@ -396,12 +396,12 @@ public class Session {
 
       String smethods = null;
       if (!auth) {
-        smethods = ((UserAuthNone) ua).getMethods();
+        smethods = uan.getMethods();
         if (smethods != null) {
           smethods = smethods.toLowerCase();
         } else {
           // methods: publickey,password,keyboard-interactive
-          // smethods="publickey,password,keyboard-interactive";
+          // smethods = "publickey,password,keyboard-interactive";
           smethods = cmethods;
         }
       }
@@ -426,7 +426,7 @@ public class Session {
             continue;
           }
 
-          // System.err.println(" method: "+method);
+          // System.err.println(" method: " + method);
 
           if (getLogger().isEnabled(Logger.INFO)) {
             String str = "Authentications that can continue: ";
@@ -439,7 +439,7 @@ public class Session {
             getLogger().log(Logger.INFO, "Next authentication method: " + method);
           }
 
-          ua = null;
+          UserAuth ua = null;
           try {
             Class<? extends UserAuth> c = null;
             if (getConfig("userauth." + method) != null) {
@@ -468,7 +468,7 @@ public class Session {
               if (!tmp.equals(smethods)) {
                 methodi = 0;
               }
-              // System.err.println("PartialAuth: "+methods);
+              // System.err.println("PartialAuth: " + methods);
               auth_cancel = false;
               continue loop;
             } catch (RuntimeException ee) {
@@ -476,8 +476,8 @@ public class Session {
             } catch (JSchException ee) {
               throw ee;
             } catch (Exception ee) {
-              // System.err.println("ee: "+ee); // SSH_MSG_DISCONNECT: 2 Too many authentication
-              // failures
+              // SSH_MSG_DISCONNECT: Too many authentication failures
+              // System.err.println("ee: " + ee);
               if (getLogger().isEnabled(Logger.WARN)) {
                 getLogger().log(Logger.WARN,
                     "an exception during authentication\n" + ee.toString());

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -1185,7 +1185,9 @@ public class Session {
           buf.buffer = foo;
           buf.index = 5 + uncompress_len[0];
         } else {
-          System.err.println("fail in inflater");
+          if (getLogger().isEnabled(Logger.ERROR)) {
+            getLogger().log(Logger.ERROR, "fail in inflater");
+          }
           break;
         }
       }
@@ -1324,7 +1326,7 @@ public class Session {
     } catch (IOException e) {
       ioe = e;
       if (getLogger().isEnabled(Logger.ERROR)) {
-        getLogger().log(Logger.ERROR, "start_discard finished early due to " + e.getMessage());
+        getLogger().log(Logger.ERROR, "start_discard finished early due to " + e.getMessage(), e);
       }
     }
 

--- a/src/main/java/com/jcraft/jsch/Util.java
+++ b/src/main/java/com/jcraft/jsch/Util.java
@@ -29,6 +29,7 @@ package com.jcraft.jsch;
 import java.net.Socket;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -512,8 +513,7 @@ class Util {
   static byte[] fromFile(String _file) throws IOException {
     _file = checkTilde(_file);
     File file = new File(_file);
-    FileInputStream fis = new FileInputStream(_file);
-    try {
+    try (InputStream fis = new FileInputStream(_file)) {
       byte[] result = new byte[(int) (file.length())];
       int len = 0;
       while (true) {
@@ -522,11 +522,7 @@ class Util {
           break;
         len += i;
       }
-      fis.close();
       return result;
-    } finally {
-      if (fis != null)
-        fis.close();
     }
   }
 

--- a/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
+++ b/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
@@ -325,7 +325,7 @@ public class BCrypt {
       if (c1 == -1 || c2 == -1)
         break;
       o = (byte) (c1 << 2);
-      o |= (c2 & 0x30) >> 4;
+      o |= (byte) ((c2 & 0x30) >> 4);
       rs.append((char) o);
       if (++olen >= maxolen || off >= slen)
         break;
@@ -333,7 +333,7 @@ public class BCrypt {
       if (c3 == -1)
         break;
       o = (byte) ((c2 & 0x0f) << 4);
-      o |= (c3 & 0x3c) >> 2;
+      o |= (byte) ((c3 & 0x3c) >> 2);
       rs.append((char) o);
       if (++olen >= maxolen || off >= slen)
         break;
@@ -710,7 +710,7 @@ public class BCrypt {
       return false;
     byte ret = 0;
     for (int i = 0; i < try_bytes.length; i++)
-      ret |= hashed_bytes[i] ^ try_bytes[i];
+      ret |= (byte) (hashed_bytes[i] ^ try_bytes[i]);
     return ret == 0;
   }
 }

--- a/src/main/java/com/jcraft/jsch/jce/HMAC.java
+++ b/src/main/java/com/jcraft/jsch/jce/HMAC.java
@@ -26,6 +26,8 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Logger;
 import com.jcraft.jsch.MAC;
 import javax.crypto.*;
 import javax.crypto.spec.*;
@@ -75,7 +77,9 @@ abstract class HMAC implements MAC {
     try {
       mac.doFinal(buf, offset);
     } catch (ShortBufferException e) {
-      System.err.println(e);
+      if (JSch.getLogger().isEnabled(Logger.ERROR)) {
+        JSch.getLogger().log(Logger.ERROR, e.getMessage(), e);
+      }
     }
   }
 

--- a/src/main/java/com/jcraft/jsch/jce/KeyPairGenEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/KeyPairGenEdDSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ * Copyright (c) 2002-2018 ymnk, JCraft,Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
@@ -26,29 +26,24 @@
 
 package com.jcraft.jsch.jce;
 
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
+public class KeyPairGenEdDSA implements com.jcraft.jsch.KeyPairGenEdDSA {
 
-public class KeyPairGenXEC implements com.jcraft.jsch.KeyPairGenXEC {
-  XECPublicKey pubKey;
-  XECPrivateKey prvKey;
+  public KeyPairGenEdDSA() {
+    throw new UnsupportedOperationException("KeyPairGenEdDSA requires Java15+.");
+  }
 
   @Override
-  public void init(String name) throws Exception {
-    KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
-    NamedParameterSpec paramSpec = new NamedParameterSpec(name);
-    kpg.initialize(paramSpec);
-    KeyPair kp = kpg.genKeyPair();
-    prvKey = (XECPrivateKey) kp.getPrivate();
-    pubKey = (XECPublicKey) kp.getPublic();
+  public void init(String name, int keylen) throws Exception {
+    throw new UnsupportedOperationException("KeyPairGenEdDSA requires Java15+.");
   }
 
-  XECPublicKey getPublicKey() {
-    return pubKey;
+  @Override
+  public byte[] getPrv() {
+    throw new UnsupportedOperationException("KeyPairGenEdDSA requires Java15+.");
   }
 
-  XECPrivateKey getPrivateKey() {
-    return prvKey;
+  @Override
+  public byte[] getPub() {
+    throw new UnsupportedOperationException("KeyPairGenEdDSA requires Java15+.");
   }
 }

--- a/src/main/java/com/jcraft/jsch/jce/MD5.java
+++ b/src/main/java/com/jcraft/jsch/jce/MD5.java
@@ -40,11 +40,7 @@ public class MD5 implements HASH {
 
   @Override
   public void init() throws Exception {
-    try {
-      md = MessageDigest.getInstance("MD5");
-    } catch (Exception e) {
-      System.err.println(e);
-    }
+    md = MessageDigest.getInstance("MD5");
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SHA1.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA1.java
@@ -40,11 +40,7 @@ public class SHA1 implements HASH {
 
   @Override
   public void init() throws Exception {
-    try {
-      md = MessageDigest.getInstance("SHA-1");
-    } catch (Exception e) {
-      System.err.println(e);
-    }
+    md = MessageDigest.getInstance("SHA-1");
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SHA224.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA224.java
@@ -40,11 +40,7 @@ public class SHA224 implements HASH {
 
   @Override
   public void init() throws Exception {
-    try {
-      md = MessageDigest.getInstance("SHA-224");
-    } catch (Exception e) {
-      System.err.println(e);
-    }
+    md = MessageDigest.getInstance("SHA-224");
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SHA256.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA256.java
@@ -40,11 +40,7 @@ public class SHA256 implements HASH {
 
   @Override
   public void init() throws Exception {
-    try {
-      md = MessageDigest.getInstance("SHA-256");
-    } catch (Exception e) {
-      System.err.println(e);
-    }
+    md = MessageDigest.getInstance("SHA-256");
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SHA384.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA384.java
@@ -38,11 +38,7 @@ public class SHA384 implements com.jcraft.jsch.HASH {
 
   @Override
   public void init() throws Exception {
-    try {
-      md = MessageDigest.getInstance("SHA-384");
-    } catch (Exception e) {
-      System.err.println(e);
-    }
+    md = MessageDigest.getInstance("SHA-384");
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SHA512.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA512.java
@@ -38,11 +38,7 @@ public class SHA512 implements com.jcraft.jsch.HASH {
 
   @Override
   public void init() throws Exception {
-    try {
-      md = MessageDigest.getInstance("SHA-512");
-    } catch (Exception e) {
-      System.err.println(e);
-    }
+    md = MessageDigest.getInstance("SHA-512");
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
@@ -131,15 +131,15 @@ public class SignatureDSA implements com.jcraft.jsch.SignatureDSA {
     tmp = new byte[length];
     tmp[0] = (byte) 0x30;
     tmp[1] = (byte) (_frst.length + _scnd.length + 4);
-    tmp[1] += frst;
-    tmp[1] += scnd;
+    tmp[1] += (byte) frst;
+    tmp[1] += (byte) scnd;
     tmp[2] = (byte) 0x02;
     tmp[3] = (byte) _frst.length;
-    tmp[3] += frst;
+    tmp[3] += (byte) frst;
     System.arraycopy(_frst, 0, tmp, 4 + frst, _frst.length);
     tmp[4 + tmp[3]] = (byte) 0x02;
     tmp[5 + tmp[3]] = (byte) _scnd.length;
-    tmp[5 + tmp[3]] += scnd;
+    tmp[5 + tmp[3]] += (byte) scnd;
     System.arraycopy(_scnd, 0, tmp, 6 + tmp[3] + scnd, _scnd.length);
     sig = tmp;
 

--- a/src/main/java/com/jcraft/jsch/jce/SignatureEd25519.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureEd25519.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+public class SignatureEd25519 implements com.jcraft.jsch.SignatureEdDSA {
+
+  public SignatureEd25519() {
+    throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");
+  }
+
+  @Override
+  public void init() throws Exception {
+    throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");
+  }
+
+  @Override
+  public void setPubKey(byte[] y_arr) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");
+  }
+
+  @Override
+  public void setPrvKey(byte[] bytes) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");
+  }
+
+  @Override
+  public byte[] sign() throws Exception {
+    throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");
+  }
+
+  @Override
+  public void update(byte[] foo) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");
+  }
+
+  @Override
+  public boolean verify(byte[] sig) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");
+  }
+}

--- a/src/main/java/com/jcraft/jsch/jce/SignatureEd448.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureEd448.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+public class SignatureEd448 implements com.jcraft.jsch.SignatureEdDSA {
+
+  public SignatureEd448() {
+    throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");
+  }
+
+  @Override
+  public void init() throws Exception {
+    throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");
+  }
+
+  @Override
+  public void setPubKey(byte[] y_arr) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");
+  }
+
+  @Override
+  public void setPrvKey(byte[] bytes) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");
+  }
+
+  @Override
+  public byte[] sign() throws Exception {
+    throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");
+  }
+
+  @Override
+  public void update(byte[] foo) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");
+  }
+
+  @Override
+  public boolean verify(byte[] sig) throws Exception {
+    throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");
+  }
+}

--- a/src/main/java/com/jcraft/jsch/jce/XDH.java
+++ b/src/main/java/com/jcraft/jsch/jce/XDH.java
@@ -24,8 +24,31 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.jcraft.jsch;
+package com.jcraft.jsch.jce;
 
-public interface KeyPairGenXEC {
-  void init(String name) throws Exception;
+public class XDH implements com.jcraft.jsch.XDH {
+
+  public XDH() {
+    throw new UnsupportedOperationException("XDH requires Java11+.");
+  }
+
+  @Override
+  public void init(String name, int keylen) throws Exception {
+    throw new UnsupportedOperationException("XDH requires Java11+.");
+  }
+
+  @Override
+  public byte[] getQ() throws Exception {
+    throw new UnsupportedOperationException("XDH requires Java11+.");
+  }
+
+  @Override
+  public byte[] getSecret(byte[] Q) throws Exception {
+    throw new UnsupportedOperationException("XDH requires Java11+.");
+  }
+
+  @Override
+  public boolean validate(byte[] u) throws Exception {
+    throw new UnsupportedOperationException("XDH requires Java11+.");
+  }
 }

--- a/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
@@ -435,7 +435,7 @@ final class Deflate implements Cloneable {
       if (++count < max_count && curlen == nextlen) {
         continue;
       } else if (count < min_count) {
-        bl_tree[curlen * 2] += count;
+        bl_tree[curlen * 2] += (short) count;
       } else if (curlen != 0) {
         if (curlen != prevlen)
           bl_tree[curlen * 2]++;
@@ -591,13 +591,13 @@ final class Deflate implements Cloneable {
     if (bi_valid > Buf_size - len) {
       int val = value;
       // bi_buf |= (val << bi_valid);
-      bi_buf |= ((val << bi_valid) & 0xffff);
+      bi_buf |= (short) ((val << bi_valid) & 0xffff);
       put_short(bi_buf);
       bi_buf = (short) (val >>> (Buf_size - bi_valid));
       bi_valid += len - Buf_size;
     } else {
       // bi_buf |= (value) << bi_valid;
-      bi_buf |= (((value) << bi_valid) & 0xffff);
+      bi_buf |= (short) (((value) << bi_valid) & 0xffff);
       bi_valid += len;
     }
   }
@@ -659,7 +659,7 @@ final class Deflate implements Cloneable {
       int in_length = strstart - block_start;
       int dcode;
       for (dcode = 0; dcode < D_CODES; dcode++) {
-        out_length += (int) dyn_dtree[dcode * 2] * (5L + Tree.extra_dbits[dcode]);
+        out_length += (int) dyn_dtree[dcode * 2] * (5 + Tree.extra_dbits[dcode]);
       }
       out_length >>>= 3;
       if ((matches < (last_lit / 2)) && out_length < in_length / 2)

--- a/src/main/java/com/jcraft/jsch/jzlib/Tree.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Tree.java
@@ -205,7 +205,7 @@ final class Tree {
         if (m > max_code)
           continue;
         if (tree[m * 2 + 1] != bits) {
-          s.opt_len += ((long) bits - (long) tree[m * 2 + 1]) * (long) tree[m * 2];
+          s.opt_len += (int) (((long) bits - (long) tree[m * 2 + 1]) * (long) tree[m * 2]);
           tree[m * 2 + 1] = (short) bits;
         }
         n--;

--- a/src/main/java11/com/jcraft/jsch/jce/XDH.java
+++ b/src/main/java11/com/jcraft/jsch/jce/XDH.java
@@ -27,11 +27,11 @@
 package com.jcraft.jsch.jce;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.security.*;
-import javax.crypto.*;
 import java.security.spec.*;
 import java.security.interfaces.*;
+import java.util.Arrays;
+import javax.crypto.*;
 
 public class XDH implements com.jcraft.jsch.XDH {
   byte[] Q_array;
@@ -44,11 +44,13 @@ public class XDH implements com.jcraft.jsch.XDH {
   public void init(String name, int keylen) throws Exception {
     this.keylen = keylen;
     myKeyAgree = KeyAgreement.getInstance("XDH");
-    KeyPairGenXEC kpair = new KeyPairGenXEC();
-    kpair.init(name);
-    publicKey = kpair.getPublicKey();
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
+    NamedParameterSpec paramSpec = new NamedParameterSpec(name);
+    kpg.initialize(paramSpec);
+    KeyPair kp = kpg.genKeyPair();
+    publicKey = (XECPublicKey) kp.getPublic();
     Q_array = rotate(publicKey.getU().toByteArray());
-    myKeyAgree.init(kpair.getPrivateKey());
+    myKeyAgree.init(kp.getPrivate());
   }
 
   @Override

--- a/src/main/java15/com/jcraft/jsch/jce/KeyPairGenEdDSA.java
+++ b/src/main/java15/com/jcraft/jsch/jce/KeyPairGenEdDSA.java
@@ -50,7 +50,7 @@ public class KeyPairGenEdDSA implements com.jcraft.jsch.KeyPairGenEdDSA {
     prv = prvKey.getBytes().get();
     pub = rotate(point.getY().toByteArray());
     if (point.isXOdd()) {
-      pub[pub.length - 1] |= 0x80;
+      pub[pub.length - 1] |= (byte) 0x80;
     }
   }
 

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,7 +1,7 @@
 module com.jcraft.jsch {
     exports com.jcraft.jsch;
 
-    requires java.security.jgss;
+    requires static java.security.jgss;
     requires static java.logging;
     requires static org.apache.logging.log4j;
     requires static org.slf4j;


### PR DESCRIPTION
- #293 allow UserAuthNone to be extended.
- Make JGSS module optional.
- Update dependencies.
- Tweak OSGi bundle manifest:
  - Avoid self-import.
  - Avoid `uses:="com.sun.jna"` on export.
  - Mark JGSS as optional.
  - Loosen import versions of dependencies.
- Correctly adhere to the Multi-release JAR spec by ensuring all public classes under versioned directories preside over classes present in the top-level directory.
- Eliminate stray `System.err.println()` calls.
- Use failOnWarning instead of directly passing -Werror.
- Change PageantConnector to use JNA's built-in support for `User32.SendMessage()`.
- Remove now uneeded `_nouses` now that PageantConnector no longer exposes JNA.
- Fix warnings with Java 20.
- Add error_prone_annotations to dependencyManagement to keep aligned with errorprone profile version.
- Add missing java10 source directory.
- Use try-with-resources.