### PR TITLE
Make OSGi dependencies optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,10 +403,10 @@
                     <instructions>
                         <Export-Package>com.jcraft.jsch;-noimport:=true</Export-Package>
                         <Import-Package><![CDATA[
-                            com.sun.jna*;version="${range;[=0,+)}",
-                            org.apache.logging.log4j*;version="${range;[=0,+)}",
-                            org.bouncycastle*;version="[1.69,${versionmask;+})",
-                            org.slf4j*;version="[1.7,${versionmask;+})",
+                            com.sun.jna*;resolution:=optional;version="${range;[=0,+)}",
+                            org.apache.logging.log4j*;resolution:=optional;version="${range;[=0,+)}",
+                            org.bouncycastle*;resolution:=optional;version="[1.69,${versionmask;+})",
+                            org.slf4j*;resolution:=optional;version="[1.7,${versionmask;+})",
                             org.ietf.jgss;resolution:=optional,
                             *
                             ]]></Import-Package>


### PR DESCRIPTION
This will make it possible to use the jsch artifact as an OSGi module without another OSGi module(s) providing optional dependencies. All those dependencies are already marked as optional in the JPMS module-info.java file: https://github.com/mwiede/jsch/blob/master/src/main/java9/module-info.java. They should be also optional in the OSGi environment.

This PR will also allow using the Jsch as a dependency in Eclipse GlassFish, without repackaging it into a different OSGi package. With this merged into the upstream project, the following PR won't be necessary:  https://github.com/eclipse-ee4j/glassfish-repackaged/pull/21