### PR TITLE
0.2.10 changes

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 * [0.2.10](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.10)
   * Fix new Java 21 compiler warning: `possible 'this' escape before subclass is fully initialized`.
+  * Tweak OSGi bundle manifest to allow Log4j 3.
 * [0.2.9](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.9)
   * [#293](https://github.com/mwiede/jsch/issues/293) allow UserAuthNone to be extended.
   * Make JGSS module optional.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+* [0.2.10](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.10)
+  * Fix new Java 21 compiler warning: `possible 'this' escape before subclass is fully initialized`.
 * [0.2.9](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.9)
   * [#293](https://github.com/mwiede/jsch/issues/293) allow UserAuthNone to be extended.
   * Make JGSS module optional.

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
-            <version>2.9.0</version>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
                         <Export-Package>com.jcraft.jsch;-noimport:=true</Export-Package>
                         <Import-Package><![CDATA[
                             com.sun.jna*;version="${range;[=0,+)}",
-                            org.apache.logging.log4j*;version="${range;[=0,+)}",
+                            org.apache.logging.log4j*;version="${range;[=0,4)}",
                             org.bouncycastle*;version="[1.69,${versionmask;+})",
                             org.slf4j*;version="[1.7,${versionmask;+})",
                             org.ietf.jgss;resolution:=optional,

--- a/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
+++ b/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
@@ -66,9 +66,9 @@ class ChannelAgentForwarding extends Channel {
   ChannelAgentForwarding() {
     super();
 
-    setLocalWindowSizeMax(LOCAL_WINDOW_SIZE_MAX);
-    setLocalWindowSize(LOCAL_WINDOW_SIZE_MAX);
-    setLocalPacketSize(LOCAL_MAXIMUM_PACKET_SIZE);
+    lwsize_max = LOCAL_WINDOW_SIZE_MAX;
+    lwsize = LOCAL_WINDOW_SIZE_MAX;
+    lmpsize = LOCAL_MAXIMUM_PACKET_SIZE;
 
     type = Util.str2byte("auth-agent@openssh.com");
     rbuf = new Buffer();

--- a/src/main/java/com/jcraft/jsch/ChannelDirectStreamLocal.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectStreamLocal.java
@@ -18,9 +18,9 @@ public class ChannelDirectStreamLocal extends ChannelDirectTCPIP {
   ChannelDirectStreamLocal() {
     super();
     type = _type;
-    setLocalWindowSizeMax(LOCAL_WINDOW_SIZE_MAX);
-    setLocalWindowSize(LOCAL_WINDOW_SIZE_MAX);
-    setLocalPacketSize(LOCAL_MAXIMUM_PACKET_SIZE);
+    lwsize_max = LOCAL_WINDOW_SIZE_MAX;
+    lwsize = LOCAL_WINDOW_SIZE_MAX;
+    lmpsize = LOCAL_MAXIMUM_PACKET_SIZE;
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
@@ -42,9 +42,9 @@ public class ChannelDirectTCPIP extends Channel {
   ChannelDirectTCPIP() {
     super();
     type = _type;
-    setLocalWindowSizeMax(LOCAL_WINDOW_SIZE_MAX);
-    setLocalWindowSize(LOCAL_WINDOW_SIZE_MAX);
-    setLocalPacketSize(LOCAL_MAXIMUM_PACKET_SIZE);
+    lwsize_max = LOCAL_WINDOW_SIZE_MAX;
+    lwsize = LOCAL_WINDOW_SIZE_MAX;
+    lmpsize = LOCAL_MAXIMUM_PACKET_SIZE;
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
@@ -46,9 +46,9 @@ public class ChannelForwardedTCPIP extends Channel {
 
   ChannelForwardedTCPIP() {
     super();
-    setLocalWindowSizeMax(LOCAL_WINDOW_SIZE_MAX);
-    setLocalWindowSize(LOCAL_WINDOW_SIZE_MAX);
-    setLocalPacketSize(LOCAL_MAXIMUM_PACKET_SIZE);
+    lwsize_max = LOCAL_WINDOW_SIZE_MAX;
+    lwsize = LOCAL_WINDOW_SIZE_MAX;
+    lmpsize = LOCAL_MAXIMUM_PACKET_SIZE;
     io = new IO();
     connected = true;
   }

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -183,9 +183,9 @@ public class ChannelSftp extends ChannelSession {
 
   public ChannelSftp() {
     super();
-    setLocalWindowSizeMax(LOCAL_WINDOW_SIZE_MAX);
-    setLocalWindowSize(LOCAL_WINDOW_SIZE_MAX);
-    setLocalPacketSize(LOCAL_MAXIMUM_PACKET_SIZE);
+    lwsize_max = LOCAL_WINDOW_SIZE_MAX;
+    lwsize = LOCAL_WINDOW_SIZE_MAX;
+    lmpsize = LOCAL_MAXIMUM_PACKET_SIZE;
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/ChannelX11.java
+++ b/src/main/java/com/jcraft/jsch/ChannelX11.java
@@ -114,9 +114,9 @@ class ChannelX11 extends Channel {
   ChannelX11() {
     super();
 
-    setLocalWindowSizeMax(LOCAL_WINDOW_SIZE_MAX);
-    setLocalWindowSize(LOCAL_WINDOW_SIZE_MAX);
-    setLocalPacketSize(LOCAL_MAXIMUM_PACKET_SIZE);
+    lwsize_max = LOCAL_WINDOW_SIZE_MAX;
+    lwsize = LOCAL_WINDOW_SIZE_MAX;
+    lmpsize = LOCAL_MAXIMUM_PACKET_SIZE;
 
     type = Util.str2byte("x11");
 

--- a/src/main/java/com/jcraft/jsch/IdentityFile.java
+++ b/src/main/java/com/jcraft/jsch/IdentityFile.java
@@ -29,24 +29,23 @@ package com.jcraft.jsch;
 import java.io.*;
 
 class IdentityFile implements Identity {
-  private JSch jsch;
   private KeyPair kpair;
   private String identity;
 
-  static IdentityFile newInstance(String prvfile, String pubfile, JSch jsch) throws JSchException {
-    KeyPair kpair = KeyPair.load(jsch, prvfile, pubfile);
-    return new IdentityFile(jsch, prvfile, kpair);
-  }
-
-  static IdentityFile newInstance(String name, byte[] prvkey, byte[] pubkey, JSch jsch)
+  static IdentityFile newInstance(String prvfile, String pubfile, JSch.InstanceLogger instLogger)
       throws JSchException {
-
-    KeyPair kpair = KeyPair.load(jsch, prvkey, pubkey);
-    return new IdentityFile(jsch, name, kpair);
+    KeyPair kpair = KeyPair.load(instLogger, prvfile, pubfile);
+    return new IdentityFile(prvfile, kpair);
   }
 
-  private IdentityFile(JSch jsch, String name, KeyPair kpair) throws JSchException {
-    this.jsch = jsch;
+  static IdentityFile newInstance(String name, byte[] prvkey, byte[] pubkey,
+      JSch.InstanceLogger instLogger) throws JSchException {
+
+    KeyPair kpair = KeyPair.load(instLogger, prvkey, pubkey);
+    return new IdentityFile(name, kpair);
+  }
+
+  private IdentityFile(String name, KeyPair kpair) throws JSchException {
     this.identity = name;
     this.kpair = kpair;
   }

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -242,9 +242,11 @@ public class JSch {
     config.put("ClearAllForwardings", "no");
   }
 
+  final InstanceLogger instLogger = new InstanceLogger();
+
   private Vector<Session> sessionPool = new Vector<>();
 
-  private IdentityRepository defaultIdentityRepository = new LocalIdentityRepository(this);
+  private IdentityRepository defaultIdentityRepository = new LocalIdentityRepository(instLogger);
 
   private IdentityRepository identityRepository = defaultIdentityRepository;
 
@@ -291,7 +293,6 @@ public class JSch {
     public void log(int level, String message) {}
   };
   static Logger logger = DEVNULL;
-  private Logger instLogger;
 
   public JSch() {}
 
@@ -480,7 +481,7 @@ public class JSch {
    * @see #addIdentity(String prvkey, String pubkey, byte[] passphrase)
    */
   public void addIdentity(String prvkey, byte[] passphrase) throws JSchException {
-    Identity identity = IdentityFile.newInstance(prvkey, null, this);
+    Identity identity = IdentityFile.newInstance(prvkey, null, instLogger);
     addIdentity(identity, passphrase);
   }
 
@@ -495,7 +496,7 @@ public class JSch {
    * @throws JSchException if <code>passphrase</code> is not right.
    */
   public void addIdentity(String prvkey, String pubkey, byte[] passphrase) throws JSchException {
-    Identity identity = IdentityFile.newInstance(prvkey, pubkey, this);
+    Identity identity = IdentityFile.newInstance(prvkey, pubkey, instLogger);
     addIdentity(identity, passphrase);
   }
 
@@ -511,7 +512,7 @@ public class JSch {
    */
   public void addIdentity(String name, byte[] prvkey, byte[] pubkey, byte[] passphrase)
       throws JSchException {
-    Identity identity = IdentityFile.newInstance(name, prvkey, pubkey, this);
+    Identity identity = IdentityFile.newInstance(name, prvkey, pubkey, instLogger);
     addIdentity(identity, passphrase);
   }
 
@@ -669,10 +670,7 @@ public class JSch {
    *         statically set logger is returned.
    */
   public Logger getInstanceLogger() {
-    if (this.instLogger == null) {
-      return logger;
-    }
-    return instLogger;
+    return instLogger.getLogger();
   }
 
   /**
@@ -682,7 +680,7 @@ public class JSch {
    *        used
    */
   public void setInstanceLogger(Logger logger) {
-    this.instLogger = logger;
+    instLogger.setLogger(logger);
   }
 
   /**
@@ -693,5 +691,22 @@ public class JSch {
    */
   public static Logger getLogger() {
     return logger;
+  }
+
+  static class InstanceLogger {
+    private Logger logger;
+
+    private InstanceLogger() {}
+
+    Logger getLogger() {
+      if (logger == null) {
+        return JSch.logger;
+      }
+      return logger;
+    }
+
+    void setLogger(Logger logger) {
+      this.logger = logger;
+    }
   }
 }

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -117,10 +117,6 @@ public abstract class KeyPair {
 
   private byte[] passphrase;
 
-  public KeyPair(JSch jsch) {
-    this(jsch.instLogger);
-  }
-
   KeyPair(JSch.InstanceLogger instLogger) {
     this.instLogger = instLogger;
   }

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -64,15 +64,15 @@ public abstract class KeyPair {
   public static KeyPair genKeyPair(JSch jsch, int type, int key_size) throws JSchException {
     KeyPair kpair = null;
     if (type == DSA) {
-      kpair = new KeyPairDSA(jsch);
+      kpair = new KeyPairDSA(jsch.instLogger);
     } else if (type == RSA) {
-      kpair = new KeyPairRSA(jsch);
+      kpair = new KeyPairRSA(jsch.instLogger);
     } else if (type == ECDSA) {
-      kpair = new KeyPairECDSA(jsch);
+      kpair = new KeyPairECDSA(jsch.instLogger);
     } else if (type == ED25519) {
-      kpair = new KeyPairEd25519(jsch);
+      kpair = new KeyPairEd25519(jsch.instLogger);
     } else if (type == ED448) {
-      kpair = new KeyPairEd448(jsch);
+      kpair = new KeyPairEd448(jsch.instLogger);
     }
     if (kpair != null) {
       kpair.generate(key_size);
@@ -108,7 +108,7 @@ public abstract class KeyPair {
 
   protected String publicKeyComment = "no comment";
 
-  JSch jsch = null;
+  JSch.InstanceLogger instLogger;
   protected Cipher cipher;
   private KDF kdf;
   private HASH sha1;
@@ -118,7 +118,11 @@ public abstract class KeyPair {
   private byte[] passphrase;
 
   public KeyPair(JSch jsch) {
-    this.jsch = jsch;
+    this(jsch.instLogger);
+  }
+
+  KeyPair(JSch.InstanceLogger instLogger) {
+    this.instLogger = instLogger;
   }
 
   static byte[][] header =
@@ -184,8 +188,8 @@ public abstract class KeyPair {
       out.write(cr);
       // out.close();
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to write private key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to write private key", e);
       }
     }
   }
@@ -234,8 +238,8 @@ public abstract class KeyPair {
       out.write(Util.str2byte(comment));
       out.write(cr);
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to write public key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to write public key", e);
       }
     }
   }
@@ -281,8 +285,8 @@ public abstract class KeyPair {
       out.write(Util.str2byte("---- END SSH2 PUBLIC KEY ----"));
       out.write(cr);
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to write public key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to write public key", e);
       }
     }
   }
@@ -372,8 +376,8 @@ public abstract class KeyPair {
       cipher.init(Cipher.ENCRYPT_MODE, key, iv);
       cipher.update(encoded, 0, encoded.length, encoded, 0);
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to encrypt key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to encrypt key", e);
       }
     }
     Util.bzero(key);
@@ -392,8 +396,8 @@ public abstract class KeyPair {
       cipher.update(data, 0, data.length, plain, 0);
       return plain;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to decrypt key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to decrypt key", e);
       }
     }
     return null;
@@ -463,8 +467,8 @@ public abstract class KeyPair {
             Class.forName(JSch.getConfig("random")).asSubclass(Random.class);
         random = c.getDeclaredConstructor().newInstance();
       } catch (Exception e) {
-        if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-          jsch.getInstanceLogger().log(Logger.ERROR, "failed to create random", e);
+        if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+          instLogger.getLogger().log(Logger.ERROR, "failed to create random", e);
         }
       }
     }
@@ -477,8 +481,8 @@ public abstract class KeyPair {
       hash = c.getDeclaredConstructor().newInstance();
       hash.init();
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to create hash", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to create hash", e);
       }
     }
     return hash;
@@ -490,8 +494,8 @@ public abstract class KeyPair {
           Class.forName(JSch.getConfig("3des-cbc")).asSubclass(Cipher.class);
       cipher = c.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to create cipher", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to create cipher", e);
       }
     }
     return cipher;
@@ -562,8 +566,8 @@ public abstract class KeyPair {
         Util.bzero(tmp);
       }
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to generate key from passphrase", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to generate key from passphrase", e);
       }
     }
     return key;
@@ -637,10 +641,15 @@ public abstract class KeyPair {
     if (!new File(pubkey).exists()) {
       pubkey = null;
     }
-    return load(jsch, prvkey, pubkey);
+    return load(jsch.instLogger, prvkey, pubkey);
   }
 
   public static KeyPair load(JSch jsch, String prvfile, String pubfile) throws JSchException {
+    return load(jsch.instLogger, prvfile, pubfile);
+  }
+
+  static KeyPair load(JSch.InstanceLogger instLogger, String prvfile, String pubfile)
+      throws JSchException {
 
     byte[] prvkey = null;
     byte[] pubkey = null;
@@ -665,13 +674,18 @@ public abstract class KeyPair {
     }
 
     try {
-      return load(jsch, prvkey, pubkey);
+      return load(instLogger, prvkey, pubkey);
     } finally {
       Util.bzero(prvkey);
     }
   }
 
   public static KeyPair load(JSch jsch, byte[] prvkey, byte[] pubkey) throws JSchException {
+    return load(jsch.instLogger, prvkey, pubkey);
+  }
+
+  static KeyPair load(JSch.InstanceLogger instLogger, byte[] prvkey, byte[] pubkey)
+      throws JSchException {
 
     byte[] iv = new byte[8]; // 8
     boolean encrypted = true;
@@ -697,16 +711,16 @@ public abstract class KeyPair {
 
       KeyPair kpair = null;
       if (_type.equals("ssh-rsa")) {
-        kpair = KeyPairRSA.fromSSHAgent(jsch, buf);
+        kpair = KeyPairRSA.fromSSHAgent(instLogger, buf);
       } else if (_type.equals("ssh-dss")) {
-        kpair = KeyPairDSA.fromSSHAgent(jsch, buf);
+        kpair = KeyPairDSA.fromSSHAgent(instLogger, buf);
       } else if (_type.equals("ecdsa-sha2-nistp256") || _type.equals("ecdsa-sha2-nistp384")
           || _type.equals("ecdsa-sha2-nistp521")) {
-        kpair = KeyPairECDSA.fromSSHAgent(jsch, buf);
+        kpair = KeyPairECDSA.fromSSHAgent(instLogger, buf);
       } else if (_type.equals("ssh-ed25519")) {
-        kpair = KeyPairEd25519.fromSSHAgent(jsch, buf);
+        kpair = KeyPairEd25519.fromSSHAgent(instLogger, buf);
       } else if (_type.equals("ssh-ed448")) {
-        kpair = KeyPairEd448.fromSSHAgent(jsch, buf);
+        kpair = KeyPairEd448.fromSSHAgent(instLogger, buf);
       } else {
         throw new JSchException("privatekey: invalid key " + _type);
       }
@@ -717,7 +731,7 @@ public abstract class KeyPair {
       byte[] buf = prvkey;
 
       if (buf != null) {
-        KeyPair ppk = loadPPK(jsch, buf);
+        KeyPair ppk = loadPPK(instLogger, buf);
         if (ppk != null)
           return ppk;
       }
@@ -906,7 +920,7 @@ public abstract class KeyPair {
       }
 
       if (vendor == VENDOR_OPENSSH_V1) {
-        return loadOpenSSHKeyv1(jsch, data);
+        return loadOpenSSHKeyv1(instLogger, data);
       } else if (data != null && data.length > 4 && // FSecure
           data[0] == (byte) 0x3f && data[1] == (byte) 0x6f && data[2] == (byte) 0xf9
           && data[3] == (byte) 0xeb) {
@@ -1077,25 +1091,25 @@ public abstract class KeyPair {
             }
           }
         } catch (Exception ee) {
-          if (jsch.getInstanceLogger().isEnabled(Logger.WARN)) {
-            jsch.getInstanceLogger().log(Logger.WARN, "failed to parse public key", ee);
+          if (instLogger.getLogger().isEnabled(Logger.WARN)) {
+            instLogger.getLogger().log(Logger.WARN, "failed to parse public key", ee);
           }
         }
       }
 
       KeyPair kpair = null;
       if (type == DSA) {
-        kpair = new KeyPairDSA(jsch);
+        kpair = new KeyPairDSA(instLogger);
       } else if (type == RSA) {
-        kpair = new KeyPairRSA(jsch);
+        kpair = new KeyPairRSA(instLogger);
       } else if (type == ECDSA) {
-        kpair = new KeyPairECDSA(jsch, pubkey);
+        kpair = new KeyPairECDSA(instLogger, pubkey);
       } else if (type == ED25519) {
-        kpair = new KeyPairEd25519(jsch, pubkey, null);
+        kpair = new KeyPairEd25519(instLogger, pubkey, null);
       } else if (type == ED448) {
-        kpair = new KeyPairEd448(jsch, pubkey, null);
+        kpair = new KeyPairEd448(instLogger, pubkey, null);
       } else if (vendor == VENDOR_PKCS8) {
-        kpair = new KeyPairPKCS8(jsch);
+        kpair = new KeyPairPKCS8(instLogger);
       }
 
       if (kpair != null) {
@@ -1127,7 +1141,8 @@ public abstract class KeyPair {
     }
   }
 
-  static KeyPair loadOpenSSHKeyv1(JSch jsch, byte[] data) throws JSchException {
+  static KeyPair loadOpenSSHKeyv1(JSch.InstanceLogger instLogger, byte[] data)
+      throws JSchException {
     if (data == null) {
       throw new JSchException("invalid privatekey");
     }
@@ -1149,7 +1164,7 @@ public abstract class KeyPair {
     }
 
     byte[] publickeyblob = buffer.getString();
-    KeyPair kpair = parsePubkeyBlob(jsch, publickeyblob, null);
+    KeyPair kpair = parsePubkeyBlob(instLogger, publickeyblob, null);
     kpair.encrypted = !"none".equals(cipherName);
     kpair.publickeyblob = publickeyblob;
     kpair.vendor = VENDOR_OPENSSH_V1;
@@ -1226,7 +1241,7 @@ public abstract class KeyPair {
     dispose();
   }
 
-  static KeyPair loadPPK(JSch jsch, byte[] buf) throws JSchException {
+  static KeyPair loadPPK(JSch.InstanceLogger instLogger, byte[] buf) throws JSchException {
     byte[] pubkey = null;
     byte[] prvkey = null;
     byte[] _prvkey = null;
@@ -1273,7 +1288,7 @@ public abstract class KeyPair {
       prvkey = Util.fromBase64(_prvkey, 0, _prvkey.length);
       pubkey = Util.fromBase64(pubkey, 0, pubkey.length);
 
-      KeyPair kpair = parsePubkeyBlob(jsch, pubkey, typ);
+      KeyPair kpair = parsePubkeyBlob(instLogger, pubkey, typ);
       kpair.encrypted = !v.get("Encryption").equals("none");
       kpair.publickeyblob = pubkey;
       kpair.vendor = ppkVersion;
@@ -1367,8 +1382,8 @@ public abstract class KeyPair {
     }
   }
 
-  private static KeyPair parsePubkeyBlob(JSch jsch, byte[] pubkeyblob, String typ)
-      throws JSchException {
+  private static KeyPair parsePubkeyBlob(JSch.InstanceLogger instLogger, byte[] pubkeyblob,
+      String typ) throws JSchException {
     Buffer _buf = new Buffer(pubkeyblob);
     _buf.skip(pubkeyblob.length);
 
@@ -1386,7 +1401,7 @@ public abstract class KeyPair {
       byte[] n_array = new byte[_buf.getInt()];
       _buf.getByte(n_array);
 
-      return new KeyPairRSA(jsch, n_array, pub_array, null);
+      return new KeyPairRSA(instLogger, n_array, pub_array, null);
     } else if (typ.equals("ssh-dss")) {
       byte[] p_array = new byte[_buf.getInt()];
       _buf.getByte(p_array);
@@ -1397,7 +1412,7 @@ public abstract class KeyPair {
       byte[] y_array = new byte[_buf.getInt()];
       _buf.getByte(y_array);
 
-      return new KeyPairDSA(jsch, p_array, q_array, g_array, y_array, null);
+      return new KeyPairDSA(instLogger, p_array, q_array, g_array, y_array, null);
     } else if (typ.equals("ecdsa-sha2-nistp256") || typ.equals("ecdsa-sha2-nistp384")
         || typ.equals("ecdsa-sha2-nistp521")) {
       byte[] name = _buf.getString(); // nistpXXX
@@ -1410,15 +1425,15 @@ public abstract class KeyPair {
       _buf.getByte(r_array);
       _buf.getByte(s_array);
 
-      return new KeyPairECDSA(jsch, name, r_array, s_array, null);
+      return new KeyPairECDSA(instLogger, name, r_array, s_array, null);
     } else if (typ.equals("ssh-ed25519") || typ.equals("ssh-ed448")) {
       byte[] pub_array = new byte[_buf.getInt()];
       _buf.getByte(pub_array);
 
       if (typ.equals("ssh-ed25519")) {
-        return new KeyPairEd25519(jsch, pub_array, null);
+        return new KeyPairEd25519(instLogger, pub_array, null);
       } else {
-        return new KeyPairEd448(jsch, pub_array, null);
+        return new KeyPairEd448(instLogger, pub_array, null);
       }
     } else {
       throw new JSchException("key type " + typ + " is not supported");

--- a/src/main/java/com/jcraft/jsch/KeyPairDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairDSA.java
@@ -38,13 +38,13 @@ class KeyPairDSA extends KeyPair {
   // private int key_size=0;
   private int key_size = 1024;
 
-  KeyPairDSA(JSch jsch) {
-    this(jsch, null, null, null, null, null);
+  KeyPairDSA(JSch.InstanceLogger instLogger) {
+    this(instLogger, null, null, null, null, null);
   }
 
-  KeyPairDSA(JSch jsch, byte[] P_array, byte[] Q_array, byte[] G_array, byte[] pub_array,
-      byte[] prv_array) {
-    super(jsch);
+  KeyPairDSA(JSch.InstanceLogger instLogger, byte[] P_array, byte[] Q_array, byte[] G_array,
+      byte[] pub_array, byte[] prv_array) {
+    super(instLogger);
     this.P_array = P_array;
     this.Q_array = Q_array;
     this.G_array = G_array;
@@ -136,8 +136,8 @@ class KeyPairDSA extends KeyPair {
           byte[][] tmp = buf.getBytes(1, "");
           prv_array = tmp[0];
         } catch (JSchException e) {
-          if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-            jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+          if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+            instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
           }
           return false;
         }
@@ -264,8 +264,8 @@ class KeyPairDSA extends KeyPair {
       if (P_array != null)
         key_size = (new BigInteger(P_array)).bitLength();
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
       }
       return false;
     }
@@ -322,8 +322,8 @@ class KeyPairDSA extends KeyPair {
       tmp[1] = sig;
       return Buffer.fromBytes(tmp).buffer;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to generate signature", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to generate signature", e);
       }
     }
     return null;
@@ -354,8 +354,8 @@ class KeyPairDSA extends KeyPair {
       dsa.setPubKey(pub_array, P_array, Q_array, G_array);
       return dsa;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to create verifier", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to create verifier", e);
       }
     }
     return null;
@@ -366,7 +366,7 @@ class KeyPairDSA extends KeyPair {
     return getVerifier();
   }
 
-  static KeyPair fromSSHAgent(JSch jsch, Buffer buf) throws JSchException {
+  static KeyPair fromSSHAgent(JSch.InstanceLogger instLogger, Buffer buf) throws JSchException {
 
     byte[][] tmp = buf.getBytes(7, "invalid key format");
 
@@ -375,7 +375,7 @@ class KeyPairDSA extends KeyPair {
     byte[] G_array = tmp[3];
     byte[] pub_array = tmp[4];
     byte[] prv_array = tmp[5];
-    KeyPairDSA kpair = new KeyPairDSA(jsch, P_array, Q_array, G_array, pub_array, prv_array);
+    KeyPairDSA kpair = new KeyPairDSA(instLogger, P_array, Q_array, G_array, pub_array, prv_array);
     kpair.publicKeyComment = Util.byte2str(tmp[6]);
     kpair.vendor = VENDOR_OPENSSH;
     return kpair;

--- a/src/main/java/com/jcraft/jsch/KeyPairECDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairECDSA.java
@@ -46,12 +46,12 @@ class KeyPairECDSA extends KeyPair {
 
   private int key_size = 256;
 
-  KeyPairECDSA(JSch jsch) {
-    this(jsch, null, null, null, null);
+  KeyPairECDSA(JSch.InstanceLogger instLogger) {
+    this(instLogger, null, null, null, null);
   }
 
-  KeyPairECDSA(JSch jsch, byte[] pubkey) {
-    this(jsch, null, null, null, null);
+  KeyPairECDSA(JSch.InstanceLogger instLogger, byte[] pubkey) {
+    this(instLogger, null, null, null, null);
 
     if (pubkey != null) {
       byte[] name = new byte[8];
@@ -67,8 +67,9 @@ class KeyPairECDSA extends KeyPair {
     }
   }
 
-  KeyPairECDSA(JSch jsch, byte[] name, byte[] r_array, byte[] s_array, byte[] prv_array) {
-    super(jsch);
+  KeyPairECDSA(JSch.InstanceLogger instLogger, byte[] name, byte[] r_array, byte[] s_array,
+      byte[] prv_array) {
+    super(instLogger);
     if (name != null)
       this.name = name;
     this.r_array = r_array;
@@ -166,8 +167,8 @@ class KeyPairECDSA extends KeyPair {
           prv_array = tmp[0];
           key_size = prv_array.length >= 64 ? 521 : (prv_array.length >= 48 ? 384 : 256);
         } catch (JSchException e) {
-          if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-            jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+          if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+            instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
           }
           return false;
         }
@@ -300,8 +301,8 @@ class KeyPairECDSA extends KeyPair {
       if (prv_array != null)
         key_size = prv_array.length >= 64 ? 521 : (prv_array.length >= 48 ? 384 : 256);
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
       }
       return false;
     }
@@ -362,8 +363,8 @@ class KeyPairECDSA extends KeyPair {
       tmp[1] = sig;
       return Buffer.fromBytes(tmp).buffer;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to generate signature", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to generate signature", e);
       }
     }
     return null;
@@ -394,8 +395,8 @@ class KeyPairECDSA extends KeyPair {
       ecdsa.setPubKey(r_array, s_array);
       return ecdsa;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to create verifier", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to create verifier", e);
       }
     }
     return null;
@@ -406,7 +407,7 @@ class KeyPairECDSA extends KeyPair {
     return getVerifier();
   }
 
-  static KeyPair fromSSHAgent(JSch jsch, Buffer buf) throws JSchException {
+  static KeyPair fromSSHAgent(JSch.InstanceLogger instLogger, Buffer buf) throws JSchException {
 
     byte[][] tmp = buf.getBytes(5, "invalid key format");
 
@@ -416,7 +417,7 @@ class KeyPairECDSA extends KeyPair {
     byte[] s_array = foo[1];
 
     byte[] prv_array = tmp[3];
-    KeyPairECDSA kpair = new KeyPairECDSA(jsch, name, r_array, s_array, prv_array);
+    KeyPairECDSA kpair = new KeyPairECDSA(instLogger, name, r_array, s_array, prv_array);
     kpair.publicKeyComment = Util.byte2str(tmp[4]);
     kpair.vendor = VENDOR_OPENSSH;
     return kpair;

--- a/src/main/java/com/jcraft/jsch/KeyPairEd25519.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairEd25519.java
@@ -32,12 +32,12 @@ class KeyPairEd25519 extends KeyPairEdDSA {
 
   private static int keySize = 32;
 
-  KeyPairEd25519(JSch jsch) {
-    this(jsch, null, null);
+  KeyPairEd25519(JSch.InstanceLogger instLogger) {
+    this(instLogger, null, null);
   }
 
-  KeyPairEd25519(JSch jsch, byte[] pub_array, byte[] prv_array) {
-    super(jsch, pub_array, prv_array);
+  KeyPairEd25519(JSch.InstanceLogger instLogger, byte[] pub_array, byte[] prv_array) {
+    super(instLogger, pub_array, prv_array);
   }
 
   @Override
@@ -60,13 +60,13 @@ class KeyPairEd25519 extends KeyPairEdDSA {
     return "Ed25519";
   }
 
-  static KeyPair fromSSHAgent(JSch jsch, Buffer buf) throws JSchException {
+  static KeyPair fromSSHAgent(JSch.InstanceLogger instLogger, Buffer buf) throws JSchException {
 
     byte[][] tmp = buf.getBytes(4, "invalid key format");
 
     byte[] pub_array = tmp[1];
     byte[] prv_array = Arrays.copyOf(tmp[2], keySize);
-    KeyPairEd25519 kpair = new KeyPairEd25519(jsch, pub_array, prv_array);
+    KeyPairEd25519 kpair = new KeyPairEd25519(instLogger, pub_array, prv_array);
     kpair.publicKeyComment = Util.byte2str(tmp[3]);
     kpair.vendor = VENDOR_OPENSSH;
     return kpair;

--- a/src/main/java/com/jcraft/jsch/KeyPairEd448.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairEd448.java
@@ -32,12 +32,12 @@ class KeyPairEd448 extends KeyPairEdDSA {
 
   private static int keySize = 57;
 
-  KeyPairEd448(JSch jsch) {
-    this(jsch, null, null);
+  KeyPairEd448(JSch.InstanceLogger instLogger) {
+    this(instLogger, null, null);
   }
 
-  KeyPairEd448(JSch jsch, byte[] pub_array, byte[] prv_array) {
-    super(jsch, pub_array, prv_array);
+  KeyPairEd448(JSch.InstanceLogger instLogger, byte[] pub_array, byte[] prv_array) {
+    super(instLogger, pub_array, prv_array);
   }
 
   @Override
@@ -60,13 +60,13 @@ class KeyPairEd448 extends KeyPairEdDSA {
     return "Ed448";
   }
 
-  static KeyPair fromSSHAgent(JSch jsch, Buffer buf) throws JSchException {
+  static KeyPair fromSSHAgent(JSch.InstanceLogger instLogger, Buffer buf) throws JSchException {
 
     byte[][] tmp = buf.getBytes(4, "invalid key format");
 
     byte[] pub_array = tmp[1];
     byte[] prv_array = Arrays.copyOf(tmp[2], keySize);
-    KeyPairEd448 kpair = new KeyPairEd448(jsch, pub_array, prv_array);
+    KeyPairEd448 kpair = new KeyPairEd448(instLogger, pub_array, prv_array);
     kpair.publicKeyComment = Util.byte2str(tmp[3]);
     kpair.vendor = VENDOR_OPENSSH;
     return kpair;

--- a/src/main/java/com/jcraft/jsch/KeyPairEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairEdDSA.java
@@ -32,8 +32,8 @@ abstract class KeyPairEdDSA extends KeyPair {
   private byte[] pub_array;
   private byte[] prv_array;
 
-  KeyPairEdDSA(JSch jsch, byte[] pub_array, byte[] prv_array) {
-    super(jsch);
+  KeyPairEdDSA(JSch.InstanceLogger instLogger, byte[] pub_array, byte[] prv_array) {
+    super(instLogger);
     this.pub_array = pub_array;
     this.prv_array = prv_array;
   }
@@ -85,8 +85,8 @@ abstract class KeyPairEdDSA extends KeyPair {
         byte[][] tmp = buf.getBytes(1, "");
         prv_array = tmp[0];
       } catch (JSchException e) {
-        if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-          jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+        if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+          instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
         }
         return false;
       }
@@ -110,8 +110,8 @@ abstract class KeyPairEdDSA extends KeyPair {
         publicKeyComment = Util.byte2str(buf.getString());
         return true;
       } catch (Exception e) {
-        if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-          jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+        if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+          instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
         }
         return false;
       }
@@ -126,14 +126,14 @@ abstract class KeyPairEdDSA extends KeyPair {
         prv_array = keypairgen.getPrv();
         return true;
       } catch (Exception | NoClassDefFoundError e) {
-        if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-          jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+        if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+          instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
         }
         return false;
       }
     } else {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key");
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to parse key");
       }
       return false;
     }
@@ -179,8 +179,8 @@ abstract class KeyPairEdDSA extends KeyPair {
       tmp[1] = sig;
       return Buffer.fromBytes(tmp).buffer;
     } catch (Exception | NoClassDefFoundError e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to generate signature", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to generate signature", e);
       }
     }
     return null;
@@ -208,8 +208,8 @@ abstract class KeyPairEdDSA extends KeyPair {
       eddsa.setPubKey(pub_array);
       return eddsa;
     } catch (Exception | NoClassDefFoundError e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to create verifier", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to create verifier", e);
       }
     }
     return null;

--- a/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
@@ -125,8 +125,8 @@ class KeyPairPKCS8 extends KeyPair {
 
   private KeyPair kpair = null;
 
-  KeyPairPKCS8(JSch jsch) {
-    super(jsch);
+  KeyPairPKCS8(JSch.InstanceLogger instLogger) {
+    super(instLogger);
   }
 
   @Override
@@ -218,7 +218,7 @@ class KeyPairPKCS8 extends KeyPair {
           throw new ASN1Exception();
         }
 
-        _kpair = new KeyPairRSA(jsch);
+        _kpair = new KeyPairRSA(instLogger);
         _kpair.copy(this);
         if (_kpair.parse(_data)) {
           kpair = _kpair;
@@ -306,10 +306,10 @@ class KeyPairPKCS8 extends KeyPair {
         byte[] pub_array = (new BigInteger(G_array))
             .modPow(new BigInteger(prv_array), new BigInteger(P_array)).toByteArray();
 
-        _key = new KeyPairDSA(jsch, P_array, Q_array, G_array, pub_array, prv_array);
+        _key = new KeyPairDSA(instLogger, P_array, Q_array, G_array, pub_array, prv_array);
         _plain = _key.getPrivateKey();
 
-        _kpair = new KeyPairDSA(jsch);
+        _kpair = new KeyPairDSA(instLogger);
         _kpair.copy(this);
         if (_kpair.parse(_plain)) {
           kpair = _kpair;
@@ -408,10 +408,10 @@ class KeyPairPKCS8 extends KeyPair {
         byte[] r_array = tmp[0];
         byte[] s_array = tmp[1];
 
-        _key = new KeyPairECDSA(jsch, name, r_array, s_array, prv_array);
+        _key = new KeyPairECDSA(instLogger, name, r_array, s_array, prv_array);
         _plain = _key.getPrivateKey();
 
-        _kpair = new KeyPairECDSA(jsch);
+        _kpair = new KeyPairECDSA(instLogger);
         _kpair.copy(this);
         if (_kpair.parse(_plain)) {
           kpair = _kpair;
@@ -431,9 +431,9 @@ class KeyPairPKCS8 extends KeyPair {
 
         prv_array = curvePrivateKey.getContent();
         if (Util.array_equals(privateKeyAlgorithmID, ed25519)) {
-          _kpair = new KeyPairEd25519(jsch);
+          _kpair = new KeyPairEd25519(instLogger);
         } else {
-          _kpair = new KeyPairEd448(jsch);
+          _kpair = new KeyPairEd448(instLogger);
         }
         _kpair.copy(this);
         if (_kpair.parse(prv_array)) {
@@ -447,14 +447,14 @@ class KeyPairPKCS8 extends KeyPair {
             "unsupported privateKeyAlgorithm oid: " + Util.toHex(privateKeyAlgorithmID));
       }
     } catch (ASN1Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "PKCS8: failed to parse key: ASN1 parsing error",
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "PKCS8: failed to parse key: ASN1 parsing error",
             e);
       }
       return false;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "PKCS8: failed to parse key: " + e.getMessage(),
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "PKCS8: failed to parse key: " + e.getMessage(),
             e);
       }
       return false;
@@ -766,15 +766,15 @@ class KeyPairPKCS8 extends KeyPair {
         throw new JSchException("failed to parse decrypted key");
       }
     } catch (ASN1Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR,
-            "PKCS8: failed to decrypt key: ASN1 parsing error", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "PKCS8: failed to decrypt key: ASN1 parsing error",
+            e);
       }
       return false;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR,
-            "PKCS8: failed to decrypt key: " + e.getMessage(), e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "PKCS8: failed to decrypt key: " + e.getMessage(),
+            e);
       }
       return false;
     } finally {

--- a/src/main/java/com/jcraft/jsch/KeyPairRSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairRSA.java
@@ -41,12 +41,12 @@ class KeyPairRSA extends KeyPair {
 
   private int key_size = 1024;
 
-  KeyPairRSA(JSch jsch) {
-    this(jsch, null, null, null);
+  KeyPairRSA(JSch.InstanceLogger instLogger) {
+    this(instLogger, null, null, null);
   }
 
-  KeyPairRSA(JSch jsch, byte[] n_array, byte[] pub_array, byte[] prv_array) {
-    super(jsch);
+  KeyPairRSA(JSch.InstanceLogger instLogger, byte[] n_array, byte[] pub_array, byte[] prv_array) {
+    super(instLogger);
     this.n_array = n_array;
     this.pub_array = pub_array;
     this.prv_array = prv_array;
@@ -139,8 +139,8 @@ class KeyPairRSA extends KeyPair {
           q_array = tmp[2];
           c_array = tmp[3];
         } catch (JSchException e) {
-          if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-            jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+          if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+            instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
           }
           return false;
         }
@@ -170,8 +170,8 @@ class KeyPairRSA extends KeyPair {
 
           return true;
         }
-        if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-          jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key");
+        if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+          instLogger.getLogger().log(Logger.ERROR, "failed to parse key");
         }
         return false;
       }
@@ -342,8 +342,8 @@ class KeyPairRSA extends KeyPair {
       }
 
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to parse key", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
       }
       return false;
     }
@@ -403,8 +403,8 @@ class KeyPairRSA extends KeyPair {
       tmp[1] = sig;
       return Buffer.fromBytes(tmp).buffer;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to generate signature", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to generate signature", e);
       }
     }
     return null;
@@ -433,21 +433,21 @@ class KeyPairRSA extends KeyPair {
       rsa.setPubKey(pub_array, n_array);
       return rsa;
     } catch (Exception e) {
-      if (jsch.getInstanceLogger().isEnabled(Logger.ERROR)) {
-        jsch.getInstanceLogger().log(Logger.ERROR, "failed to create verifier", e);
+      if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
+        instLogger.getLogger().log(Logger.ERROR, "failed to create verifier", e);
       }
     }
     return null;
   }
 
-  static KeyPair fromSSHAgent(JSch jsch, Buffer buf) throws JSchException {
+  static KeyPair fromSSHAgent(JSch.InstanceLogger instLogger, Buffer buf) throws JSchException {
 
     byte[][] tmp = buf.getBytes(8, "invalid key format");
 
     byte[] n_array = tmp[1];
     byte[] pub_array = tmp[2];
     byte[] prv_array = tmp[3];
-    KeyPairRSA kpair = new KeyPairRSA(jsch, n_array, pub_array, prv_array);
+    KeyPairRSA kpair = new KeyPairRSA(instLogger, n_array, pub_array, prv_array);
     kpair.c_array = tmp[4]; // iqmp
     kpair.p_array = tmp[5];
     kpair.q_array = tmp[6];

--- a/src/main/java/com/jcraft/jsch/LocalIdentityRepository.java
+++ b/src/main/java/com/jcraft/jsch/LocalIdentityRepository.java
@@ -32,10 +32,10 @@ class LocalIdentityRepository implements IdentityRepository {
   private static final String name = "Local Identity Repository";
 
   private Vector<Identity> identities = new Vector<>();
-  private JSch jsch;
+  private JSch.InstanceLogger instLogger;
 
-  LocalIdentityRepository(JSch jsch) {
-    this.jsch = jsch;
+  LocalIdentityRepository(JSch.InstanceLogger instLogger) {
+    this.instLogger = instLogger;
   }
 
   @Override
@@ -82,7 +82,7 @@ class LocalIdentityRepository implements IdentityRepository {
   @Override
   public synchronized boolean add(byte[] identity) {
     try {
-      Identity _identity = IdentityFile.newInstance("from remote:", identity, null, jsch);
+      Identity _identity = IdentityFile.newInstance("from remote:", identity, null, instLogger);
       add(_identity);
       return true;
     } catch (JSchException e) {

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -3108,7 +3108,7 @@ public class Session {
           }
           if (ifile == null)
             continue;
-          Identity identity = IdentityFile.newInstance(ifile, null, jsch);
+          Identity identity = IdentityFile.newInstance(ifile, null, jsch.instLogger);
           ir.add(identity);
         }
         this.setIdentityRepository(ir);

--- a/src/test/java/com/jcraft/jsch/AbstractBufferMargin.java
+++ b/src/test/java/com/jcraft/jsch/AbstractBufferMargin.java
@@ -45,26 +45,30 @@ public abstract class AbstractBufferMargin {
   private Slf4jLogConsumer sshdLogConsumer;
 
   @Container
-  public GenericContainer<?> sshd = new GenericContainer<>(
-      new ImageFromDockerfile().withFileFromClasspath("asyncsshd.py", "docker/asyncsshd.py")
-          .withFileFromClasspath("ssh_host_ed448_key", "docker/ssh_host_ed448_key")
-          .withFileFromClasspath("ssh_host_ed448_key.pub", "docker/ssh_host_ed448_key.pub")
-          .withFileFromClasspath("ssh_host_rsa_key", "docker/ssh_host_rsa_key")
-          .withFileFromClasspath("ssh_host_rsa_key.pub", "docker/ssh_host_rsa_key.pub")
-          .withFileFromClasspath("ssh_host_ecdsa256_key", "docker/ssh_host_ecdsa256_key")
-          .withFileFromClasspath("ssh_host_ecdsa256_key.pub", "docker/ssh_host_ecdsa256_key.pub")
-          .withFileFromClasspath("ssh_host_ecdsa384_key", "docker/ssh_host_ecdsa384_key")
-          .withFileFromClasspath("ssh_host_ecdsa384_key.pub", "docker/ssh_host_ecdsa384_key.pub")
-          .withFileFromClasspath("ssh_host_ecdsa521_key", "docker/ssh_host_ecdsa521_key")
-          .withFileFromClasspath("ssh_host_ecdsa521_key.pub", "docker/ssh_host_ecdsa521_key.pub")
-          .withFileFromClasspath("ssh_host_ed25519_key", "docker/ssh_host_ed25519_key")
-          .withFileFromClasspath("ssh_host_ed25519_key.pub", "docker/ssh_host_ed25519_key.pub")
-          .withFileFromClasspath("ssh_host_dsa_key", "docker/ssh_host_dsa_key")
-          .withFileFromClasspath("ssh_host_dsa_key.pub", "docker/ssh_host_dsa_key.pub")
-          .withFileFromClasspath("authorized_keys", "docker/authorized_keys")
-          .withFileFromClasspath("Dockerfile", "docker/Dockerfile.asyncssh")
-          .withBuildArg("MAX_PKTSIZE", Integer.toString(maxPktSize())))
-      .withExposedPorts(22);
+  public GenericContainer<?> sshd;
+
+  protected AbstractBufferMargin(int maxPktSize) {
+    sshd = new GenericContainer<>(
+        new ImageFromDockerfile().withFileFromClasspath("asyncsshd.py", "docker/asyncsshd.py")
+            .withFileFromClasspath("ssh_host_ed448_key", "docker/ssh_host_ed448_key")
+            .withFileFromClasspath("ssh_host_ed448_key.pub", "docker/ssh_host_ed448_key.pub")
+            .withFileFromClasspath("ssh_host_rsa_key", "docker/ssh_host_rsa_key")
+            .withFileFromClasspath("ssh_host_rsa_key.pub", "docker/ssh_host_rsa_key.pub")
+            .withFileFromClasspath("ssh_host_ecdsa256_key", "docker/ssh_host_ecdsa256_key")
+            .withFileFromClasspath("ssh_host_ecdsa256_key.pub", "docker/ssh_host_ecdsa256_key.pub")
+            .withFileFromClasspath("ssh_host_ecdsa384_key", "docker/ssh_host_ecdsa384_key")
+            .withFileFromClasspath("ssh_host_ecdsa384_key.pub", "docker/ssh_host_ecdsa384_key.pub")
+            .withFileFromClasspath("ssh_host_ecdsa521_key", "docker/ssh_host_ecdsa521_key")
+            .withFileFromClasspath("ssh_host_ecdsa521_key.pub", "docker/ssh_host_ecdsa521_key.pub")
+            .withFileFromClasspath("ssh_host_ed25519_key", "docker/ssh_host_ed25519_key")
+            .withFileFromClasspath("ssh_host_ed25519_key.pub", "docker/ssh_host_ed25519_key.pub")
+            .withFileFromClasspath("ssh_host_dsa_key", "docker/ssh_host_dsa_key")
+            .withFileFromClasspath("ssh_host_dsa_key.pub", "docker/ssh_host_dsa_key.pub")
+            .withFileFromClasspath("authorized_keys", "docker/authorized_keys")
+            .withFileFromClasspath("Dockerfile", "docker/Dockerfile.asyncssh")
+            .withBuildArg("MAX_PKTSIZE", Integer.toString(maxPktSize)))
+        .withExposedPorts(22);
+  }
 
   @BeforeAll
   public static void beforeAll() {
@@ -100,8 +104,6 @@ public abstract class AbstractBufferMargin {
     jschLogger.clearAll();
     sshdLogger.clearAll();
   }
-
-  protected abstract int maxPktSize();
 
   protected void doTestSftp(String cipher, String mac, String compression) throws Exception {
     JSch ssh = createRSAIdentity();

--- a/src/test/java/com/jcraft/jsch/KeyPairTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairTest.java
@@ -156,7 +156,7 @@ class KeyPairTest {
     final String prvkey =
         Paths.get(ClassLoader.getSystemResource(keyFile).toURI()).toFile().getAbsolutePath();
     assertTrue(new File(prvkey).exists());
-    IdentityFile identity = IdentityFile.newInstance(prvkey, null, jSch);
+    IdentityFile identity = IdentityFile.newInstance(prvkey, null, jSch.instLogger);
 
     // Decrypt the key file
     assertTrue(identity.getKeyPair().decrypt("secret123"));

--- a/src/test/java/com/jcraft/jsch/PktSize128IT.java
+++ b/src/test/java/com/jcraft/jsch/PktSize128IT.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 public class PktSize128IT extends AbstractBufferMargin {
 
+  public PktSize128IT() {
+    super(128);
+  }
+
   @ParameterizedTest
   @CsvSource(value = {
       // 16 byte tag (MAC doesn't matter)
@@ -33,10 +37,5 @@ public class PktSize128IT extends AbstractBufferMargin {
       "aes128-ctr,hmac-sha2-256,none", "aes128-ctr,hmac-sha2-256,zlib@openssh.com"})
   public void testScp(String cipher, String mac, String compression) throws Exception {
     doTestScp(cipher, mac, compression);
-  }
-
-  @Override
-  protected int maxPktSize() {
-    return 128;
   }
 }

--- a/src/test/java/com/jcraft/jsch/PktSize160IT.java
+++ b/src/test/java/com/jcraft/jsch/PktSize160IT.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 public class PktSize160IT extends AbstractBufferMargin {
 
+  public PktSize160IT() {
+    super(160);
+  }
+
   @ParameterizedTest
   @CsvSource(value = {
       // 32 byte MAC
@@ -19,10 +23,5 @@ public class PktSize160IT extends AbstractBufferMargin {
       "aes128-ctr,hmac-sha2-512,none", "aes128-ctr,hmac-sha2-512,zlib@openssh.com"})
   public void testScp(String cipher, String mac, String compression) throws Exception {
     doTestScp(cipher, mac, compression);
-  }
-
-  @Override
-  protected int maxPktSize() {
-    return 160;
   }
 }

--- a/src/test/java/com/jcraft/jsch/PktSize192IT.java
+++ b/src/test/java/com/jcraft/jsch/PktSize192IT.java
@@ -5,16 +5,15 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 public class PktSize192IT extends AbstractBufferMargin {
 
+  public PktSize192IT() {
+    super(192);
+  }
+
   @ParameterizedTest
   @CsvSource(value = {
       // 64 byte MAC
       "aes128-ctr,hmac-sha2-512,none", "aes128-ctr,hmac-sha2-512,zlib@openssh.com"})
   public void testSftp(String cipher, String mac, String compression) throws Exception {
     doTestSftp(cipher, mac, compression);
-  }
-
-  @Override
-  protected int maxPktSize() {
-    return 192;
   }
 }

--- a/src/test/java/com/jcraft/jsch/PktSize32768IT.java
+++ b/src/test/java/com/jcraft/jsch/PktSize32768IT.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 public class PktSize32768IT extends AbstractBufferMargin {
 
+  public PktSize32768IT() {
+    super(32768);
+  }
+
   @ParameterizedTest
   @CsvSource(value = {
       // 16 byte tag (MAC doesn't matter)
@@ -39,10 +43,5 @@ public class PktSize32768IT extends AbstractBufferMargin {
       "aes128-ctr,hmac-sha2-512,none", "aes128-ctr,hmac-sha2-512,zlib@openssh.com"})
   public void testScp(String cipher, String mac, String compression) throws Exception {
     doTestScp(cipher, mac, compression);
-  }
-
-  @Override
-  protected int maxPktSize() {
-    return 32768;
   }
 }

--- a/src/test/java/com/jcraft/jsch/Slf4jLoggerTest.java
+++ b/src/test/java/com/jcraft/jsch/Slf4jLoggerTest.java
@@ -9,17 +9,28 @@ import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.org.lidalia.slf4jext.ConventionalLevelHierarchy;
+import org.slf4j.event.Level;
 
 public class Slf4jLoggerTest {
 
   private static final TestLogger logger = TestLoggerFactory.getTestLogger(JSch.class);
+
+  private final Set<Level> OFF_LEVELS = EnumSet.noneOf(Level.class);
+  private final Set<Level> TRACE_LEVELS =
+      EnumSet.of(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
+  private final Set<Level> DEBUG_LEVELS =
+      EnumSet.of(Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
+  private final Set<Level> INFO_LEVELS = EnumSet.of(Level.INFO, Level.WARN, Level.ERROR);
+  private final Set<Level> WARN_LEVELS = EnumSet.of(Level.WARN, Level.ERROR);
+  private final Set<Level> ERROR_LEVELS = EnumSet.of(Level.ERROR);
 
   private final Exception testException = new Exception("dummy exception");
 
@@ -37,7 +48,7 @@ public class Slf4jLoggerTest {
   public void testIsEnabled() {
     Slf4jLogger sl = new Slf4jLogger();
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.DEBUG_LEVELS);
+    logger.setEnabledLevelsForAllThreads(DEBUG_LEVELS);
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.DEBUG), "debug should be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.ERROR), "error should be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.FATAL), "fatal should be enabled");
@@ -45,7 +56,7 @@ public class Slf4jLoggerTest {
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.WARN), "warn should be enabled");
     assertFalse(sl.isEnabled(-1), "trace should not be enabled");
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.ERROR_LEVELS);
+    logger.setEnabledLevelsForAllThreads(ERROR_LEVELS);
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.DEBUG), "debug should not be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.ERROR), "error should be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.FATAL), "fatal should be enabled");
@@ -53,7 +64,7 @@ public class Slf4jLoggerTest {
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.WARN), "warn should not be enabled");
     assertFalse(sl.isEnabled(-1), "trace should not be enabled");
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.INFO_LEVELS);
+    logger.setEnabledLevelsForAllThreads(INFO_LEVELS);
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.DEBUG), "debug should not be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.ERROR), "error should be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.FATAL), "fatal should be enabled");
@@ -61,7 +72,7 @@ public class Slf4jLoggerTest {
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.WARN), "warn should be enabled");
     assertFalse(sl.isEnabled(-1), "trace should not be enabled");
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.OFF_LEVELS);
+    logger.setEnabledLevelsForAllThreads(OFF_LEVELS);
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.DEBUG), "debug should not be enabled");
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.ERROR), "error should not be enabled");
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.FATAL), "fatal should not be enabled");
@@ -69,7 +80,7 @@ public class Slf4jLoggerTest {
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.WARN), "warn should not be enabled");
     assertFalse(sl.isEnabled(-1), "trace should not be enabled");
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.TRACE_LEVELS);
+    logger.setEnabledLevelsForAllThreads(TRACE_LEVELS);
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.DEBUG), "debug should be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.ERROR), "error should be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.FATAL), "fatal should be enabled");
@@ -77,7 +88,7 @@ public class Slf4jLoggerTest {
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.WARN), "warn should be enabled");
     assertTrue(sl.isEnabled(-1), "trace should be enabled");
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.WARN_LEVELS);
+    logger.setEnabledLevelsForAllThreads(WARN_LEVELS);
     assertFalse(sl.isEnabled(com.jcraft.jsch.Logger.DEBUG), "debug should not be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.ERROR), "error should be enabled");
     assertTrue(sl.isEnabled(com.jcraft.jsch.Logger.FATAL), "fatal should be enabled");
@@ -95,25 +106,25 @@ public class Slf4jLoggerTest {
     List<Optional<Throwable>> expectedExceptions =
         Arrays.asList(Optional.empty(), Optional.ofNullable(null), Optional.of(testException));
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.TRACE_LEVELS);
+    logger.setEnabledLevelsForAllThreads(TRACE_LEVELS);
     sl.log(-1, "debug message");
     sl.log(-1, "debug message with null cause", null);
     sl.log(-1, "debug message with cause", testException);
     checkMessages(expectedMessages, expectedExceptions);
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.TRACE_LEVELS);
+    logger.setEnabledLevelsForAllThreads(TRACE_LEVELS);
     sl.log(com.jcraft.jsch.Logger.FATAL, "debug message");
     sl.log(com.jcraft.jsch.Logger.FATAL, "debug message with null cause", null);
     sl.log(com.jcraft.jsch.Logger.FATAL, "debug message with cause", testException);
     checkMessages(expectedMessages, expectedExceptions);
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.ERROR_LEVELS);
+    logger.setEnabledLevelsForAllThreads(ERROR_LEVELS);
     sl.log(-1, "debug message");
     sl.log(-1, "debug message with null cause", null);
     sl.log(-1, "debug message with cause", testException);
     checkMessages(Collections.emptyList(), Collections.emptyList());
 
-    logger.setEnabledLevelsForAllThreads(ConventionalLevelHierarchy.ERROR_LEVELS);
+    logger.setEnabledLevelsForAllThreads(ERROR_LEVELS);
     sl.log(com.jcraft.jsch.Logger.FATAL, "debug message");
     sl.log(com.jcraft.jsch.Logger.FATAL, "debug message with null cause", null);
     sl.log(com.jcraft.jsch.Logger.FATAL, "debug message with cause", testException);


### PR DESCRIPTION
- Update dependencies.
- Fix new Java 21 compiler warning: `possible 'this' escape before subclass is fully initialized`.
- Eliminate KeyPair's public constructor since it cannot be meaningfully used by consumers.
- Tweak OSGi bundle manifest to allow Log4j 3.