### PR TITLE
0.2.12 changes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+* [0.2.12](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.12)
+  * Further refine previous fixes for windows line endings in PEM keys from [#369](https://github.com/mwiede/jsch/issues/369) & [#362](https://github.com/mwiede/jsch/issues/362).
 * [0.2.11](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.11)
   * [#369](https://github.com/mwiede/jsch/issues/369) fix multi-line PEM key parsing to work with windows line endings due to regression from previous fix for [#362](https://github.com/mwiede/jsch/issues/362).
 * [0.2.10](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.10)

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <junixsocket.version>2.6.2</junixsocket.version>
         <jna.version>5.13.0</jna.version>
         <log4j.version>2.20.0</log4j.version>
-        <errorprone.version>2.20.0</errorprone.version>
+        <errorprone.version>2.21.0</errorprone.version>
         <surefire.version>3.1.2</surefire.version>
     </properties>
     <dependencies>

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -891,17 +891,16 @@ public abstract class KeyPair {
 
         start = 0;
         i = 0;
-        boolean xds = false;
 
         int _len = _buf.length;
         while (i < _len) {
           if (_buf[i] == '\n') {
-            boolean xd = (_buf[i - 1] == '\r');
+            boolean xd = (i > 0 && _buf[i - 1] == '\r');
             // ignore \n (or \r\n)
             System.arraycopy(_buf, i + 1, _buf, i - (xd ? 1 : 0), _len - (i + 1));
             if (xd) {
               _len--;
-              xds = true;
+              i--;
             }
             _len--;
             continue;
@@ -912,8 +911,8 @@ public abstract class KeyPair {
           i++;
         }
 
-        if (i - (xds ? 1 : 0) - start > 0)
-          data = Util.fromBase64(_buf, start, i - (xds ? 1 : 0) - start);
+        if (i - start > 0)
+          data = Util.fromBase64(_buf, start, i - start);
 
         Util.bzero(_buf);
       }


### PR DESCRIPTION
- Further refine previous fixes for windows line endings in PEM keys from #369 & #362.
- Update dependencies.