### PR TITLE
#392 replace call to BigInteger.intValueExact to remain comptaible wi…

### DIFF
--- a/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
@@ -862,6 +862,13 @@ class KeyPairPKCS8 extends KeyPair {
   }
 
   static int parseASN1IntegerAsInt(byte[] content) {
-    return new BigInteger(content).intValueExact();
+    BigInteger b = new BigInteger(content);
+    // https://github.com/mwiede/jsch/issues/392 not using intValueExact() because of Android
+    // incompatibility.
+    if (b.bitLength() <= 31) {
+      return b.intValue();
+    } else {
+      throw new ArithmeticException("BigInteger out of int range");
+    }
   }
 }


### PR DESCRIPTION
Although java 8 compatibility is given, it is just a one line and an easy fix.