### PR TITLE
UAN should return null for methods when the server response is empty

### DIFF
--- a/src/main/java/com/jcraft/jsch/UserAuthNone.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthNone.java
@@ -103,14 +103,20 @@ public class UserAuthNone extends UserAuth {
         continue loop;
       }
       if (command == UserAuth.SSH_MSG_USERAUTH_FAILURE) {
+        if (session.getLogger().isEnabled(Logger.INFO)) {
+          session.getLogger().log(Logger.INFO, "auth_none authentication failed");
+        }
         buf.getInt();
         buf.getByte();
         buf.getByte();
         byte[] foo = buf.getString();
         int partial_success = buf.getByte();
         if (foo.length > 0 ) {
-          // Session.java expects methods to be null if we dont get a response from the server
+          // Session.java expects methods to be null if we don't get a response from the server
           setMethods(Util.byte2str(foo));
+          if (session.getLogger().isEnabled(Logger.INFO)) {
+            session.getLogger().log(Logger.INFO, "server will allow auth methods: " + getMethods());
+          }
         }
         // System.err.println("UserAuthNone: " + methods + " partial_success:" + (partial_success !=
         // 0));

--- a/src/main/java/com/jcraft/jsch/UserAuthNone.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthNone.java
@@ -108,7 +108,10 @@ public class UserAuthNone extends UserAuth {
         buf.getByte();
         byte[] foo = buf.getString();
         int partial_success = buf.getByte();
-        setMethods(Util.byte2str(foo));
+        if (foo.length > 0 ) {
+          // Session.java expects methods to be null if we dont get a response from the server
+          setMethods(Util.byte2str(foo));
+        }
         // System.err.println("UserAuthNone: " + methods + " partial_success:" + (partial_success !=
         // 0));
         // if (partial_success != 0) {

--- a/src/main/java/com/jcraft/jsch/UserAuthNone.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthNone.java
@@ -115,7 +115,9 @@ public class UserAuthNone extends UserAuth {
           // Session.java expects methods to be null if we don't get a response from the server
           setMethods(Util.byte2str(foo));
           if (session.getLogger().isEnabled(Logger.INFO)) {
-            session.getLogger().log(Logger.INFO, "server will allow auth methods: " + getMethods());
+            session.getLogger().log(Logger.INFO, "server will allow auth methods: "
+                    + getMethods()
+                    + " after auth_none authentication failed");
           }
         }
         // System.err.println("UserAuthNone: " + methods + " partial_success:" + (partial_success !=


### PR DESCRIPTION
when the server does not respond with any methods, userAuthNone should return null for the methods call. 

a simple test like this shows that if the buffer was of size 0, we would return an empty string 

```    void byte2str_withEmptyArray_returnsNull() {
        String emptyString = Util.byte2str(new byte[0]);
        assertNotNull(emptyString);
    }```

which in turn causes Session.java to not try any other authentication mechanisms. 