### PR TITLE
Introduce JSchSessionDisconnectException to allow the reasonCode to be retrieved without String parsing

### DIFF
--- a/src/main/java/com/jcraft/jsch/JSchSessionDisconnectException.java
+++ b/src/main/java/com/jcraft/jsch/JSchSessionDisconnectException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch;
+
+public class JSchSessionDisconnectException extends JSchException {
+  private static final long serialVersionUID = -1L;
+
+  // RFC 4253 11.1.
+  private final int reasonCode; // RFC 4250 4.2.2.
+  private final String description;
+  private final String languageTag;
+
+  JSchSessionDisconnectException(String s, int reasonCode, String description, String languageTag) {
+    super(s);
+    this.reasonCode = reasonCode;
+    this.description = description;
+    this.languageTag = languageTag;
+  }
+
+  public int getReasonCode() {
+    return reasonCode;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getLanguageTag() {
+    return languageTag;
+  }
+}

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -1199,10 +1199,13 @@ public class Session {
         buf.getInt();
         buf.getShort();
         int reason_code = buf.getInt();
-        byte[] description = buf.getString();
-        byte[] language_tag = buf.getString();
-        throw new JSchException("SSH_MSG_DISCONNECT: " + reason_code + " "
-            + Util.byte2str(description) + " " + Util.byte2str(language_tag));
+        byte[] description_array = buf.getString();
+        byte[] language_tag_array = buf.getString();
+        String description = Util.byte2str(description_array);
+        String language_tag = Util.byte2str(language_tag_array);
+        throw new JSchSessionDisconnectException(
+            "SSH_MSG_DISCONNECT: " + reason_code + " " + description + " " + language_tag,
+            reason_code, description, language_tag);
         // break;
       } else if (type == SSH_MSG_IGNORE) {
       } else if (type == SSH_MSG_UNIMPLEMENTED) {


### PR DESCRIPTION
Similar to #410 , did not change any of the messages in case anyone is matching the exception message due to the lack of specific sub exception throwing .

Relates to #357

