### PR TITLE
0.2.13 changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: '17'
+        java-version: '21'
         check-latest: true    
         cache: 'maven'
         

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: '17'
+        java-version: '21'
         check-latest: true    
         cache: 'maven'
     - uses: vapier/coverity-scan-action@v1

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           check-latest: true
       - name: Build Javadoc
         run: mvn -B -V javadoc:javadoc --file pom.xml

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '21'
           check-latest: true
       - name: Build Javadoc
-        run: mvn -B -V javadoc:javadoc --file pom.xml
+        run: ./mvnw -B -V -e javadoc:javadoc
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['8', '11', '17', '21']
     steps:
     - uses: actions/checkout@v4
     - name: Cache local Maven repository
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: '17'
+        java-version: '21'
         check-latest: true
     - name: Build with Maven
       run: mvn -B -V -DskipTests=true package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         java-version: '21'
         check-latest: true
     - name: Build with Maven
-      run: mvn -B -V -DskipTests=true package --file pom.xml
+      run: ./mvnw -B -V -e -DskipTests=true package
     - uses: actions/upload-artifact@v3
       with:
         name: java-${{ matrix.java }}-jars
@@ -49,7 +49,7 @@ jobs:
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Test with Maven
-      run: mvn -B -V -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dmaven.main.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -DskipITs=false --file pom.xml
+      run: ./mvnw -B -V -e -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dmaven.main.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -DskipITs=false
     - uses: actions/upload-artifact@v3
       with:
         name: java-${{ matrix.java }}-testresults

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -208,6 +208,11 @@ public abstract class Channel {
   }
 
   public InputStream getInputStream() throws IOException {
+    Session _session = this.session;
+    if (_session != null && isConnected() && _session.getLogger().isEnabled(Logger.WARN)) {
+      _session.getLogger().log(Logger.WARN, "getInputStream() should be called before connect()");
+    }
+
     int max_input_buffer_size = 32 * 1024;
     try {
       max_input_buffer_size = Integer.parseInt(getSession().getConfig("max_input_buffer_size"));
@@ -221,6 +226,12 @@ public abstract class Channel {
   }
 
   public InputStream getExtInputStream() throws IOException {
+    Session _session = this.session;
+    if (_session != null && isConnected() && _session.getLogger().isEnabled(Logger.WARN)) {
+      _session.getLogger().log(Logger.WARN,
+          "getExtInputStream() should be called before connect()");
+    }
+
     int max_input_buffer_size = 32 * 1024;
     try {
       max_input_buffer_size = Integer.parseInt(getSession().getConfig("max_input_buffer_size"));

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -67,7 +67,11 @@ public abstract class Channel {
       ret = new ChannelForwardedTCPIP();
     }
     if (type.equals("sftp")) {
-      ret = new ChannelSftp();
+      ChannelSftp sftp = new ChannelSftp();
+      boolean useWriteFlushWorkaround =
+          session.getConfig("use_sftp_write_flush_workaround").equals("yes");
+      sftp.setUseWriteFlushWorkaround(useWriteFlushWorkaround);
+      ret = sftp;
     }
     if (type.equals("subsystem")) {
       ret = new ChannelSubsystem();

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -157,6 +157,8 @@ public class ChannelSftp extends ChannelSession {
   private Charset fEncoding = StandardCharsets.UTF_8;
   private boolean fEncoding_is_utf8 = true;
 
+  private boolean useWriteFlushWorkaround = true;
+
   private RequestQueue rq = new RequestQueue(16);
 
   /**
@@ -179,6 +181,14 @@ public class ChannelSftp extends ChannelSession {
    */
   public int getBulkRequests() {
     return rq.size();
+  }
+
+  public void setUseWriteFlushWorkaround(boolean useWriteFlushWorkaround) {
+    this.useWriteFlushWorkaround = useWriteFlushWorkaround;
+  }
+
+  public boolean getUseWriteFlushWorkaround() {
+    return useWriteFlushWorkaround;
   }
 
   public ChannelSftp() {
@@ -754,6 +764,9 @@ public class ChannelSftp extends ChannelSession {
           try {
             int _len = len;
             while (_len > 0) {
+              if (useWriteFlushWorkaround && rwsize < 21 + handle.length + _len + 4) {
+                flush();
+              }
               int sent = sendWRITE(handle, _offset[0], d, s, _len);
               writecount++;
               _offset[0] += sent;

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -228,6 +228,8 @@ public class JSch {
     config.put("try_additional_pubkey_algorithms",
         Util.getSystemProperty("jsch.try_additional_pubkey_algorithms", "yes"));
     config.put("enable_auth_none", Util.getSystemProperty("jsch.enable_auth_none", "yes"));
+    config.put("use_sftp_write_flush_workaround",
+        Util.getSystemProperty("jsch.use_sftp_write_flush_workaround", "yes"));
 
     config.put("CheckCiphers",
         Util.getSystemProperty("jsch.check_ciphers", "chacha20-poly1305@openssh.com"));

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -3069,6 +3069,7 @@ public class Session {
     checkConfig(config, "enable_pubkey_auth_query");
     checkConfig(config, "try_additional_pubkey_algorithms");
     checkConfig(config, "enable_auth_none");
+    checkConfig(config, "use_sftp_write_flush_workaround");
 
     checkConfig(config, "cipher.c2s");
     checkConfig(config, "cipher.s2c");


### PR DESCRIPTION
- #411 add flush operation from is/jsch#39, with new config option to allow disabling in case it causes regressions.
- Update dependencies.
- Add Java 21 to CI pipeline and also use it by default for building.
- Switch CI pipelines to using maven wrapper and produce any execution error messages.
- #403 add a warning when `Channel.getInputStream()` or `Channel.getExtInputStream()` is called after `Channel.connect()`.