### PR TITLE
0.2.14 changes

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/src/main/java/com/jcraft/jsch/Util.java
+++ b/src/main/java/com/jcraft/jsch/Util.java
@@ -26,11 +26,13 @@
 
 package com.jcraft.jsch;
 
-import java.net.Socket;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Vector;
@@ -369,55 +371,20 @@ class Util {
   }
 
   static Socket createSocket(String host, int port, int timeout) throws JSchException {
-    Socket socket = null;
-    if (timeout == 0) {
-      try {
-        socket = new Socket(host, port);
-        return socket;
-      } catch (Exception e) {
-        String message = e.toString();
-        throw new JSchException(message, e);
-      }
-    }
-    final String _host = host;
-    final int _port = port;
-    final Socket[] sockp = new Socket[1];
-    final Exception[] ee = new Exception[1];
-    String message = "";
-    Thread tmp = new Thread(() -> {
-      sockp[0] = null;
-      try {
-        sockp[0] = new Socket(_host, _port);
-      } catch (Exception e) {
-        ee[0] = e;
-        if (sockp[0] != null && sockp[0].isConnected()) {
-          try {
-            sockp[0].close();
-          } catch (Exception eee) {
-          }
-        }
-        sockp[0] = null;
-      }
-    });
-    tmp.setName("Opening Socket " + host);
-    tmp.start();
+    Socket socket = new Socket();
     try {
-      tmp.join(timeout);
-      message = "timeout: ";
-    } catch (InterruptedException eee) {
-    }
-    if (sockp[0] != null && sockp[0].isConnected()) {
-      socket = sockp[0];
-    } else {
-      message += "socket is not established";
-      if (ee[0] != null) {
-        message = ee[0].toString();
+      socket.connect(new InetSocketAddress(host, port), timeout);
+      return socket;
+    } catch (Exception e) {
+      try {
+        socket.close();
+      } catch (Exception ignore) {
       }
-      tmp.interrupt();
-      tmp = null;
-      throw new JSchException(message, ee[0]);
+
+      String message =
+          e instanceof SocketTimeoutException ? "timeout: socket is not established" : e.toString();
+      throw new JSchException(message, e);
     }
-    return socket;
   }
 
   static byte[] str2byte(String str, Charset encoding) {


### PR DESCRIPTION
- #450 use `Socket.connect()` with a timeout that has been supported since Java 1.4 instead of using old method of creating a separate thread and joining to that thread with timeout.
- Update dependencies.