### PR TITLE
0.2.15 changes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         java-version: '21'
         check-latest: true
     - name: Build with Maven
-      run: ./mvnw -B -V -e -DskipTests=true package
+      run: ./mvnw -B -V -e -DskipTests=true verify
     - uses: actions/upload-artifact@v3
       with:
         name: java-${{ matrix.java }}-jars
@@ -48,8 +48,10 @@ jobs:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
         check-latest: true
-    - name: Test with Maven
-      run: ./mvnw -B -V -e -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dmaven.main.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -DskipITs=false
+    - name: Unit Tests with Maven
+      run: ./mvnw -B -V -e jacoco:prepare-agent surefire:test jacoco:report
+    - name: Integration Tests with Maven
+      run: ./mvnw -B -V -e -DskipITs=false jacoco:prepare-agent-integration failsafe:integration-test failsafe:verify jacoco:report-integration
     - uses: actions/upload-artifact@v3
       with:
         name: java-${{ matrix.java }}-testresults

--- a/pom.xml
+++ b/pom.xml
@@ -650,6 +650,19 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <version>3.6</version>
+                <configuration>
+                    <bundledSignatures>
+                        <bundledSignature>jdk-unsafe</bundledSignature>
+                        <bundledSignature>jdk-deprecated</bundledSignature>
+                        <bundledSignature>jdk-non-portable</bundledSignature>
+                        <bundledSignature>jdk-reflection</bundledSignature>
+                    </bundledSignatures>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -799,6 +812,47 @@
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>forbiddenapis</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>de.thetaphi</groupId>
+                        <artifactId>forbiddenapis</artifactId>
+                        <configuration>
+                            <releaseVersion>16</releaseVersion>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <bundledSignatures combine.children="append">
+                                        <bundledSignature>jdk-system-out</bundledSignature>
+                                    </bundledSignatures>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>testCheck</id>
+                                <goals>
+                                    <goal>testCheck</goal>
+                                </goals>
+                                <configuration>
+                                    <bundledSignatures combine.children="append">
+                                        <bundledSignature>commons-io-unsafe-2.14.0</bundledSignature>
+                                    </bundledSignatures>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/src/main/java/com/jcraft/jsch/HostKey.java
+++ b/src/main/java/com/jcraft/jsch/HostKey.java
@@ -26,6 +26,8 @@
 
 package com.jcraft.jsch;
 
+import java.util.Locale;
+
 public class HostKey {
 
   private static final byte[][] names =
@@ -118,7 +120,7 @@ public class HostKey {
   public String getFingerPrint(JSch jsch) {
     HASH hash = null;
     try {
-      String _c = JSch.getConfig("FingerprintHash").toLowerCase();
+      String _c = JSch.getConfig("FingerprintHash").toLowerCase(Locale.ROOT);
       Class<? extends HASH> c = Class.forName(JSch.getConfig(_c)).asSubclass(HASH.class);
       hash = c.getDeclaredConstructor().newInstance();
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -45,6 +45,8 @@ public class JSch {
         "ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256"));
     config.put("prefer_known_host_key_types",
         Util.getSystemProperty("jsch.prefer_known_host_key_types", "yes"));
+    config.put("enable_strict_kex", Util.getSystemProperty("jsch.enable_strict_kex", "yes"));
+    config.put("require_strict_kex", Util.getSystemProperty("jsch.require_strict_kex", "no"));
     config.put("enable_server_sig_algs",
         Util.getSystemProperty("jsch.enable_server_sig_algs", "yes"));
     config.put("cipher.s2c", Util.getSystemProperty("jsch.cipher",

--- a/src/main/java/com/jcraft/jsch/JSchAlgoNegoFailException.java
+++ b/src/main/java/com/jcraft/jsch/JSchAlgoNegoFailException.java
@@ -1,5 +1,7 @@
 package com.jcraft.jsch;
 
+import java.util.Locale;
+
 /**
  * Extension of {@link JSchException} to indicate when a connection fails during algorithm
  * negotiation.
@@ -35,7 +37,7 @@ public class JSchAlgoNegoFailException extends JSchException {
   }
 
   private static String failString(int algorithmIndex, String jschProposal, String serverProposal) {
-    return String.format(
+    return String.format(Locale.ROOT,
         "Algorithm negotiation fail: algorithmName=\"%s\" jschProposal=\"%s\" serverProposal=\"%s\"",
         algorithmNameFromIndex(algorithmIndex), jschProposal, serverProposal);
   }

--- a/src/main/java/com/jcraft/jsch/JSchStrictKexException.java
+++ b/src/main/java/com/jcraft/jsch/JSchStrictKexException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch;
+
+public class JSchStrictKexException extends JSchException {
+  private static final long serialVersionUID = -1L;
+
+  JSchStrictKexException() {
+    super();
+  }
+
+  JSchStrictKexException(String s) {
+    super(s);
+  }
+}

--- a/src/main/java/com/jcraft/jsch/KeyExchange.java
+++ b/src/main/java/com/jcraft/jsch/KeyExchange.java
@@ -26,6 +26,8 @@
 
 package com.jcraft.jsch;
 
+import java.util.Locale;
+
 public abstract class KeyExchange {
 
   static final int PROPOSAL_KEX_ALGS = 0;
@@ -198,7 +200,7 @@ public abstract class KeyExchange {
   public String getFingerPrint() {
     HASH hash = null;
     try {
-      String _c = session.getConfig("FingerprintHash").toLowerCase();
+      String _c = session.getConfig("FingerprintHash").toLowerCase(Locale.ROOT);
       Class<? extends HASH> c = Class.forName(session.getConfig(_c)).asSubclass(HASH.class);
       hash = c.getDeclaredConstructor().newInstance();
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
+++ b/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.Vector;
 import java.util.stream.Collectors;
@@ -75,9 +76,10 @@ import java.util.stream.Stream;
  */
 public class OpenSSHConfig implements ConfigRepository {
 
-  private static final Set<String> keysWithListAdoption =
-      Stream.of("KexAlgorithms", "Ciphers", "HostKeyAlgorithms", "MACs", "PubkeyAcceptedAlgorithms",
-          "PubkeyAcceptedKeyTypes").map(String::toUpperCase).collect(Collectors.toSet());
+  private static final Set<String> keysWithListAdoption = Stream
+      .of("KexAlgorithms", "Ciphers", "HostKeyAlgorithms", "MACs", "PubkeyAcceptedAlgorithms",
+          "PubkeyAcceptedKeyTypes")
+      .map(string -> string.toUpperCase(Locale.ROOT)).collect(Collectors.toSet());
 
   /**
    * Parses the given string, and returns an instance of ConfigRepository.
@@ -209,13 +211,13 @@ public class OpenSSHConfig implements ConfigRepository {
       if (keymap.get(key) != null) {
         key = keymap.get(key);
       }
-      key = key.toUpperCase();
+      key = key.toUpperCase(Locale.ROOT);
       String value = null;
       for (int i = 0; i < _configs.size(); i++) {
         Vector<String[]> v = _configs.elementAt(i);
         for (int j = 0; j < v.size(); j++) {
           String[] kv = v.elementAt(j);
-          if (kv[0].toUpperCase().equals(key)) {
+          if (kv[0].toUpperCase(Locale.ROOT).equals(key)) {
             value = kv[1];
             break;
           }
@@ -255,13 +257,13 @@ public class OpenSSHConfig implements ConfigRepository {
     }
 
     private String[] multiFind(String key) {
-      key = key.toUpperCase();
+      key = key.toUpperCase(Locale.ROOT);
       Vector<String> value = new Vector<>();
       for (int i = 0; i < _configs.size(); i++) {
         Vector<String[]> v = _configs.elementAt(i);
         for (int j = 0; j < v.size(); j++) {
           String[] kv = v.elementAt(j);
-          if (kv[0].toUpperCase().equals(key)) {
+          if (kv[0].toUpperCase(Locale.ROOT).equals(key)) {
             String foo = kv[1];
             if (foo != null) {
               value.remove(foo);

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -40,6 +40,7 @@ import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinUser;
 import com.sun.jna.platform.win32.WinUser.COPYDATASTRUCT;
+import java.util.Locale;
 
 public class PageantConnector implements AgentConnector {
 
@@ -84,7 +85,8 @@ public class PageantConnector implements AgentConnector {
       throw new AgentProxyException("Pageant is not runnning.");
     }
 
-    String mapname = String.format("PageantRequest%08x", kernel32.GetCurrentThreadId());
+    String mapname =
+        String.format(Locale.ROOT, "PageantRequest%08x", kernel32.GetCurrentThreadId());
 
     HANDLE sharedFile = null;
     Pointer sharedMemory = null;

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -37,6 +37,7 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.Vector;
 
@@ -400,7 +401,7 @@ public class Session {
       if (!auth) {
         smethods = uan.getMethods();
         if (smethods != null) {
-          smethods = smethods.toLowerCase();
+          smethods = smethods.toLowerCase(Locale.ROOT);
         } else {
           // methods: publickey,password,keyboard-interactive
           // smethods = "publickey,password,keyboard-interactive";

--- a/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
@@ -26,6 +26,8 @@
 
 package com.jcraft.jsch;
 
+import java.util.Locale;
+
 class UserAuthKeyboardInteractive extends UserAuth {
   @Override
   public boolean start(Session session) throws Exception {
@@ -129,7 +131,7 @@ class UserAuthKeyboardInteractive extends UserAuth {
           byte[][] response = null;
 
           if (password != null && prompt.length == 1 && !echo[0]
-              && prompt[0].toLowerCase().indexOf("password:") >= 0) {
+              && prompt[0].toLowerCase(Locale.ROOT).indexOf("password:") >= 0) {
             response = new byte[1][];
             response[0] = password;
             password = null;

--- a/src/main/java/com/jcraft/jsch/jzlib/InflaterInputStream.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InflaterInputStream.java
@@ -27,6 +27,7 @@
 package com.jcraft.jsch.jzlib;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 final class InflaterInputStream extends FilterInputStream {
   protected final Inflater inflater;
@@ -223,7 +224,7 @@ final class InflaterInputStream extends FilterInputStream {
 
   void readHeader() throws IOException {
 
-    byte[] empty = "".getBytes();
+    byte[] empty = "".getBytes(StandardCharsets.UTF_8);
     inflater.setInput(empty, 0, 0, false);
     inflater.setOutput(empty, 0, 0);
 

--- a/src/test/java/com/jcraft/jsch/AbstractBufferMargin.java
+++ b/src/test/java/com/jcraft/jsch/AbstractBufferMargin.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.input.BoundedInputStream;
@@ -140,7 +141,8 @@ public abstract class AbstractBufferMargin {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/Algorithms2IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms2IT.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -146,7 +147,7 @@ public class Algorithms2IT {
     session.setConfig("kex", kex);
     doSftp(session, true);
 
-    String expected = String.format("kex: algorithm: %s.*", kex);
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
     checkLogs(expected);
   }
 
@@ -177,9 +178,9 @@ public class Algorithms2IT {
     session.setConfig("dhgex_preferred", size);
     doSftp(session, true);
 
-    String expectedKex = String.format("kex: algorithm: %s.*", kex);
-    String expectedSizes =
-        String.format("SSH_MSG_KEX_DH_GEX_REQUEST\\(%s<%s<%s\\) sent", size, size, size);
+    String expectedKex = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
+    String expectedSizes = String.format(Locale.ROOT,
+        "SSH_MSG_KEX_DH_GEX_REQUEST\\(%s<%s<%s\\) sent", size, size, size);
     checkLogs(expectedKex);
     checkLogs(expectedSizes);
   }
@@ -235,7 +236,7 @@ public class Algorithms2IT {
     session.setConfig("server_host_key", keyType);
     doSftp(session, true);
 
-    String expected = String.format("kex: host key algorithm: %s.*", keyType);
+    String expected = String.format(Locale.ROOT, "kex: host key algorithm: %s.*", keyType);
     checkLogs(expected);
   }
 
@@ -250,8 +251,8 @@ public class Algorithms2IT {
     session.setConfig("compression.c2s", compression);
     doSftp(session, true);
 
-    String expectedS2C = String.format("kex: server->client cipher: %s.*", cipher);
-    String expectedC2S = String.format("kex: client->server cipher: %s.*", cipher);
+    String expectedS2C = String.format(Locale.ROOT, "kex: server->client cipher: %s.*", cipher);
+    String expectedC2S = String.format(Locale.ROOT, "kex: client->server cipher: %s.*", cipher);
     checkLogs(expectedS2C);
     checkLogs(expectedC2S);
   }
@@ -274,8 +275,8 @@ public class Algorithms2IT {
     session.setConfig("cipher.c2s", "aes128-ctr");
     doSftp(session, true);
 
-    String expectedS2C = String.format("kex: server->client .* MAC: %s.*", mac);
-    String expectedC2S = String.format("kex: client->server .* MAC: %s.*", mac);
+    String expectedS2C = String.format(Locale.ROOT, "kex: server->client .* MAC: %s.*", mac);
+    String expectedC2S = String.format(Locale.ROOT, "kex: client->server .* MAC: %s.*", mac);
     checkLogs(expectedS2C);
     checkLogs(expectedC2S);
   }
@@ -304,7 +305,7 @@ public class Algorithms2IT {
     session.setConfig("zlib", impl);
     doSftp(session, true);
 
-    String expectedImpl = String.format("zlib using %s", impl);
+    String expectedImpl = String.format(Locale.ROOT, "zlib using %s", impl);
     String expectedS2C = "kex: server->client .* compression: zlib.*";
     String expectedC2S = "kex: client->server .* compression: zlib.*";
     checkLogs(expectedImpl);
@@ -332,7 +333,8 @@ public class Algorithms2IT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/Algorithms3IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms3IT.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -96,8 +97,8 @@ public class Algorithms3IT {
     session.setConfig("compression.c2s", compression);
     doSftp(session, true);
 
-    String expectedS2C = String.format("kex: server->client cipher: %s.*", cipher);
-    String expectedC2S = String.format("kex: client->server cipher: %s.*", cipher);
+    String expectedS2C = String.format(Locale.ROOT, "kex: server->client cipher: %s.*", cipher);
+    String expectedC2S = String.format(Locale.ROOT, "kex: client->server cipher: %s.*", cipher);
     checkLogs(expectedS2C);
     checkLogs(expectedC2S);
   }
@@ -113,7 +114,8 @@ public class Algorithms3IT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
+++ b/src/test/java/com/jcraft/jsch/AlgorithmsIT.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -115,7 +116,7 @@ public class AlgorithmsIT {
     session.setConfig("kex", kex);
     doSftp(session, true);
 
-    String expected = String.format("kex: algorithm: %s.*", kex);
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
     checkLogs(expected);
   }
 
@@ -128,7 +129,7 @@ public class AlgorithmsIT {
     session.setConfig("kex", kex);
     doSftp(session, true);
 
-    String expected = String.format("kex: algorithm: %s.*", kex);
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
     checkLogs(expected);
   }
 
@@ -144,7 +145,7 @@ public class AlgorithmsIT {
     session.setConfig("kex", kex);
     doSftp(session, true);
 
-    String expected = String.format("kex: algorithm: %s.*", kex);
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
     checkLogs(expected);
   }
 
@@ -164,9 +165,9 @@ public class AlgorithmsIT {
     session.setConfig("dhgex_preferred", size);
     doSftp(session, true);
 
-    String expectedKex = String.format("kex: algorithm: %s.*", kex);
-    String expectedSizes =
-        String.format("SSH_MSG_KEX_DH_GEX_REQUEST\\(%s<%s<%s\\) sent", size, size, size);
+    String expectedKex = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
+    String expectedSizes = String.format(Locale.ROOT,
+        "SSH_MSG_KEX_DH_GEX_REQUEST\\(%s<%s<%s\\) sent", size, size, size);
     checkLogs(expectedKex);
     checkLogs(expectedSizes);
   }
@@ -257,7 +258,7 @@ public class AlgorithmsIT {
     session.setConfig("server_host_key", keyType);
     doSftp(session, true);
 
-    String expected = String.format("kex: host key algorithm: %s.*", keyType);
+    String expected = String.format(Locale.ROOT, "kex: host key algorithm: %s.*", keyType);
     checkLogs(expected);
   }
 
@@ -296,8 +297,8 @@ public class AlgorithmsIT {
     session.setConfig("compression.c2s", compression);
     doSftp(session, true);
 
-    String expectedS2C = String.format("kex: server->client cipher: %s.*", cipher);
-    String expectedC2S = String.format("kex: client->server cipher: %s.*", cipher);
+    String expectedS2C = String.format(Locale.ROOT, "kex: server->client cipher: %s.*", cipher);
+    String expectedC2S = String.format(Locale.ROOT, "kex: client->server cipher: %s.*", cipher);
     checkLogs(expectedS2C);
     checkLogs(expectedC2S);
   }
@@ -329,8 +330,8 @@ public class AlgorithmsIT {
     session.setConfig("cipher.c2s", "aes128-ctr");
     doSftp(session, true);
 
-    String expectedS2C = String.format("kex: server->client .* MAC: %s.*", mac);
-    String expectedC2S = String.format("kex: client->server .* MAC: %s.*", mac);
+    String expectedS2C = String.format(Locale.ROOT, "kex: server->client .* MAC: %s.*", mac);
+    String expectedC2S = String.format(Locale.ROOT, "kex: client->server .* MAC: %s.*", mac);
     checkLogs(expectedS2C);
     checkLogs(expectedC2S);
   }
@@ -344,8 +345,10 @@ public class AlgorithmsIT {
     session.setConfig("compression.c2s", compression);
     doSftp(session, true);
 
-    String expectedS2C = String.format("kex: server->client .* compression: %s.*", compression);
-    String expectedC2S = String.format("kex: client->server .* compression: %s.*", compression);
+    String expectedS2C =
+        String.format(Locale.ROOT, "kex: server->client .* compression: %s.*", compression);
+    String expectedC2S =
+        String.format(Locale.ROOT, "kex: client->server .* compression: %s.*", compression);
     checkLogs(expectedS2C);
     checkLogs(expectedC2S);
   }
@@ -360,7 +363,7 @@ public class AlgorithmsIT {
     session.setConfig("zlib@openssh.com", impl);
     doSftp(session, true);
 
-    String expectedImpl = String.format("zlib using %s", impl);
+    String expectedImpl = String.format(Locale.ROOT, "zlib using %s", impl);
     String expectedS2C = "kex: server->client .* compression: zlib@openssh\\.com.*";
     String expectedC2S = "kex: client->server .* compression: zlib@openssh\\.com.*";
     checkLogs(expectedImpl);
@@ -392,7 +395,7 @@ public class AlgorithmsIT {
     } catch (JSchException expected) {
     }
 
-    String expected = String.format("RSA key fingerprint is %s.", fingerprint);
+    String expected = String.format(Locale.ROOT, "RSA key fingerprint is %s.", fingerprint);
     List<String> msgs = userInfo.getMessages().stream().map(msg -> msg.split("\n"))
         .flatMap(Arrays::stream).collect(toList());
     Optional<String> actual = msgs.stream().filter(msg -> msg.equals(expected)).findFirst();
@@ -460,7 +463,8 @@ public class AlgorithmsIT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/JSchAlgoNegoFailExceptionIT.java
+++ b/src/test/java/com/jcraft/jsch/JSchAlgoNegoFailExceptionIT.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.testcontainers.containers.GenericContainer;
@@ -62,7 +63,7 @@ public class JSchAlgoNegoFailExceptionIT {
     if (algorithmName.equals("kex")) {
       jschProposal += ",ext-info-c";
     }
-    String message = String.format(
+    String message = String.format(Locale.ROOT,
         "Algorithm negotiation fail: algorithmName=\"%s\" jschProposal=\"%s\" serverProposal=\"%s\"",
         algorithmName, jschProposal, serverProposal);
 
@@ -83,7 +84,8 @@ public class JSchAlgoNegoFailExceptionIT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSH74ServerSigAlgsIT.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -143,7 +144,8 @@ public class OpenSSH74ServerSigAlgsIT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -15,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class OpenSSHConfigTest {
 
-  Map<String, String> keyMap = OpenSSHConfig.getKeymap().entrySet().stream().collect(
-      Collectors.toMap(entry -> entry.getValue().toUpperCase(), Map.Entry::getKey, (s, s2) -> s2));
+  Map<String, String> keyMap = OpenSSHConfig.getKeymap().entrySet().stream().collect(Collectors
+      .toMap(entry -> entry.getValue().toUpperCase(Locale.ROOT), Map.Entry::getKey, (s, s2) -> s2));
 
   @Test
   void parseFile() throws IOException, URISyntaxException {
@@ -52,7 +53,7 @@ class OpenSSHConfigTest {
   void appendAlgorithms(String key) throws IOException {
     OpenSSHConfig parse = OpenSSHConfig.parse(key + " +someValue,someValue1");
     ConfigRepository.Config config = parse.getConfig("");
-    String mappedKey = Optional.ofNullable(keyMap.get(key.toUpperCase())).orElse(key);
+    String mappedKey = Optional.ofNullable(keyMap.get(key.toUpperCase(Locale.ROOT))).orElse(key);
     assertEquals(JSch.getConfig(mappedKey) + "," + "someValue,someValue1",
         config.getValue(mappedKey));
   }
@@ -63,7 +64,7 @@ class OpenSSHConfigTest {
   void prependAlgorithms(String key) throws IOException {
     OpenSSHConfig parse = OpenSSHConfig.parse(key + " ^someValue,someValue1");
     ConfigRepository.Config config = parse.getConfig("");
-    String mappedKey = Optional.ofNullable(keyMap.get(key.toUpperCase())).orElse(key);
+    String mappedKey = Optional.ofNullable(keyMap.get(key.toUpperCase(Locale.ROOT))).orElse(key);
     assertEquals("someValue,someValue1," + JSch.getConfig(mappedKey), config.getValue(mappedKey));
   }
 

--- a/src/test/java/com/jcraft/jsch/SSHAgentIT.java
+++ b/src/test/java/com/jcraft/jsch/SSHAgentIT.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -353,7 +354,8 @@ public class SSHAgentIT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -139,8 +140,8 @@ public class ServerSigAlgsIT {
     doSftp(session, true);
 
     String expectedKex = "kex: host key algorithm: rsa-sha2-512";
-    String expectedPubkeysNoServerSigs =
-        String.format("No server-sig-algs found, using PubkeyAcceptedAlgorithms = %s", algos);
+    String expectedPubkeysNoServerSigs = String.format(Locale.ROOT,
+        "No server-sig-algs found, using PubkeyAcceptedAlgorithms = %s", algos);
     String expectedPreauthFail1 = "ssh-rsa-sha512@ssh.com preauth failure";
     String expectedPreauthFail2 = "ssh-rsa-sha384@ssh.com preauth failure";
     String expectedPreauthFail3 = "ssh-rsa-sha256@ssh.com preauth failure";
@@ -167,7 +168,8 @@ public class ServerSigAlgsIT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/SessionReconnectIT.java
+++ b/src/test/java/com/jcraft/jsch/SessionReconnectIT.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -112,7 +113,8 @@ public class SessionReconnectIT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/UserAuthIT.java
+++ b/src/test/java/com/jcraft/jsch/UserAuthIT.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -144,7 +145,8 @@ public class UserAuthIT {
   private HostKey readHostKey(String fileName) throws Exception {
     List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
     String[] split = lines.get(0).split("\\s+");
-    String hostname = String.format("[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
     return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
   }
 

--- a/src/test/java/com/jcraft/jsch/jbcrypt/BCryptTest.java
+++ b/src/test/java/com/jcraft/jsch/jbcrypt/BCryptTest.java
@@ -14,11 +14,11 @@
 
 package com.jcraft.jsch.jbcrypt;
 
-import org.junit.jupiter.api.Test;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit unit tests for BCrypt routines
@@ -246,14 +246,14 @@ public class BCryptTest {
   }
 
   BCryptPbkdfTV[] bcrypt_pbkdf_test_vectors = new BCryptPbkdfTV[] {
-      new BCryptPbkdfTV("password".getBytes(), "salt".getBytes(), 4,
+      new BCryptPbkdfTV("password".getBytes(UTF_8), "salt".getBytes(UTF_8), 4,
           new byte[] {(byte) 0x5b, (byte) 0xbf, (byte) 0x0c, (byte) 0xc2, (byte) 0x93, (byte) 0x58,
               (byte) 0x7f, (byte) 0x1c, (byte) 0x36, (byte) 0x35, (byte) 0x55, (byte) 0x5c,
               (byte) 0x27, (byte) 0x79, (byte) 0x65, (byte) 0x98, (byte) 0xd4, (byte) 0x7e,
               (byte) 0x57, (byte) 0x90, (byte) 0x71, (byte) 0xbf, (byte) 0x42, (byte) 0x7e,
               (byte) 0x9d, (byte) 0x8f, (byte) 0xbe, (byte) 0x84, (byte) 0x2a, (byte) 0xba,
               (byte) 0x34, (byte) 0xd9,}),
-      new BCryptPbkdfTV("password".getBytes(), "salt".getBytes(), 8,
+      new BCryptPbkdfTV("password".getBytes(UTF_8), "salt".getBytes(UTF_8), 8,
           new byte[] {(byte) 0xe1, (byte) 0x36, (byte) 0x7e, (byte) 0xc5, (byte) 0x15, (byte) 0x1a,
               (byte) 0x33, (byte) 0xfa, (byte) 0xac, (byte) 0x4c, (byte) 0xc1, (byte) 0xc1,
               (byte) 0x44, (byte) 0xcd, (byte) 0x23, (byte) 0xfa, (byte) 0x15, (byte) 0xd5,
@@ -265,7 +265,7 @@ public class BCryptTest {
               (byte) 0xe7, (byte) 0x4b, (byte) 0xba, (byte) 0x51, (byte) 0x72, (byte) 0x3f,
               (byte) 0xef, (byte) 0xa9, (byte) 0xf9, (byte) 0x47, (byte) 0x4d, (byte) 0x65,
               (byte) 0x08, (byte) 0x84, (byte) 0x5e, (byte) 0x8d}),
-      new BCryptPbkdfTV("password".getBytes(), "salt".getBytes(), 42,
+      new BCryptPbkdfTV("password".getBytes(UTF_8), "salt".getBytes(UTF_8), 42,
           new byte[] {(byte) 0x83, (byte) 0x3c, (byte) 0xf0, (byte) 0xdc, (byte) 0xf5, (byte) 0x6d,
               (byte) 0xb6, (byte) 0x56, (byte) 0x08, (byte) 0xe8, (byte) 0xf0, (byte) 0xdc,
               (byte) 0x0c, (byte) 0xe8, (byte) 0x82, (byte) 0xbd}),};

--- a/src/test/java/com/jcraft/jsch/jzlib/DeflateInflateTest.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/DeflateInflateTest.java
@@ -1,6 +1,7 @@
 package com.jcraft.jsch.jzlib;
 
 import static com.jcraft.jsch.jzlib.JZlib.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -90,7 +91,7 @@ public class DeflateInflateTest {
 
   @Test
   public void testDeflaterAndInflaterCanDeflateAndInflateDataInSmallBuffer() {
-    byte[] data = "hello, hello!".getBytes();
+    byte[] data = "hello, hello!".getBytes(UTF_8);
 
     err = deflater.init(Z_DEFAULT_COMPRESSION);
     assertEquals(Z_OK, err);
@@ -142,8 +143,8 @@ public class DeflateInflateTest {
 
   @Test
   public void testDeflaterAndInflaterSupportDictionary() {
-    byte[] hello = "hello".getBytes();
-    byte[] dictionary = "hello, hello!".getBytes();
+    byte[] hello = "hello".getBytes(UTF_8);
+    byte[] dictionary = "hello, hello!".getBytes(UTF_8);
 
     err = deflater.init(Z_DEFAULT_COMPRESSION);
     assertEquals(Z_OK, err);
@@ -198,7 +199,7 @@ public class DeflateInflateTest {
 
   @Test
   public void testDeflaterAndInflaterSupportSync() {
-    byte[] hello = "hello".getBytes();
+    byte[] hello = "hello".getBytes(UTF_8);
 
     err = deflater.init(Z_DEFAULT_COMPRESSION);
     assertEquals(Z_OK, err);
@@ -244,12 +245,12 @@ public class DeflateInflateTest {
     byte[] actual = new byte[total_out];
     System.arraycopy(uncompr, 0, actual, 0, total_out);
 
-    assertEquals(new String(hello), "hel" + new String(actual));
+    assertEquals(new String(hello, UTF_8), "hel" + new String(actual, UTF_8));
   }
 
   @Test
   public void testInflaterCanInflateGzipData() {
-    byte[] hello = "foo".getBytes();
+    byte[] hello = "foo".getBytes(UTF_8);
     byte[] data = {(byte) 0x1f, (byte) 0x8b, (byte) 0x08, (byte) 0x18, (byte) 0x08, (byte) 0xeb,
         (byte) 0x7a, (byte) 0x0b, (byte) 0x00, (byte) 0x0b, (byte) 0x58, (byte) 0x00, (byte) 0x59,
         (byte) 0x00, (byte) 0x4b, (byte) 0xcb, (byte) 0xcf, (byte) 0x07, (byte) 0x00, (byte) 0x21,
@@ -284,7 +285,7 @@ public class DeflateInflateTest {
 
   @Test
   public void testInflaterAndDeflaterCanSupportGzipData() {
-    byte[] data = "hello, hello!".getBytes();
+    byte[] data = "hello, hello!".getBytes(UTF_8);
 
     err = deflater.init(Z_DEFAULT_COMPRESSION, 15 + 16);
     assertEquals(Z_OK, err);

--- a/src/test/java/com/jcraft/jsch/jzlib/DeflaterInflaterStreamTest.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/DeflaterInflaterStreamTest.java
@@ -1,6 +1,7 @@
 package com.jcraft.jsch.jzlib;
 
 import static com.jcraft.jsch.jzlib.Package.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -94,7 +95,7 @@ public class DeflaterInflaterStreamTest {
 
     Arrays.asList(randombuf(10240),
         "{\"color\":2,\"id\":\"EvLd4UG.CXjnk35o1e8LrYYQfHu0h.d*SqVJPoqmzXM::Ly::Snaps::Store::Commit\"}"
-            .getBytes())
+            .getBytes(UTF_8))
         .forEach(uncheckedConsumer(data1 -> {
           Deflater deflater = new Deflater(JZlib.Z_DEFAULT_COMPRESSION, JZlib.MAX_WBITS, true);
 

--- a/src/test/java/com/jcraft/jsch/jzlib/WrapperTypeTest.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/WrapperTypeTest.java
@@ -2,6 +2,7 @@ package com.jcraft.jsch.jzlib;
 
 import static com.jcraft.jsch.jzlib.JZlib.*;
 import static com.jcraft.jsch.jzlib.Package.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -17,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class WrapperTypeTest {
-  private final byte[] data = "hello, hello!".getBytes();
+  private final byte[] data = "hello, hello!".getBytes(UTF_8);
 
   private final int comprLen = 40000;
   private final int uncomprLen = comprLen;
@@ -92,7 +93,7 @@ public class WrapperTypeTest {
       c.good.forEach(w -> {
         ZStream inflater = inflate(compr, uncompr, w);
         int total_out = (int) inflater.total_out;
-        assertEquals(new String(data), new String(uncompr, 0, total_out));
+        assertEquals(new String(data, UTF_8), new String(uncompr, 0, total_out, UTF_8));
       });
 
       c.bad.forEach(w -> {
@@ -129,7 +130,7 @@ public class WrapperTypeTest {
     assertEquals(Z_OK, err);
 
     int total_out = (int) inflater.total_out;
-    assertEquals(new String(data), new String(uncompr, 0, total_out));
+    assertEquals(new String(data, UTF_8), new String(uncompr, 0, total_out, UTF_8));
 
     deflater = new Deflater();
     err = deflater.init(Z_BEST_SPEED, DEF_WBITS + 16, 9);
@@ -156,7 +157,7 @@ public class WrapperTypeTest {
     assertEquals(Z_OK, err);
 
     total_out = (int) inflater.total_out;
-    assertEquals(new String(data), new String(uncompr, 0, total_out));
+    assertEquals(new String(data, UTF_8), new String(uncompr, 0, total_out, UTF_8));
   }
 
   private void deflate(ZStream deflater, byte[] data, byte[] compr) {


### PR DESCRIPTION
- Adjust maven workflow to split unit & integrations into separate steps so that they can be executed via direct mojo calls and thus avoiding potentially reexecuting prior phases.
- Integrate Forbidden API Checker and resolve issues it flagged.
- #457 address CVE-2023-48795 by adding support for new strict key exchange extension.
-- This change introduces two new config options to control usage of the new strict key exchange extension:
--- `enable_strict_kex` (set to `yes` by default)
--- `require_strict_kex` (set to `no` by default)
-- If either option (or both) is enabled, then JSch will attempt to use the new strict key exchange extension.
--- If the `require_strict_kex` option is enabled and JSch detects the server does not support it, then JSch will terminate the connection and throw an exception.
--- If the `require_strict_kex` option is not enabled and JSch detects the server does not support it, then JSch will fallback and proceed with the connection without using the new extension.
--- This gives users the ability to enable a strong security posture if needed and avoid proceeding with connections to potentially insecure servers.
