### PR TITLE
Do not falsely log support for ext-info if the server did not return 'ext-info-s'

### DIFF
--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -602,7 +602,7 @@ public class Session {
 
       if (enable_server_sig_algs) {
         doExtInfo = checkServerExtInfo();
-        if (getLogger().isEnabled(Logger.INFO)) {
+        if (doExtInfo && getLogger().isEnabled(Logger.INFO)) {
           getLogger().log(Logger.INFO, "ext-info messaging supported by server");
         }
       }


### PR DESCRIPTION
Opted for not logging, another option would be to log something along the lines of `not supported` 