### PR TITLE
0.2.17 changes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,7 @@ jobs:
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Test with Maven
-      run: ./mvnw -B -V -e -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -DskipITs=false
+      run: ./mvnw -B -V -e -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -DskipITs=false
     - uses: actions/upload-artifact@v4
       with:
         name: java-${{ matrix.java }}-testresults

--- a/examples/AES.java
+++ b/examples/AES.java
@@ -1,7 +1,4 @@
-/**
- * This program will demonstrate how to use "aes128-cbc".
- *
- */
+/** This program will demonstrate how to use "aes128-cbc". */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;
@@ -153,5 +150,3 @@ public class AES {
     }
   }
 }
-
-

--- a/examples/AES.java
+++ b/examples/AES.java
@@ -2,9 +2,20 @@
  * This program will demonstrate how to use "aes128-cbc".
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class AES {
   public static void main(String[] arg) {

--- a/examples/ChangePassphrase.java
+++ b/examples/ChangePassphrase.java
@@ -3,7 +3,6 @@
  * a new private key. A passphrase will be prompted if the given private-key has been encrypted.
  * After successfully loading the content of the private-key, the new passphrase will be prompted
  * and the given private-key will be re-encrypted with that new passphrase.
- *
  */
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;

--- a/examples/ChangePassphrase.java
+++ b/examples/ChangePassphrase.java
@@ -5,8 +5,11 @@
  * and the given private-key will be re-encrypted with that new passphrase.
  *
  */
-import com.jcraft.jsch.*;
-import javax.swing.*;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.KeyPair;
+import javax.swing.JOptionPane;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class ChangePassphrase {
   public static void main(String[] arg) {

--- a/examples/Compression.java
+++ b/examples/Compression.java
@@ -4,9 +4,20 @@
  * sshd server to jsch will be compressed.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class Compression {
   public static void main(String[] arg) {

--- a/examples/Compression.java
+++ b/examples/Compression.java
@@ -2,7 +2,6 @@
  * This program will demonstrate the packet compression. You will be asked username, hostname and
  * passwd. If everything works fine, you will get the shell prompt. In this program, all data from
  * sshd server to jsch will be compressed.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
@@ -152,5 +151,3 @@ public class Compression {
     }
   }
 }
-
-

--- a/examples/Daemon.java
+++ b/examples/Daemon.java
@@ -1,7 +1,6 @@
 /**
  * This program will demonstrate how to provide a network service like inetd by using remote
  * port-forwarding functionality.
- *
  */
 import com.jcraft.jsch.ChannelForwardedTCPIP;
 import com.jcraft.jsch.ForwardedTCPIPDaemon;

--- a/examples/Daemon.java
+++ b/examples/Daemon.java
@@ -3,10 +3,25 @@
  * port-forwarding functionality.
  *
  */
-import com.jcraft.jsch.*;
-import java.io.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.ChannelForwardedTCPIP;
+import com.jcraft.jsch.ForwardedTCPIPDaemon;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class Daemon {
   public static void main(String[] arg) {

--- a/examples/Exec.java
+++ b/examples/Exec.java
@@ -2,7 +2,6 @@
  * This program will demonstrate remote exec. You will be asked username, hostname, displayname,
  * passwd and command. If everything works fine, given command will be invoked on the remote side
  * and outputs will be printed out.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;

--- a/examples/Exec.java
+++ b/examples/Exec.java
@@ -4,10 +4,22 @@
  * and outputs will be printed out.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
-import java.io.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.InputStream;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class Exec {
   public static void main(String[] arg) {

--- a/examples/JSchWithAgentProxy.java
+++ b/examples/JSchWithAgentProxy.java
@@ -1,6 +1,13 @@
-import com.jcraft.jsch.*;
-import java.io.*;
-import javax.swing.*;
+import com.jcraft.jsch.AgentIdentityRepository;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelShell;
+import com.jcraft.jsch.IdentityRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.SSHAgentConnector;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import javax.swing.JOptionPane;
 
 public class JSchWithAgentProxy {
   public static void main(String[] arg) {

--- a/examples/JumpHosts.java
+++ b/examples/JumpHosts.java
@@ -3,7 +3,6 @@
  * to host2 and host3. java JumpHosts usr1@host1 usr2@host2 usr3@host3. You will be asked passwords
  * for those destinations. If everything works fine, you will get file lists of your home-directory
  * at host3.
- *
  */
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;

--- a/examples/JumpHosts.java
+++ b/examples/JumpHosts.java
@@ -5,9 +5,20 @@
  * at host3.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class JumpHosts {
   public static void main(String[] arg) {

--- a/examples/KeyGen.java
+++ b/examples/KeyGen.java
@@ -4,8 +4,11 @@
  * output_keyfile+".pub". The private key and public key are in the OpenSSH format.
  *
  */
-import com.jcraft.jsch.*;
-import javax.swing.*;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.KeyPair;
+import javax.swing.JOptionPane;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class KeyGen {
   public static void main(String[] arg) {

--- a/examples/KeyGen.java
+++ b/examples/KeyGen.java
@@ -2,7 +2,6 @@
  * This progam will demonstrate the keypair generation. You will be asked a passphrase for
  * output_keyfile. If everything works fine, you will get the keypair, output_keyfile and
  * output_keyfile+".pub". The private key and public key are in the OpenSSH format.
- *
  */
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;

--- a/examples/KnownHosts.java
+++ b/examples/KnownHosts.java
@@ -5,9 +5,23 @@
  * it.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.HostKey;
+import com.jcraft.jsch.HostKeyRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class KnownHosts {
   public static void main(String[] arg) {

--- a/examples/KnownHosts.java
+++ b/examples/KnownHosts.java
@@ -3,7 +3,6 @@
  * hostname, a path for 'known_hosts' and passwd. If everything works fine, you will get the shell
  * prompt. In current implementation, jsch only reads 'known_hosts' for checking and does not modify
  * it.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.HostKey;
@@ -173,5 +172,3 @@ public class KnownHosts {
     }
   }
 }
-
-

--- a/examples/Logger.java
+++ b/examples/Logger.java
@@ -2,9 +2,20 @@
  * This program will demonstrate how to enable logging mechanism and get logging messages.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class Logger {
   public static void main(String[] arg) {

--- a/examples/Logger.java
+++ b/examples/Logger.java
@@ -1,7 +1,4 @@
-/**
- * This program will demonstrate how to enable logging mechanism and get logging messages.
- *
- */
+/** This program will demonstrate how to enable logging mechanism and get logging messages. */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;
@@ -55,6 +52,7 @@ public class Logger {
 
   public static class MyLogger implements com.jcraft.jsch.Logger {
     static java.util.Map<Integer, String> name = new java.util.HashMap<>();
+
     static {
       name.put(DEBUG, "DEBUG: ");
       name.put(INFO, "INFO: ");
@@ -169,5 +167,3 @@ public class Logger {
     }
   }
 }
-
-

--- a/examples/OpenSSHConfig.java
+++ b/examples/OpenSSHConfig.java
@@ -4,9 +4,13 @@
  * lacks of terminal-emulation, but you can issue commands.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ConfigRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import javax.swing.JOptionPane;
 
 public class OpenSSHConfig {
   public static void main(String[] arg) {

--- a/examples/OpenSSHConfig.java
+++ b/examples/OpenSSHConfig.java
@@ -2,7 +2,6 @@
  * This program demonsrates how to use OpenSSHConfig class. You will be asked username, hostname and
  * passwd. If everything works fine, you will get the shell prompt. Output may be ugly because of
  * lacks of terminal-emulation, but you can issue commands.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ConfigRepository;
@@ -100,7 +99,7 @@ public class OpenSSHConfig {
     }
   }
 
-  public static abstract class MyUserInfo implements UserInfo, UIKeyboardInteractive {
+  public abstract static class MyUserInfo implements UserInfo, UIKeyboardInteractive {
     @Override
     public String getPassword() {
       return null;

--- a/examples/PortForwardingL.java
+++ b/examples/PortForwardingL.java
@@ -5,9 +5,19 @@
  * will get the shell prompt. Try the port on localhost.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class PortForwardingL {
   public static void main(String[] arg) {

--- a/examples/PortForwardingL.java
+++ b/examples/PortForwardingL.java
@@ -3,7 +3,6 @@
  * on the local host will be forwarded to the given remote host and port on the remote side. You
  * will be asked username, hostname, port:host:hostport and passwd. If everything works fine, you
  * will get the shell prompt. Try the port on localhost.
- *
  */
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;

--- a/examples/PortForwardingR.java
+++ b/examples/PortForwardingR.java
@@ -5,9 +5,19 @@
  * the shell prompt. Try the port on remote host.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class PortForwardingR {
   public static void main(String[] arg) {

--- a/examples/PortForwardingR.java
+++ b/examples/PortForwardingR.java
@@ -3,7 +3,6 @@
  * on the remote host will be forwarded to the given host and port on the local side. You will be
  * asked username, hostname, port:host:hostport and passwd. If everything works fine, you will get
  * the shell prompt. Try the port on remote host.
- *
  */
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;

--- a/examples/ScpFrom.java
+++ b/examples/ScpFrom.java
@@ -1,7 +1,6 @@
 /**
  * This program will demonstrate the file transfer from remote to local. If everything works fine, a
  * file 'file1' on 'remotehost' will copied to local 'file1'.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;

--- a/examples/ScpFrom.java
+++ b/examples/ScpFrom.java
@@ -3,10 +3,26 @@
  * file 'file1' on 'remotehost' will copied to local 'file1'.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
-import java.io.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class ScpFrom {
   public static void main(String[] arg) {

--- a/examples/ScpTo.java
+++ b/examples/ScpTo.java
@@ -1,7 +1,6 @@
 /**
  * This program will demonstrate the file transfer from local to remote. You will be asked passwd.
  * If everything works fine, a local file 'file1' will copied to 'file2' on 'remotehost'.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;

--- a/examples/ScpTo.java
+++ b/examples/ScpTo.java
@@ -3,10 +3,26 @@
  * If everything works fine, a local file 'file1' will copied to 'file2' on 'remotehost'.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
-import java.io.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class ScpTo {
   public static void main(String[] arg) {

--- a/examples/ScpToNoneCipher.java
+++ b/examples/ScpToNoneCipher.java
@@ -3,10 +3,26 @@
  * works fine, a local file 'file1' will copied to 'file2' on 'remotehost'.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
-import java.io.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class ScpToNoneCipher {
   public static void main(String[] arg) {

--- a/examples/ScpToNoneCipher.java
+++ b/examples/ScpToNoneCipher.java
@@ -1,7 +1,6 @@
 /**
  * This program will demonstrate how to enable none cipher. You will be asked passwd. If everything
  * works fine, a local file 'file1' will copied to 'file2' on 'remotehost'.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;

--- a/examples/Sftp.java
+++ b/examples/Sftp.java
@@ -2,7 +2,6 @@
  * This program will demonstrate the sftp protocol support. If everything works fine, you will get a
  * prompt 'sftp>'. 'help' command will show available command. In current implementation, the
  * destination path for 'get' and 'put' commands must be a file, not a directory.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelSftp;

--- a/examples/Sftp.java
+++ b/examples/Sftp.java
@@ -4,9 +4,26 @@
  * destination path for 'get' and 'put' commands must be a file, not a directory.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.SftpATTRS;
+import com.jcraft.jsch.SftpException;
+import com.jcraft.jsch.SftpProgressMonitor;
+import com.jcraft.jsch.SftpStatVFS;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
+import javax.swing.ProgressMonitor;
 
 public class Sftp {
   public static void main(String[] arg) {

--- a/examples/Shell.java
+++ b/examples/Shell.java
@@ -4,9 +4,12 @@
  * may be ugly because of lacks of terminal-emulation, but you can issue commands.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import javax.swing.JOptionPane;
 
 public class Shell {
   public static void main(String[] arg) {

--- a/examples/Shell.java
+++ b/examples/Shell.java
@@ -2,7 +2,6 @@
  * This program enables you to connect to sshd server and get the shell prompt. You will be asked
  * username, hostname and passwd. If everything works fine, you will get the shell prompt. Output
  * may be ugly because of lacks of terminal-emulation, but you can issue commands.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
@@ -94,7 +93,7 @@ public class Shell {
     }
   }
 
-  public static abstract class MyUserInfo implements UserInfo, UIKeyboardInteractive {
+  public abstract static class MyUserInfo implements UserInfo, UIKeyboardInteractive {
     @Override
     public String getPassword() {
       return null;

--- a/examples/SocketForwardingL.java
+++ b/examples/SocketForwardingL.java
@@ -2,7 +2,6 @@
  * This program enables you to connect to sshd server and forward the docker socket. You will be
  * asked username, hostname and passwd. If everything works fine, you will get the response code to
  * the _ping endpoint of the dockerd.
- *
  */
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;
@@ -77,13 +76,12 @@ public class SocketForwardingL {
       HttpURLConnection myURLConnection2 = (HttpURLConnection) myURL.openConnection();
       System.out.println("Docker Ping http response code: " + myURLConnection2.getResponseCode());
 
-
     } catch (Exception e) {
       System.out.println(e);
     }
   }
 
-  public static abstract class MyUserInfo implements UserInfo, UIKeyboardInteractive {
+  public abstract static class MyUserInfo implements UserInfo, UIKeyboardInteractive {
     @Override
     public String getPassword() {
       return null;

--- a/examples/SocketForwardingL.java
+++ b/examples/SocketForwardingL.java
@@ -4,11 +4,13 @@
  * the _ping endpoint of the dockerd.
  *
  */
-import com.jcraft.jsch.*;
-
-import javax.swing.*;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import javax.swing.JOptionPane;
 
 public class SocketForwardingL {
   public static void main(String[] arg) {

--- a/examples/StreamForwarding.java
+++ b/examples/StreamForwarding.java
@@ -4,7 +4,6 @@
  * command, but you don't have to assign and open a local tcp port. You will be asked username,
  * hostname, host:hostport and passwd. If everything works fine, System.in and System.out streams
  * will be forwared to remote port and you can send messages from command line.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
@@ -155,5 +154,3 @@ public class StreamForwarding {
     }
   }
 }
-
-

--- a/examples/StreamForwarding.java
+++ b/examples/StreamForwarding.java
@@ -6,9 +6,20 @@
  * will be forwared to remote port and you can send messages from command line.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class StreamForwarding {
   public static void main(String[] arg) {

--- a/examples/Subsystem.java
+++ b/examples/Subsystem.java
@@ -2,9 +2,21 @@
  * This program will demonstrate how to use the Subsystem channel.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelSubsystem;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class Subsystem {
   public static void main(String[] arg) {

--- a/examples/Subsystem.java
+++ b/examples/Subsystem.java
@@ -1,7 +1,4 @@
-/**
- * This program will demonstrate how to use the Subsystem channel.
- *
- */
+/** This program will demonstrate how to use the Subsystem channel. */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelSubsystem;
 import com.jcraft.jsch.JSch;

--- a/examples/Sudo.java
+++ b/examples/Sudo.java
@@ -1,7 +1,4 @@
-/**
- * This program will demonstrate how to exec 'sudo' on the remote.
- *
- */
+/** This program will demonstrate how to exec 'sudo' on the remote. */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
@@ -64,7 +61,6 @@ public class Sudo {
       // -p The -p (prompt) option allows you to override the default
       // password prompt and use a custom one.
       ((ChannelExec) channel).setCommand("sudo -S -p '' " + command);
-
 
       InputStream in = channel.getInputStream();
       OutputStream out = channel.getOutputStream();

--- a/examples/Sudo.java
+++ b/examples/Sudo.java
@@ -2,10 +2,23 @@
  * This program will demonstrate how to exec 'sudo' on the remote.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
-import java.io.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class Sudo {
   public static void main(String[] arg) {

--- a/examples/UserAuthKI.java
+++ b/examples/UserAuthKI.java
@@ -1,7 +1,6 @@
 /**
  * This program will demonstrate the keyboard-interactive authentication. If the remote sshd
  * supports keyboard-interactive authentication, you will be prompted.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;

--- a/examples/UserAuthKI.java
+++ b/examples/UserAuthKI.java
@@ -3,9 +3,20 @@
  * supports keyboard-interactive authentication, you will be prompted.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class UserAuthKI {
   public static void main(String[] arg) {

--- a/examples/UserAuthPubKey.java
+++ b/examples/UserAuthPubKey.java
@@ -2,7 +2,6 @@
  * This program will demonstrate the user authentification by public key. You will be asked
  * username, hostname, privatekey(id_dsa) and passphrase. If everything works fine, you will get the
  * shell prompt.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
@@ -64,7 +63,6 @@ public class UserAuthPubKey {
       System.out.println(e);
     }
   }
-
 
   public static class MyUserInfo implements UserInfo, UIKeyboardInteractive {
     @Override

--- a/examples/UserAuthPubKey.java
+++ b/examples/UserAuthPubKey.java
@@ -4,9 +4,21 @@
  * shell prompt.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class UserAuthPubKey {
   public static void main(String[] arg) {

--- a/examples/ViaHTTP.java
+++ b/examples/ViaHTTP.java
@@ -1,7 +1,6 @@
 /**
  * This program will demonstrate the ssh session via HTTP proxy. You will be asked username,
  * hostname, proxy-server and passwd. If everything works fine, you will get the shell prompt.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
@@ -156,7 +155,4 @@ public class ViaHTTP {
       }
     }
   }
-
 }
-
-

--- a/examples/ViaHTTP.java
+++ b/examples/ViaHTTP.java
@@ -3,9 +3,21 @@
  * hostname, proxy-server and passwd. If everything works fine, you will get the shell prompt.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.ProxyHTTP;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class ViaHTTP {
   public static void main(String[] arg) {

--- a/examples/ViaSOCKS5.java
+++ b/examples/ViaSOCKS5.java
@@ -1,7 +1,6 @@
 /**
  * This program will demonstrate the ssh session via SOCKS proxy. You will be asked username,
  * hostname, proxy-server and passwd. If everything works fine, you will get the shell prompt.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
@@ -157,5 +156,3 @@ public class ViaSOCKS5 {
     }
   }
 }
-
-

--- a/examples/ViaSOCKS5.java
+++ b/examples/ViaSOCKS5.java
@@ -3,9 +3,21 @@
  * hostname, proxy-server and passwd. If everything works fine, you will get the shell prompt.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.ProxySOCKS5;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class ViaSOCKS5 {
   public static void main(String[] arg) {

--- a/examples/X11Forwarding.java
+++ b/examples/X11Forwarding.java
@@ -4,9 +4,20 @@
  * everything works fine, you will get the shell prompt. Try X applications; for example, xlogo.
  *
  */
-import com.jcraft.jsch.*;
-import java.awt.*;
-import javax.swing.*;
+import com.jcraft.jsch.Channel;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
 
 public class X11Forwarding {
   public static void main(String[] arg) {

--- a/examples/X11Forwarding.java
+++ b/examples/X11Forwarding.java
@@ -2,7 +2,6 @@
  * This program will demonstrate X11 forwarding. You will be asked username, hostname, displayname
  * and passwd. If your X server does not run at 127.0.0.1, please enter correct displayname. If
  * everything works fine, you will get the shell prompt. Try X applications; for example, xlogo.
- *
  */
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.JSch;
@@ -160,5 +159,3 @@ public class X11Forwarding {
     }
   }
 }
-
-

--- a/src/main/java/com/jcraft/jsch/Buffer.java
+++ b/src/main/java/com/jcraft/jsch/Buffer.java
@@ -290,7 +290,6 @@ public class Buffer {
     return buf;
   }
 
-
   /*
    * static String[] chars={ "0","1","2","3","4","5","6","7","8","9", "a","b","c","d","e","f" };
    * static void dump_buffer(){ int foo; for(int i=0; i<tmp_buffer_index; i++){

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -26,7 +26,11 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.util.Vector;
 
 public abstract class Channel {

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -271,7 +271,6 @@ public abstract class Channel {
         } catch (JSchException e) {
           throw new IOException("failed to initialize the channel.", e);
         }
-
       }
 
       byte[] b = new byte[1];
@@ -340,7 +339,6 @@ public abstract class Channel {
           close();
           throw new IOException(e.toString(), e);
         }
-
       }
 
       @Override
@@ -701,6 +699,7 @@ public abstract class Channel {
       this.os = null;
     }
   }
+
   static class PassiveOutputStream extends PipedOutputStream {
     private MyPipedInputStream _sink = null;
 

--- a/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
+++ b/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
@@ -27,7 +27,6 @@
 package com.jcraft.jsch;
 
 import java.io.IOException;
-import java.net.*;
 import java.util.Vector;
 
 class ChannelAgentForwarding extends Channel {

--- a/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
+++ b/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
@@ -31,31 +31,31 @@ import java.util.Vector;
 
 class ChannelAgentForwarding extends Channel {
 
-  static private final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
-  static private final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
+  private static final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
+  private static final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
 
-  static private final byte SSH_AGENTC_REQUEST_RSA_IDENTITIES = 1;
-  static private final byte SSH_AGENT_RSA_IDENTITIES_ANSWER = 2;
-  static private final byte SSH_AGENTC_RSA_CHALLENGE = 3;
-  static private final byte SSH_AGENT_RSA_RESPONSE = 4;
-  static private final byte SSH_AGENT_FAILURE = 5;
-  static private final byte SSH_AGENT_SUCCESS = 6;
-  static private final byte SSH_AGENTC_ADD_RSA_IDENTITY = 7;
-  static private final byte SSH_AGENTC_REMOVE_RSA_IDENTITY = 8;
-  static private final byte SSH_AGENTC_REMOVE_ALL_RSA_IDENTITIES = 9;
+  private static final byte SSH_AGENTC_REQUEST_RSA_IDENTITIES = 1;
+  private static final byte SSH_AGENT_RSA_IDENTITIES_ANSWER = 2;
+  private static final byte SSH_AGENTC_RSA_CHALLENGE = 3;
+  private static final byte SSH_AGENT_RSA_RESPONSE = 4;
+  private static final byte SSH_AGENT_FAILURE = 5;
+  private static final byte SSH_AGENT_SUCCESS = 6;
+  private static final byte SSH_AGENTC_ADD_RSA_IDENTITY = 7;
+  private static final byte SSH_AGENTC_REMOVE_RSA_IDENTITY = 8;
+  private static final byte SSH_AGENTC_REMOVE_ALL_RSA_IDENTITIES = 9;
 
-  static private final byte SSH2_AGENTC_REQUEST_IDENTITIES = 11;
-  static private final byte SSH2_AGENT_IDENTITIES_ANSWER = 12;
-  static private final byte SSH2_AGENTC_SIGN_REQUEST = 13;
-  static private final byte SSH2_AGENT_SIGN_RESPONSE = 14;
-  static private final byte SSH2_AGENTC_ADD_IDENTITY = 17;
-  static private final byte SSH2_AGENTC_REMOVE_IDENTITY = 18;
-  static private final byte SSH2_AGENTC_REMOVE_ALL_IDENTITIES = 19;
-  static private final byte SSH2_AGENT_FAILURE = 30;
+  private static final byte SSH2_AGENTC_REQUEST_IDENTITIES = 11;
+  private static final byte SSH2_AGENT_IDENTITIES_ANSWER = 12;
+  private static final byte SSH2_AGENTC_SIGN_REQUEST = 13;
+  private static final byte SSH2_AGENT_SIGN_RESPONSE = 14;
+  private static final byte SSH2_AGENTC_ADD_IDENTITY = 17;
+  private static final byte SSH2_AGENTC_REMOVE_IDENTITY = 18;
+  private static final byte SSH2_AGENTC_REMOVE_ALL_IDENTITIES = 19;
+  private static final byte SSH2_AGENT_FAILURE = 30;
 
   // static private final int SSH_AGENT_OLD_SIGNATURE=0x1;
-  static private final int SSH_AGENT_RSA_SHA2_256 = 0x2;
-  static private final int SSH_AGENT_RSA_SHA2_512 = 0x4;
+  private static final int SSH_AGENT_RSA_SHA2_256 = 0x2;
+  private static final int SSH_AGENT_RSA_SHA2_512 = 0x4;
 
   private Buffer rbuf = null;
   private Buffer wbuf = null;

--- a/src/main/java/com/jcraft/jsch/ChannelDirectStreamLocal.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectStreamLocal.java
@@ -4,14 +4,15 @@ import static com.jcraft.jsch.Session.SSH_MSG_CHANNEL_OPEN;
 
 /**
  * Extension of {@link ChannelDirectTCPIP} to support socket forwarding.
+ *
  * <p>
  * https://raw.githubusercontent.com/openssh/openssh-portable/master/PROTOCOL
  */
 public class ChannelDirectStreamLocal extends ChannelDirectTCPIP {
 
-  static private final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
-  static private final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
-  static private final byte[] _type = Util.str2byte("direct-streamlocal@openssh.com");
+  private static final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
+  private static final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
+  private static final byte[] _type = Util.str2byte("direct-streamlocal@openssh.com");
 
   private String socketPath;
 

--- a/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
@@ -31,9 +31,9 @@ import java.io.OutputStream;
 
 public class ChannelDirectTCPIP extends Channel {
 
-  static private final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
-  static private final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
-  static private final byte[] _type = Util.str2byte("direct-tcpip");
+  private static final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
+  private static final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
+  private static final byte[] _type = Util.str2byte("direct-tcpip");
   String host;
   int port;
 

--- a/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
@@ -26,7 +26,8 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class ChannelDirectTCPIP extends Channel {
 

--- a/src/main/java/com/jcraft/jsch/ChannelExec.java
+++ b/src/main/java/com/jcraft/jsch/ChannelExec.java
@@ -26,7 +26,9 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class ChannelExec extends ChannelSession {
 

--- a/src/main/java/com/jcraft/jsch/ChannelExec.java
+++ b/src/main/java/com/jcraft/jsch/ChannelExec.java
@@ -27,7 +27,6 @@
 package com.jcraft.jsch;
 
 import java.io.*;
-import java.util.*;
 
 public class ChannelExec extends ChannelSession {
 

--- a/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
@@ -26,8 +26,8 @@
 
 package com.jcraft.jsch;
 
-import java.net.*;
-import java.io.*;
+import java.io.PipedOutputStream;
+import java.net.Socket;
 import java.util.Vector;
 
 public class ChannelForwardedTCPIP extends Channel {

--- a/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
@@ -34,11 +34,11 @@ public class ChannelForwardedTCPIP extends Channel {
 
   private static Vector<Config> pool = new Vector<>();
 
-  static private final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
+  private static final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
   // static private final int LOCAL_WINDOW_SIZE_MAX=0x100000;
-  static private final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
+  private static final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
 
-  static private final int TIMEOUT = 10 * 1000;
+  private static final int TIMEOUT = 10 * 1000;
 
   private Socket socket = null;
   private ForwardedTCPIPDaemon daemon = null;
@@ -278,7 +278,7 @@ public class ChannelForwardedTCPIP extends Channel {
       // string address_to_bind (e.g. "127.0.0.1")
       // uint32 port number to bind
       packet.reset();
-      buf.putByte((byte) 80/* SSH_MSG_GLOBAL_REQUEST */);
+      buf.putByte((byte) 80 /* SSH_MSG_GLOBAL_REQUEST */);
       buf.putString(Util.str2byte("cancel-tcpip-forward"));
       buf.putByte((byte) 0);
       buf.putString(Util.str2byte(address_to_bind));
@@ -315,7 +315,7 @@ public class ChannelForwardedTCPIP extends Channel {
       ((ConfigLHost) config).factory = factory;
   }
 
-  static abstract class Config {
+  abstract static class Config {
     Session session;
     int rport;
     int allocated_rport;

--- a/src/main/java/com/jcraft/jsch/ChannelSession.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSession.java
@@ -26,7 +26,8 @@
 
 package com.jcraft.jsch;
 
-import java.util.*;
+import java.util.Enumeration;
+import java.util.Hashtable;
 
 class ChannelSession extends Channel {
   private static byte[] _session = Util.str2byte("session");

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -26,7 +26,14 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Hashtable;

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -41,8 +41,8 @@ import java.util.Vector;
 
 public class ChannelSftp extends ChannelSession {
 
-  static private final int LOCAL_MAXIMUM_PACKET_SIZE = 32 * 1024;
-  static private final int LOCAL_WINDOW_SIZE_MAX = (64 * LOCAL_MAXIMUM_PACKET_SIZE);
+  private static final int LOCAL_MAXIMUM_PACKET_SIZE = 32 * 1024;
+  private static final int LOCAL_WINDOW_SIZE_MAX = (64 * LOCAL_MAXIMUM_PACKET_SIZE);
 
   private static final byte SSH_FXP_INIT = 1;
   private static final byte SSH_FXP_VERSION = 2;
@@ -1076,12 +1076,10 @@ public class ChannelSftp extends ChannelSession {
         length -= 4;
         int length_of_data = buf.getInt(); // length of data
 
-        /**
-         * Since sftp protocol version 6, "end-of-file" has been defined,
-         *
-         * byte SSH_FXP_DATA uint32 request-id string data bool end-of-file [optional]
-         *
-         * but some sftpd server will send such a field in the sftp protocol 3 ;-(
+        /*
+         * Since sftp protocol version 6, "end-of-file" has been defined, byte SSH_FXP_DATA uint32
+         * request-id string data bool end-of-file [optional] but some sftpd server will send such a
+         * field in the sftp protocol 3 ;-(
          */
         int optional_data = length - length_of_data;
 
@@ -1110,7 +1108,6 @@ public class ChannelSftp extends ChannelSession {
               break loop;
             }
           }
-
         }
         // System.err.println("length: "+length); // length should be 0
 
@@ -1143,7 +1140,6 @@ public class ChannelSftp extends ChannelSession {
     }
   }
 
-
   private class RequestQueue {
     class OutOfOrderException extends Exception {
       private static final long serialVersionUID = -1L;
@@ -1153,6 +1149,7 @@ public class ChannelSftp extends ChannelSession {
         this.offset = offset;
       }
     }
+
     class Request {
       int id;
       long offset;
@@ -1435,12 +1432,10 @@ public class ChannelSftp extends ChannelSession {
           int length_of_data = buf.getInt();
           rest_length -= 4;
 
-          /**
-           * Since sftp protocol version 6, "end-of-file" has been defined,
-           *
-           * byte SSH_FXP_DATA uint32 request-id string data bool end-of-file [optional]
-           *
-           * but some sftpd server will send such a field in the sftp protocol 3 ;-(
+          /*
+           * Since sftp protocol version 6, "end-of-file" has been defined, byte SSH_FXP_DATA uint32
+           * request-id string data bool end-of-file [optional] but some sftpd server will send such
+           * a field in the sftp protocol 3 ;-(
            */
           int optional_data = rest_length - length_of_data;
 
@@ -1593,7 +1588,6 @@ public class ChannelSftp extends ChannelSession {
             _pattern = Util.unquote(_pattern);
             pattern = Util.str2byte(_pattern, fEncoding);
           }
-
         }
       }
 
@@ -2522,7 +2516,7 @@ public class ChannelSftp extends ChannelSession {
   }
 
   private void sendOPENA(byte[] path) throws Exception {
-    sendOPEN(path, SSH_FXF_WRITE | /* SSH_FXF_APPEND| */SSH_FXF_CREAT);
+    sendOPEN(path, SSH_FXF_WRITE | /* SSH_FXF_APPEND | */ SSH_FXF_CREAT);
   }
 
   private void sendOPEN(byte[] path, int mode) throws Exception {
@@ -3034,7 +3028,6 @@ public class ChannelSftp extends ChannelSession {
     public final int BREAK = 1;
 
     /**
-     * <p>
      * The <code>select</code> method will be invoked in <code>ls</code> method for each file entry.
      * If this method returns BREAK, <code>ls</code> will be canceled.
      *

--- a/src/main/java/com/jcraft/jsch/ChannelShell.java
+++ b/src/main/java/com/jcraft/jsch/ChannelShell.java
@@ -26,8 +26,6 @@
 
 package com.jcraft.jsch;
 
-import java.util.*;
-
 public class ChannelShell extends ChannelSession {
 
   ChannelShell() {

--- a/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
@@ -26,7 +26,9 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class ChannelSubsystem extends ChannelSession {
   boolean want_reply = true;

--- a/src/main/java/com/jcraft/jsch/ChannelX11.java
+++ b/src/main/java/com/jcraft/jsch/ChannelX11.java
@@ -32,10 +32,10 @@ import java.util.Hashtable;
 
 class ChannelX11 extends Channel {
 
-  static private final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
-  static private final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
+  private static final int LOCAL_WINDOW_SIZE_MAX = 0x20000;
+  private static final int LOCAL_MAXIMUM_PACKET_SIZE = 0x4000;
 
-  static private final int TIMEOUT = 10 * 1000;
+  private static final int TIMEOUT = 10 * 1000;
 
   private static String host = "127.0.0.1";
   private static int port = 6000;

--- a/src/main/java/com/jcraft/jsch/ChannelX11.java
+++ b/src/main/java/com/jcraft/jsch/ChannelX11.java
@@ -27,7 +27,7 @@
 package com.jcraft.jsch;
 
 import java.io.IOException;
-import java.net.*;
+import java.net.Socket;
 import java.util.Hashtable;
 
 class ChannelX11 extends Channel {

--- a/src/main/java/com/jcraft/jsch/Compression.java
+++ b/src/main/java/com/jcraft/jsch/Compression.java
@@ -27,8 +27,8 @@
 package com.jcraft.jsch;
 
 public interface Compression {
-  static public final int INFLATER = 0;
-  static public final int DEFLATER = 1;
+  public static final int INFLATER = 0;
+  public static final int DEFLATER = 1;
 
   default void init(int type, int level, Session session) {
     init(type, level);

--- a/src/main/java/com/jcraft/jsch/ForwardedTCPIPDaemon.java
+++ b/src/main/java/com/jcraft/jsch/ForwardedTCPIPDaemon.java
@@ -26,7 +26,8 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public interface ForwardedTCPIPDaemon extends Runnable {
   void setChannel(ChannelForwardedTCPIP channel, InputStream in, OutputStream out);

--- a/src/main/java/com/jcraft/jsch/IO.java
+++ b/src/main/java/com/jcraft/jsch/IO.java
@@ -26,7 +26,9 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.SocketException;
 
 class IO {

--- a/src/main/java/com/jcraft/jsch/Identity.java
+++ b/src/main/java/com/jcraft/jsch/Identity.java
@@ -45,12 +45,12 @@ public interface Identity {
 
   /**
    * Signs on data with this identity, and returns the result.
+   *
    * <p>
    * <em>IMPORTANT NOTE:</em> <br>
    * The {@link #getSignature(byte[], String)} method should be overridden to ensure {@code ssh-rsa}
    * type public keys function with the {@code rsa-sha2-256} or {@code rsa-sha2-512} signature
    * algorithms.
-   * </p>
    *
    * @param data data to be signed
    * @return the signature
@@ -60,17 +60,17 @@ public interface Identity {
 
   /**
    * Signs on data with this identity, and returns the result.
+   *
    * <p>
    * <em>IMPORTANT NOTE:</em> <br>
    * The default implementation of this method simply calls {@link #getSignature(byte[])}, which
    * will fail with {@code ssh-rsa} type public keys when utilized with the {@code rsa-sha2-256} or
    * {@code rsa-sha2-512} signature algorithms: <br>
    * it exists only to maintain backwards compatibility of this interface.
-   * </p>
+   *
    * <p>
    * This default method should be overridden by implementations to ensure the {@code rsa-sha2-256}
    * and {@code rsa-sha2-512} signature algorithms function correctly.
-   * </p>
    *
    * @param data data to be signed
    * @param alg signature algorithm to use
@@ -117,8 +117,6 @@ public interface Identity {
    */
   public boolean isEncrypted();
 
-  /**
-   * Disposes internally allocated data, like byte array for the private key.
-   */
+  /** Disposes internally allocated data, like byte array for the private key. */
   public void clear();
 }

--- a/src/main/java/com/jcraft/jsch/IdentityFile.java
+++ b/src/main/java/com/jcraft/jsch/IdentityFile.java
@@ -123,9 +123,7 @@ class IdentityFile implements Identity {
     return kpair.isEncrypted();
   }
 
-  /**
-   * Disposes internally allocated data, like byte array for the private key.
-   */
+  /** Disposes internally allocated data, like byte array for the private key. */
   @Override
   public void clear() {
     kpair.dispose();

--- a/src/main/java/com/jcraft/jsch/IdentityFile.java
+++ b/src/main/java/com/jcraft/jsch/IdentityFile.java
@@ -26,8 +26,6 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
-
 class IdentityFile implements Identity {
   private KeyPair kpair;
   private String identity;

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -32,12 +32,11 @@ import java.util.Hashtable;
 import java.util.Vector;
 
 public class JSch {
-  /**
-   * The version number.
-   */
+  /** The version number. */
   public static final String VERSION = Version.getVersion();
 
   static Hashtable<String, String> config = new Hashtable<>();
+
   static {
     config.put("kex", Util.getSystemProperty("jsch.kex",
         "curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256"));
@@ -269,7 +268,6 @@ public class JSch {
    *
    * @param identityRepository if <code>null</code> is given, the default repository, which usually
    *        refers to ~/.ssh/, will be used.
-   *
    * @see #getIdentityRepository()
    */
   public synchronized void setIdentityRepository(IdentityRepository identityRepository) {
@@ -313,11 +311,8 @@ public class JSch {
    * "user.name" will be referred.
    *
    * @param host hostname
-   *
    * @throws JSchException if <code>username</code> or <code>host</code> are invalid.
-   *
    * @return the instance of <code>Session</code> class.
-   *
    * @see #getSession(String username, String host, int port)
    * @see com.jcraft.jsch.Session
    * @see com.jcraft.jsch.ConfigRepository
@@ -333,11 +328,8 @@ public class JSch {
    *
    * @param username user name
    * @param host hostname
-   *
    * @throws JSchException if <code>username</code> or <code>host</code> are invalid.
-   *
    * @return the instance of <code>Session</code> class.
-   *
    * @see #getSession(String username, String host, int port)
    * @see com.jcraft.jsch.Session
    */
@@ -353,11 +345,8 @@ public class JSch {
    * @param username user name
    * @param host hostname
    * @param port port number
-   *
    * @throws JSchException if <code>username</code> or <code>host</code> are invalid.
-   *
    * @return the instance of <code>Session</code> class.
-   *
    * @see #getSession(String username, String host, int port)
    * @see com.jcraft.jsch.Session
    */
@@ -385,7 +374,6 @@ public class JSch {
    * Sets the hostkey repository.
    *
    * @param hkrepo
-   *
    * @see com.jcraft.jsch.HostKeyRepository
    * @see com.jcraft.jsch.KnownHosts
    */
@@ -397,9 +385,7 @@ public class JSch {
    * Sets the instance of <code>KnownHosts</code>, which refers to <code>filename</code>.
    *
    * @param filename filename of known_hosts file.
-   *
    * @throws JSchException if the given filename is invalid.
-   *
    * @see com.jcraft.jsch.KnownHosts
    */
   public void setKnownHosts(String filename) throws JSchException {
@@ -416,9 +402,7 @@ public class JSch {
    * Sets the instance of <code>KnownHosts</code> generated with <code>stream</code>.
    *
    * @param stream the instance of InputStream from known_hosts file.
-   *
    * @throws JSchException if an I/O error occurs.
-   *
    * @see com.jcraft.jsch.KnownHosts
    */
   public void setKnownHosts(InputStream stream) throws JSchException {
@@ -436,7 +420,6 @@ public class JSch {
    * <code>KnownHosts</code>.
    *
    * @return current hostkey repository.
-   *
    * @see com.jcraft.jsch.HostKeyRepository
    * @see com.jcraft.jsch.KnownHosts
    */
@@ -450,9 +433,7 @@ public class JSch {
    * Sets the private key, which will be referred in the public key authentication.
    *
    * @param prvkey filename of the private key.
-   *
    * @throws JSchException if <code>prvkey</code> is invalid.
-   *
    * @see #addIdentity(String prvkey, String passphrase)
    */
   public void addIdentity(String prvkey) throws JSchException {
@@ -465,9 +446,7 @@ public class JSch {
    *
    * @param prvkey filename of the private key.
    * @param passphrase passphrase for <code>prvkey</code>.
-   *
    * @throws JSchException if <code>passphrase</code> is not right.
-   *
    * @see #addIdentity(String prvkey, byte[] passphrase)
    */
   public void addIdentity(String prvkey, String passphrase) throws JSchException {
@@ -486,9 +465,7 @@ public class JSch {
    *
    * @param prvkey filename of the private key.
    * @param passphrase passphrase for <code>prvkey</code>.
-   *
    * @throws JSchException if <code>passphrase</code> is not right.
-   *
    * @see #addIdentity(String prvkey, String pubkey, byte[] passphrase)
    */
   public void addIdentity(String prvkey, byte[] passphrase) throws JSchException {
@@ -503,7 +480,6 @@ public class JSch {
    * @param prvkey filename of the private key.
    * @param pubkey filename of the public key.
    * @param passphrase passphrase for <code>prvkey</code>.
-   *
    * @throws JSchException if <code>passphrase</code> is not right.
    */
   public void addIdentity(String prvkey, String pubkey, byte[] passphrase) throws JSchException {
@@ -519,7 +495,6 @@ public class JSch {
    * @param prvkey private key in byte array.
    * @param pubkey public key in byte array.
    * @param passphrase passphrase for <code>prvkey</code>.
-   *
    */
   public void addIdentity(String name, byte[] prvkey, byte[] pubkey, byte[] passphrase)
       throws JSchException {
@@ -533,7 +508,6 @@ public class JSch {
    *
    * @param identity private key.
    * @param passphrase passphrase for <code>identity</code>.
-   *
    * @throws JSchException if <code>passphrase</code> is not right.
    */
   public void addIdentity(Identity identity, byte[] passphrase) throws JSchException {
@@ -583,7 +557,6 @@ public class JSch {
    * Removes the identity from identityRepository.
    *
    * @param identity the indentity to be removed.
-   *
    * @throws JSchException if <code>identity</code> is invalid.
    */
   public void removeIdentity(Identity identity) throws JSchException {
@@ -594,7 +567,6 @@ public class JSch {
    * Lists names of identities included in the identityRepository.
    *
    * @return names of identities
-   *
    * @throws JSchException if identityReposory has problems.
    */
   public Vector<String> getIdentityNames() throws JSchException {
@@ -665,7 +637,6 @@ public class JSch {
    * Sets the logger
    *
    * @param logger logger or <code>null</code> if no logging should take place
-   *
    * @see com.jcraft.jsch.Logger
    */
   public static void setLogger(Logger logger) {

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -202,6 +202,8 @@ public class JSch {
     config.put("pbkdf2-hmac-sha256", "com.jcraft.jsch.jce.PBKDF2HMACSHA256");
     config.put("pbkdf2-hmac-sha384", "com.jcraft.jsch.jce.PBKDF2HMACSHA384");
     config.put("pbkdf2-hmac-sha512", "com.jcraft.jsch.jce.PBKDF2HMACSHA512");
+    config.put("pbkdf2-hmac-sha512-224", "com.jcraft.jsch.jce.PBKDF2HMACSHA512224");
+    config.put("pbkdf2-hmac-sha512-256", "com.jcraft.jsch.jce.PBKDF2HMACSHA512256");
     config.put("bcrypt", "com.jcraft.jsch.jbcrypt.JBCrypt");
     config.put("argon2", "com.jcraft.jsch.bc.Argon2");
     config.put("scrypt", "com.jcraft.jsch.bc.SCrypt");

--- a/src/main/java/com/jcraft/jsch/JUnixSocketFactory.java
+++ b/src/main/java/com/jcraft/jsch/JUnixSocketFactory.java
@@ -31,8 +31,8 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
 import org.newsclub.net.unix.AFUNIXServerSocketChannel;
-import org.newsclub.net.unix.AFUNIXSocketChannel;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
+import org.newsclub.net.unix.AFUNIXSocketChannel;
 
 public class JUnixSocketFactory implements USocketFactory {
 

--- a/src/main/java/com/jcraft/jsch/JUnixSocketFactory.java
+++ b/src/main/java/com/jcraft/jsch/JUnixSocketFactory.java
@@ -26,17 +26,13 @@
 
 package com.jcraft.jsch;
 
-import com.jcraft.jsch.AgentProxyException;
-import com.jcraft.jsch.USocketFactory;
-
-import org.newsclub.net.unix.AFUNIXServerSocketChannel;
-import org.newsclub.net.unix.AFUNIXSocketChannel;
-import org.newsclub.net.unix.AFUNIXSocketAddress;
-
 import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
+import org.newsclub.net.unix.AFUNIXServerSocketChannel;
+import org.newsclub.net.unix.AFUNIXSocketChannel;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
 
 public class JUnixSocketFactory implements USocketFactory {
 

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -26,7 +26,11 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -41,6 +41,7 @@ public abstract class KeyPair {
 
   /** DEFERRED should not be be used. */
   public static final int DEFERRED = -1;
+
   public static final int ERROR = 0;
   public static final int DSA = 1;
   public static final int RSA = 2;
@@ -1221,13 +1222,13 @@ public abstract class KeyPair {
         && ident.equals(Util.byte2str(Arrays.copyOfRange(buf, i, i + ident.length())));
   }
 
-  static private byte a2b(byte c) {
+  private static byte a2b(byte c) {
     if ('0' <= c && c <= '9')
       return (byte) (c - '0');
     return (byte) (c - 'a' + 10);
   }
 
-  static private byte b2a(byte c) {
+  private static byte b2a(byte c) {
     if (0 <= c && c <= 9)
       return (byte) (c + '0');
     return (byte) (c - 10 + 'A');

--- a/src/main/java/com/jcraft/jsch/KeyPairDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairDSA.java
@@ -165,7 +165,6 @@ class KeyPairDSA extends KeyPair {
         publicKeyComment = Util.byte2str(prvKEyBuffer.getString());
         // if(P_array!=null) key_size = (new BigInteger(P_array)).bitLength();
         return true;
-
       }
 
       int index = 0;

--- a/src/main/java/com/jcraft/jsch/KeyPairECDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairECDSA.java
@@ -201,7 +201,6 @@ class KeyPairECDSA extends KeyPair {
         prvKeyBuffer.getByte(x);
         prvKeyBuffer.getByte(y);
 
-
         prv_array = prvKeyBuffer.getString();
         publicKeyComment = Util.byte2str(prvKeyBuffer.getString());
         r_array = x;
@@ -209,7 +208,6 @@ class KeyPairECDSA extends KeyPair {
         key_size = x.length >= 64 ? 521 : (x.length >= 48 ? 384 : 256);
 
         return true;
-
       }
 
       int index = 0;

--- a/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
@@ -797,9 +797,9 @@ class KeyPairPKCS8 extends KeyPair {
     } else if (Util.array_equals(id, hmacWithSha512)) {
       name = "pbkdf2-hmac-sha512";
     } else if (Util.array_equals(id, hmacWithSha512224)) {
-      throw new JSchException("unsupported pbkdf2 function: pbkdf2-hmac-sha512-224");
+      name = "pbkdf2-hmac-sha512-224";
     } else if (Util.array_equals(id, hmacWithSha512256)) {
-      throw new JSchException("unsupported pbkdf2 function: pbkdf2-hmac-sha512-256");
+      name = "pbkdf2-hmac-sha512-256";
     }
 
     if (name == null) {

--- a/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairPKCS8.java
@@ -122,7 +122,6 @@ class KeyPairPKCS8 extends KeyPair {
   private static final byte[] pbeWithSHA1AndRC2CBC = {(byte) 0x2a, (byte) 0x86, (byte) 0x48,
       (byte) 0x86, (byte) 0xf7, (byte) 0x0d, (byte) 0x01, (byte) 0x05, (byte) 0x0b};
 
-
   private KeyPair kpair = null;
 
   KeyPairPKCS8(JSch.InstanceLogger instLogger) {

--- a/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
+++ b/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
 /**
  * This class implements ConfigRepository interface, and parses OpenSSH's configuration file. The
  * following keywords will be recognized,
+ *
  * <ul>
  * <li>Host</li>
  * <li>User</li>
@@ -160,6 +161,7 @@ public class OpenSSHConfig implements ConfigRepository {
   }
 
   private static final Hashtable<String, String> keymap = new Hashtable<>();
+
   static {
     keymap.put("kex", "KexAlgorithms");
     keymap.put("server_host_key", "HostKeyAlgorithms");

--- a/src/main/java/com/jcraft/jsch/PBKDF.java
+++ b/src/main/java/com/jcraft/jsch/PBKDF.java
@@ -26,9 +26,7 @@
 
 package com.jcraft.jsch;
 
-/**
- * Use PBKDF2 instead.
- */
+/** Use PBKDF2 instead. */
 @Deprecated
 public interface PBKDF {
   byte[] getKey(byte[] pass, byte[] salt, int iteration, int size);

--- a/src/main/java/com/jcraft/jsch/PortWatcher.java
+++ b/src/main/java/com/jcraft/jsch/PortWatcher.java
@@ -37,6 +37,7 @@ import java.util.Vector;
 class PortWatcher {
   private static Vector<PortWatcher> pool = new Vector<>();
   private static InetAddress anyLocalAddress = null;
+
   static {
     // 0.0.0.0
     /*
@@ -48,7 +49,6 @@ class PortWatcher {
     } catch (UnknownHostException e) {
     }
   }
-
 
   Session session;
   int lport;

--- a/src/main/java/com/jcraft/jsch/Proxy.java
+++ b/src/main/java/com/jcraft/jsch/Proxy.java
@@ -26,7 +26,8 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.Socket;
 
 public interface Proxy {

--- a/src/main/java/com/jcraft/jsch/ProxyHTTP.java
+++ b/src/main/java/com/jcraft/jsch/ProxyHTTP.java
@@ -26,8 +26,10 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
-import java.net.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
 
 public class ProxyHTTP implements Proxy {
   private static int DEFAULTPORT = 80;

--- a/src/main/java/com/jcraft/jsch/ProxySOCKS4.java
+++ b/src/main/java/com/jcraft/jsch/ProxySOCKS4.java
@@ -31,8 +31,11 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
-import java.net.*;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
 
 public class ProxySOCKS4 implements Proxy {
   private static int DEFAULTPORT = 1080;

--- a/src/main/java/com/jcraft/jsch/ProxySOCKS5.java
+++ b/src/main/java/com/jcraft/jsch/ProxySOCKS5.java
@@ -31,8 +31,10 @@
 
 package com.jcraft.jsch;
 
-import java.io.*;
-import java.net.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
 
 public class ProxySOCKS5 implements Proxy {
   private static int DEFAULTPORT = 1080;

--- a/src/main/java/com/jcraft/jsch/ServerSocketFactory.java
+++ b/src/main/java/com/jcraft/jsch/ServerSocketFactory.java
@@ -26,8 +26,9 @@
 
 package com.jcraft.jsch;
 
-import java.net.*;
-import java.io.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
 
 public interface ServerSocketFactory {
   public ServerSocket createServerSocket(int port, int backlog, InetAddress bindAddr)

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Vector;
-
 import javax.crypto.AEADBadTagException;
 
 public class Session {
@@ -1597,7 +1596,6 @@ public class Session {
     }
   }
 
-
   /*
    * RFC 4253 7.2. Output from Key Exchange If the key length needed is longer than the output of
    * the HASH, the key is extended by computing HASH of the concatenation of K and H and the entire
@@ -1639,7 +1637,6 @@ public class Session {
         continue;
       }
       synchronized (c) {
-
         if (c.rwsize < length) {
           try {
             c.notifyme++;
@@ -1658,7 +1655,6 @@ public class Session {
           c.rwsize -= length;
           break;
         }
-
       }
       if (c.close || !c.isConnected()) {
         throw new IOException("channel is broken");
@@ -1786,7 +1782,7 @@ public class Session {
         try {
           buf = read(buf);
           stimeout = 0;
-        } catch (InterruptedIOException/* SocketTimeoutException */ ee) {
+        } catch (InterruptedIOException /* SocketTimeoutException */ ee) {
           if (!in_kex && stimeout < serverAliveCountMax) {
             sendKeepAliveMsg();
             stimeout++;
@@ -3292,7 +3288,6 @@ public class Session {
     if (value != null) {
       setConfig("ClearAllForwardings", value);
     }
-
   }
 
   private void applyConfigChannel(ChannelSession channel) throws JSchException {

--- a/src/main/java/com/jcraft/jsch/SftpATTRS.java
+++ b/src/main/java/com/jcraft/jsch/SftpATTRS.java
@@ -26,7 +26,6 @@
 
 package com.jcraft.jsch;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /*

--- a/src/main/java/com/jcraft/jsch/SftpATTRS.java
+++ b/src/main/java/com/jcraft/jsch/SftpATTRS.java
@@ -26,7 +26,11 @@
 
 package com.jcraft.jsch;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 /*
  * uint32 flags uint64 size present only if flag SSH_FILEXFER_ATTR_SIZE uint32 uid present only if
@@ -122,13 +126,20 @@ public class SftpATTRS {
   }
 
   public String getAtimeString() {
-    Date date = new Date(((long) atime) * 1000L);
-    return (date.toString());
+    return toDateString(Integer.toUnsignedLong(atime));
   }
 
   public String getMtimeString() {
-    Date date = new Date(((long) mtime) * 1000L);
-    return (date.toString());
+    return toDateString(Integer.toUnsignedLong(mtime));
+  }
+
+  private static DateTimeFormatter DTF =
+      DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ROOT);
+
+  static String toDateString(long epochSeconds) {
+    Instant instant = Instant.ofEpochSecond(epochSeconds);
+    ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+    return DTF.format(zdt);
   }
 
   public static final int SSH_FILEXFER_ATTR_SIZE = 0x00000001;

--- a/src/main/java/com/jcraft/jsch/SftpStatVFS.java
+++ b/src/main/java/com/jcraft/jsch/SftpStatVFS.java
@@ -71,8 +71,8 @@ public class SftpStatVFS {
     int flag = (int) buf.getLong();
     statvfs.namemax = buf.getLong();
 
-    statvfs.flag = (flag & 1/* SSH2_FXE_STATVFS_ST_RDONLY */) != 0 ? 1/* ST_RDONLY */ : 0;
-    statvfs.flag |= (flag & 2/* SSH2_FXE_STATVFS_ST_NOSUID */) != 0 ? 2/* ST_NOSUID */ : 0;
+    statvfs.flag = (flag & 1 /* SSH2_FXE_STATVFS_ST_RDONLY */) != 0 ? 1 /* ST_RDONLY */ : 0;
+    statvfs.flag |= (flag & 2 /* SSH2_FXE_STATVFS_ST_NOSUID */) != 0 ? 2 /* ST_NOSUID */ : 0;
 
     return statvfs;
   }

--- a/src/main/java/com/jcraft/jsch/SftpStatVFS.java
+++ b/src/main/java/com/jcraft/jsch/SftpStatVFS.java
@@ -26,9 +26,6 @@
 
 package com.jcraft.jsch;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 public class SftpStatVFS {
 
   /*

--- a/src/main/java/com/jcraft/jsch/Slf4jLogger.java
+++ b/src/main/java/com/jcraft/jsch/Slf4jLogger.java
@@ -3,9 +3,7 @@ package com.jcraft.jsch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * JSch logger to log entries using the SLF4J framework
- */
+/** JSch logger to log entries using the SLF4J framework */
 public class Slf4jLogger implements com.jcraft.jsch.Logger {
 
   private static final Logger logger = LoggerFactory.getLogger(JSch.class);

--- a/src/main/java/com/jcraft/jsch/SocketFactory.java
+++ b/src/main/java/com/jcraft/jsch/SocketFactory.java
@@ -26,8 +26,11 @@
 
 package com.jcraft.jsch;
 
-import java.net.*;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.UnknownHostException;
 
 public interface SocketFactory {
   public Socket createSocket(String host, int port) throws IOException, UnknownHostException;

--- a/src/main/java/com/jcraft/jsch/UnixDomainSocketFactory.java
+++ b/src/main/java/com/jcraft/jsch/UnixDomainSocketFactory.java
@@ -26,9 +26,6 @@
 
 package com.jcraft.jsch;
 
-import com.jcraft.jsch.AgentProxyException;
-import com.jcraft.jsch.USocketFactory;
-
 import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;

--- a/src/main/java/com/jcraft/jsch/UserAuthGSSAPIWithMIC.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthGSSAPIWithMIC.java
@@ -221,5 +221,3 @@ class UserAuthGSSAPIWithMIC extends UserAuth {
     return false;
   }
 }
-
-

--- a/src/main/java/com/jcraft/jsch/UserAuthPassword.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthPassword.java
@@ -174,7 +174,6 @@ class UserAuthPassword extends UserAuth {
           Util.bzero(password);
           password = null;
         }
-
       }
 
     } finally {

--- a/src/main/java/com/jcraft/jsch/UserAuthPublicKey.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthPublicKey.java
@@ -26,7 +26,12 @@
 
 package com.jcraft.jsch;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Vector;
 
 class UserAuthPublicKey extends UserAuth {
 

--- a/src/main/java/com/jcraft/jsch/Util.java
+++ b/src/main/java/com/jcraft/jsch/Util.java
@@ -28,8 +28,8 @@ package com.jcraft.jsch;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -152,7 +152,7 @@ class Util {
     return glob0(pattern, 0, name, 0);
   }
 
-  static private boolean glob0(byte[] pattern, int pattern_index, byte[] name, int name_index) {
+  private static boolean glob0(byte[] pattern, int pattern_index, byte[] name, int name_index) {
     if (name.length > 0 && name[0] == '.') {
       if (pattern.length > 0 && pattern[0] == '.') {
         if (pattern.length == 2 && pattern[1] == '*')
@@ -164,7 +164,7 @@ class Util {
     return glob(pattern, pattern_index, name, name_index);
   }
 
-  static private boolean glob(byte[] pattern, int pattern_index, byte[] name, int name_index) {
+  private static boolean glob(byte[] pattern, int pattern_index, byte[] name, int name_index) {
     // System.err.println("glob: "+new String(pattern)+", "+pattern_index+" "+new String(name)+",
     // "+name_index);
 

--- a/src/main/java/com/jcraft/jsch/annotations/SuppressForbiddenApi.java
+++ b/src/main/java/com/jcraft/jsch/annotations/SuppressForbiddenApi.java
@@ -1,9 +1,9 @@
 package com.jcraft.jsch.annotations;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.annotation.ElementType;
 
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.METHOD,

--- a/src/main/java/com/jcraft/jsch/bc/ChaCha20Poly1305.java
+++ b/src/main/java/com/jcraft/jsch/bc/ChaCha20Poly1305.java
@@ -31,7 +31,8 @@ import java.nio.ByteBuffer;
 import javax.crypto.AEADBadTagException;
 import org.bouncycastle.crypto.engines.ChaChaEngine;
 import org.bouncycastle.crypto.macs.Poly1305;
-import org.bouncycastle.crypto.params.*;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
 
 public class ChaCha20Poly1305 implements Cipher {
   // Actually the block size, not IV size

--- a/src/main/java/com/jcraft/jsch/bc/KeyPairGenEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/bc/KeyPairGenEdDSA.java
@@ -26,8 +26,10 @@
 
 package com.jcraft.jsch.bc;
 
-import java.security.*;
-import org.bouncycastle.crypto.params.*;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed448PrivateKeyParameters;
 
 public class KeyPairGenEdDSA implements com.jcraft.jsch.KeyPairGenEdDSA {
   byte[] prv; // private

--- a/src/main/java/com/jcraft/jsch/bc/SNTRUP761.java
+++ b/src/main/java/com/jcraft/jsch/bc/SNTRUP761.java
@@ -31,7 +31,12 @@ import com.jcraft.jsch.annotations.SuppressForbiddenApi;
 import java.lang.reflect.Constructor;
 import java.security.SecureRandom;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
-import org.bouncycastle.pqc.crypto.ntruprime.*;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKEMExtractor;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKeyGenerationParameters;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKeyPairGenerator;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeParameters;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimePrivateKeyParameters;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimePublicKeyParameters;
 
 public class SNTRUP761 implements KEM {
   SNTRUPrimeKEMExtractor extractor;

--- a/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
@@ -26,13 +26,12 @@
 
 package com.jcraft.jsch.bc;
 
+import com.jcraft.jsch.Buffer;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
-import java.util.Arrays;
 import org.bouncycastle.crypto.Signer;
 import org.bouncycastle.crypto.params.*;
 import org.bouncycastle.crypto.signers.*;
-import com.jcraft.jsch.Buffer;
 
 abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
 

--- a/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/bc/SignatureEdDSA.java
@@ -28,10 +28,16 @@ package com.jcraft.jsch.bc;
 
 import com.jcraft.jsch.Buffer;
 import java.nio.charset.StandardCharsets;
-import java.security.*;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 import org.bouncycastle.crypto.Signer;
-import org.bouncycastle.crypto.params.*;
-import org.bouncycastle.crypto.signers.*;
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+import org.bouncycastle.crypto.params.Ed448PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed448PublicKeyParameters;
+import org.bouncycastle.crypto.signers.Ed25519Signer;
+import org.bouncycastle.crypto.signers.Ed448Signer;
 
 abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
 

--- a/src/main/java/com/jcraft/jsch/bc/XDH.java
+++ b/src/main/java/com/jcraft/jsch/bc/XDH.java
@@ -26,8 +26,13 @@
 
 package com.jcraft.jsch.bc;
 
-import java.security.*;
-import org.bouncycastle.crypto.params.*;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters;
+import org.bouncycastle.crypto.params.X448PrivateKeyParameters;
+import org.bouncycastle.crypto.params.X448PublicKeyParameters;
 
 public class XDH implements com.jcraft.jsch.XDH {
   byte[] Q_array;

--- a/src/main/java/com/jcraft/jsch/bc/XDH.java
+++ b/src/main/java/com/jcraft/jsch/bc/XDH.java
@@ -27,7 +27,6 @@
 package com.jcraft.jsch.bc;
 
 import java.security.*;
-import java.util.Arrays;
 import org.bouncycastle.crypto.params.*;
 
 public class XDH implements com.jcraft.jsch.XDH {

--- a/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
+++ b/src/main/java/com/jcraft/jsch/jbcrypt/BCrypt.java
@@ -23,20 +23,25 @@ import java.security.SecureRandom;
 /**
  * BCrypt implements OpenBSD-style Blowfish password hashing using the scheme described in "A
  * Future-Adaptable Password Scheme" by Niels Provos and David Mazieres.
+ *
  * <p>
  * This password hashing system tries to thwart off-line password cracking using a
  * computationally-intensive hashing algorithm, based on Bruce Schneier's Blowfish cipher. The work
  * factor of the algorithm is parameterised, so it can be increased as computers get faster.
+ *
  * <p>
  * Usage is really simple. To hash a password for the first time, call the hashpw method with a
  * random salt, like this:
+ *
  * <p>
  * <code>
  * String pw_hash = BCrypt.hashpw(plain_password, BCrypt.gensalt()); <br>
  * </code>
+ *
  * <p>
  * To check whether a plaintext password matches one that has been hashed previously, use the
  * checkpw method:
+ *
  * <p>
  * <code>
  * if (BCrypt.checkpw(candidate_password, stored_hash))<br>
@@ -44,14 +49,17 @@ import java.security.SecureRandom;
  * else<br>
  * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It does not match");<br>
  * </code>
+ *
  * <p>
  * The gensalt() method takes an optional parameter (log_rounds) that determines the computational
  * complexity of the hashing:
+ *
  * <p>
  * <code>
  * String strong_salt = BCrypt.gensalt(10)<br>
  * String stronger_salt = BCrypt.gensalt(12)<br>
  * </code>
+ *
  * <p>
  * The amount of work increases exponentially (2**log_rounds), so each increment is twice as much
  * work. The default log_rounds is 10, and the valid range is 4 to 30.
@@ -226,17 +234,17 @@ public class BCrypt {
   // bcrypt IV: "OrpheanBeholderScryDoubt". The C implementation calls
   // this "ciphertext", but it is really plaintext or an IV. We keep
   // the name to make code comparison easier.
-  static private final int bf_crypt_ciphertext[] =
+  private static final int bf_crypt_ciphertext[] =
       {0x4f727068, 0x65616e42, 0x65686f6c, 0x64657253, 0x63727944, 0x6f756274};
 
   // Table for Base64 encoding
-  static private final char base64_code[] = {'.', '/', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I',
+  private static final char base64_code[] = {'.', '/', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I',
       'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b',
       'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
       'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 
   // Table for Base64 decoding
-  static private final byte index_64[] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  private static final byte index_64[] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
       -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
       -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, -1, -1, -1,
       -1, -1, -1, -1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
@@ -400,9 +408,7 @@ public class BCrypt {
     return word;
   }
 
-  /**
-   * Initialise the Blowfish key schedule
-   */
+  /** Initialise the Blowfish key schedule */
   private void init_key() {
     P = P_orig.clone();
     S = S_orig.clone();
@@ -468,9 +474,7 @@ public class BCrypt {
     }
   }
 
-  /**
-   * Compatibility with new OpenBSD function.
-   */
+  /** Compatibility with new OpenBSD function. */
   public void hash(byte[] hpass, byte[] hsalt, byte[] output) {
     init_key();
     ekskey(hsalt, hpass);
@@ -496,9 +500,7 @@ public class BCrypt {
     }
   }
 
-  /**
-   * Compatibility with new OpenBSD function.
-   */
+  /** Compatibility with new OpenBSD function. */
   public void pbkdf(byte[] password, byte[] salt, int rounds, byte[] output) {
     try {
       MessageDigest sha512 = MessageDigest.getInstance("SHA-512");

--- a/src/main/java/com/jcraft/jsch/jce/AES128CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES128CBC.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class AES128CBC implements Cipher {
   private static final int ivsize = 16;

--- a/src/main/java/com/jcraft/jsch/jce/AES128CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES128CBC.java
@@ -47,7 +47,6 @@ public class AES128CBC implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -62,7 +61,7 @@ public class AES128CBC implements Cipher {
 
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CBC/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("AES/CBC/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/AES128CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES128CBC.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class AES128CBC implements Cipher {
+public class AES128CBC implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 16;
   private static final int bsize = 16;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -61,9 +61,10 @@ public class AES128CBC implements Cipher {
 
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CBC/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("AES/CBC/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/AES128CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES128CTR.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class AES128CTR implements Cipher {
   private static final int ivsize = 16;

--- a/src/main/java/com/jcraft/jsch/jce/AES128CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES128CTR.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class AES128CTR implements Cipher {
+public class AES128CTR implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 16;
   private static final int bsize = 16;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -61,9 +61,10 @@ public class AES128CTR implements Cipher {
 
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CTR/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("AES/CTR/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/AES128CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES128CTR.java
@@ -47,7 +47,6 @@ public class AES128CTR implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -62,7 +61,7 @@ public class AES128CTR implements Cipher {
 
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CTR/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("AES/CTR/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/AES192CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES192CBC.java
@@ -47,7 +47,6 @@ public class AES192CBC implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -61,7 +60,7 @@ public class AES192CBC implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CBC/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("AES/CBC/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/AES192CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES192CBC.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class AES192CBC implements Cipher {
   private static final int ivsize = 16;

--- a/src/main/java/com/jcraft/jsch/jce/AES192CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES192CBC.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class AES192CBC implements Cipher {
+public class AES192CBC implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 16;
   private static final int bsize = 24;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -60,9 +60,10 @@ public class AES192CBC implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CBC/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("AES/CBC/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/AES192CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES192CTR.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class AES192CTR implements Cipher {
+public class AES192CTR implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 16;
   private static final int bsize = 24;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -60,9 +60,10 @@ public class AES192CTR implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CTR/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("AES/CTR/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/AES192CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES192CTR.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class AES192CTR implements Cipher {
   private static final int ivsize = 16;

--- a/src/main/java/com/jcraft/jsch/jce/AES192CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES192CTR.java
@@ -47,7 +47,6 @@ public class AES192CTR implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -61,7 +60,7 @@ public class AES192CTR implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CTR/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("AES/CTR/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/AES256CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES256CBC.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class AES256CBC implements Cipher {
+public class AES256CBC implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 16;
   private static final int bsize = 32;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -60,9 +60,10 @@ public class AES256CBC implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CBC/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("AES/CBC/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/AES256CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES256CBC.java
@@ -47,7 +47,6 @@ public class AES256CBC implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -61,7 +60,7 @@ public class AES256CBC implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CBC/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("AES/CBC/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/AES256CBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES256CBC.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class AES256CBC implements Cipher {
   private static final int ivsize = 16;

--- a/src/main/java/com/jcraft/jsch/jce/AES256CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES256CTR.java
@@ -47,7 +47,6 @@ public class AES256CTR implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -61,7 +60,7 @@ public class AES256CTR implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CTR/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("AES/CTR/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/AES256CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES256CTR.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class AES256CTR implements Cipher {
+public class AES256CTR implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 16;
   private static final int bsize = 32;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -60,9 +60,10 @@ public class AES256CTR implements Cipher {
     }
     try {
       SecretKeySpec keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/CTR/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), keyspec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("AES/CTR/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          keyspec, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/AES256CTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/AES256CTR.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class AES256CTR implements Cipher {
   private static final int ivsize = 16;

--- a/src/main/java/com/jcraft/jsch/jce/AESGCM.java
+++ b/src/main/java/com/jcraft/jsch/jce/AESGCM.java
@@ -26,16 +26,16 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
 import java.nio.ByteBuffer;
+import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-abstract class AESGCM implements Cipher {
+abstract class AESGCM implements com.jcraft.jsch.Cipher {
   // Actually the block size, not IV size
   private static final int ivsize = 16;
   private static final int tagsize = 16;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
   private SecretKeySpec keyspec;
   private int mode;
   private ByteBuffer iv;
@@ -65,13 +65,13 @@ abstract class AESGCM implements Cipher {
       System.arraycopy(key, 0, tmp, 0, tmp.length);
       key = tmp;
     }
-    this.mode = ((mode == ENCRYPT_MODE) ? javax.crypto.Cipher.ENCRYPT_MODE
-        : javax.crypto.Cipher.DECRYPT_MODE);
+    this.mode =
+        ((mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE) ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE);
     this.iv = ByteBuffer.wrap(iv);
     this.initcounter = this.iv.getLong(4);
     try {
       keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/GCM/NoPadding");
+      cipher = Cipher.getInstance("AES/GCM/NoPadding");
       cipher.init(this.mode, keyspec, new GCMParameterSpec(tagsize * 8, iv));
     } catch (Exception e) {
       cipher = null;

--- a/src/main/java/com/jcraft/jsch/jce/AESGCM.java
+++ b/src/main/java/com/jcraft/jsch/jce/AESGCM.java
@@ -28,7 +28,8 @@ package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
 import java.nio.ByteBuffer;
-import javax.crypto.spec.*;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 abstract class AESGCM implements Cipher {
   // Actually the block size, not IV size

--- a/src/main/java/com/jcraft/jsch/jce/AESGCM.java
+++ b/src/main/java/com/jcraft/jsch/jce/AESGCM.java
@@ -53,7 +53,6 @@ abstract class AESGCM implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (iv.length > 12) {
       tmp = new byte[12];
@@ -72,7 +71,7 @@ abstract class AESGCM implements Cipher {
     this.initcounter = this.iv.getLong(4);
     try {
       keyspec = new SecretKeySpec(key, "AES");
-      cipher = javax.crypto.Cipher.getInstance("AES/GCM/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("AES/GCM/NoPadding");
       cipher.init(this.mode, keyspec, new GCMParameterSpec(tagsize * 8, iv));
     } catch (Exception e) {
       cipher = null;

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
@@ -26,13 +26,13 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
-public class ARCFOUR implements Cipher {
+public class ARCFOUR implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 8;
   private static final int bsize = 16;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -54,10 +54,11 @@ public class ARCFOUR implements Cipher {
     }
 
     try {
-      cipher = javax.crypto.Cipher.getInstance("RC4");
+      cipher = Cipher.getInstance("RC4");
       SecretKeySpec _key = new SecretKeySpec(key, "RC4");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), _key);
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          _key);
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
@@ -27,7 +27,6 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.*;
 import javax.crypto.spec.*;
 
 public class ARCFOUR implements Cipher {

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
@@ -27,7 +27,7 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.SecretKeySpec;
 
 public class ARCFOUR implements Cipher {
   private static final int ivsize = 8;

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR.java
@@ -46,7 +46,6 @@ public class ARCFOUR implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
     byte[] tmp;
     if (key.length > bsize) {
       tmp = new byte[bsize];

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR128.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR128.java
@@ -27,7 +27,6 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.*;
 import javax.crypto.spec.*;
 
 public class ARCFOUR128 implements Cipher {

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR128.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR128.java
@@ -27,7 +27,7 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.SecretKeySpec;
 
 public class ARCFOUR128 implements Cipher {
   private static final int ivsize = 8;

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR128.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR128.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
-public class ARCFOUR128 implements Cipher {
+public class ARCFOUR128 implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 8;
   private static final int bsize = 16;
   private static final int skip = 1536;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -54,10 +54,11 @@ public class ARCFOUR128 implements Cipher {
       key = tmp;
     }
     try {
-      cipher = javax.crypto.Cipher.getInstance("RC4");
+      cipher = Cipher.getInstance("RC4");
       SecretKeySpec _key = new SecretKeySpec(key, "RC4");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), _key);
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          _key);
       byte[] foo = new byte[1];
       for (int i = 0; i < skip; i++) {
         cipher.update(foo, 0, 1, foo, 0);

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR256.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR256.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
-public class ARCFOUR256 implements Cipher {
+public class ARCFOUR256 implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 8;
   private static final int bsize = 32;
   private static final int skip = 1536;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -54,10 +54,11 @@ public class ARCFOUR256 implements Cipher {
       key = tmp;
     }
     try {
-      cipher = javax.crypto.Cipher.getInstance("RC4");
+      cipher = Cipher.getInstance("RC4");
       SecretKeySpec _key = new SecretKeySpec(key, "RC4");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), _key);
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          _key);
       byte[] foo = new byte[1];
       for (int i = 0; i < skip; i++) {
         cipher.update(foo, 0, 1, foo, 0);

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR256.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR256.java
@@ -27,7 +27,6 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.*;
 import javax.crypto.spec.*;
 
 public class ARCFOUR256 implements Cipher {

--- a/src/main/java/com/jcraft/jsch/jce/ARCFOUR256.java
+++ b/src/main/java/com/jcraft/jsch/jce/ARCFOUR256.java
@@ -27,7 +27,7 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.SecretKeySpec;
 
 public class ARCFOUR256 implements Cipher {
   private static final int ivsize = 8;

--- a/src/main/java/com/jcraft/jsch/jce/BlowfishCBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/BlowfishCBC.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class BlowfishCBC implements Cipher {
   private static final int ivsize = 8;

--- a/src/main/java/com/jcraft/jsch/jce/BlowfishCBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/BlowfishCBC.java
@@ -47,8 +47,6 @@ public class BlowfishCBC implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
-    // if(padding) pad="PKCS5Padding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -62,7 +60,7 @@ public class BlowfishCBC implements Cipher {
     }
     try {
       SecretKeySpec skeySpec = new SecretKeySpec(key, "Blowfish");
-      cipher = javax.crypto.Cipher.getInstance("Blowfish/CBC/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("Blowfish/CBC/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), skeySpec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/BlowfishCBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/BlowfishCBC.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class BlowfishCBC implements Cipher {
+public class BlowfishCBC implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 8;
   private static final int bsize = 16;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -60,9 +60,10 @@ public class BlowfishCBC implements Cipher {
     }
     try {
       SecretKeySpec skeySpec = new SecretKeySpec(key, "Blowfish");
-      cipher = javax.crypto.Cipher.getInstance("Blowfish/CBC/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), skeySpec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("Blowfish/CBC/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          skeySpec, new IvParameterSpec(iv));
     } catch (Exception e) {
       throw e;
     }

--- a/src/main/java/com/jcraft/jsch/jce/BlowfishCTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/BlowfishCTR.java
@@ -26,14 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-public class BlowfishCTR implements Cipher {
+public class BlowfishCTR implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 8;
   private static final int bsize = 32;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -60,9 +60,10 @@ public class BlowfishCTR implements Cipher {
     }
     try {
       SecretKeySpec skeySpec = new SecretKeySpec(key, "Blowfish");
-      cipher = javax.crypto.Cipher.getInstance("Blowfish/CTR/NoPadding");
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), skeySpec, new IvParameterSpec(iv));
+      cipher = Cipher.getInstance("Blowfish/CTR/NoPadding");
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          skeySpec, new IvParameterSpec(iv));
     } catch (Exception e) {
       throw e;
     }

--- a/src/main/java/com/jcraft/jsch/jce/BlowfishCTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/BlowfishCTR.java
@@ -27,7 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.spec.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class BlowfishCTR implements Cipher {
   private static final int ivsize = 8;

--- a/src/main/java/com/jcraft/jsch/jce/BlowfishCTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/BlowfishCTR.java
@@ -47,8 +47,6 @@ public class BlowfishCTR implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
-    // if(padding) pad="PKCS5Padding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -62,7 +60,7 @@ public class BlowfishCTR implements Cipher {
     }
     try {
       SecretKeySpec skeySpec = new SecretKeySpec(key, "Blowfish");
-      cipher = javax.crypto.Cipher.getInstance("Blowfish/CTR/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("Blowfish/CTR/NoPadding");
       cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
           : javax.crypto.Cipher.DECRYPT_MODE), skeySpec, new IvParameterSpec(iv));
     } catch (Exception e) {

--- a/src/main/java/com/jcraft/jsch/jce/DH.java
+++ b/src/main/java/com/jcraft/jsch/jce/DH.java
@@ -26,12 +26,12 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.JSchException;
 import java.math.BigInteger;
 import java.security.*;
 import javax.crypto.*;
 import javax.crypto.interfaces.*;
 import javax.crypto.spec.*;
-import com.jcraft.jsch.JSchException;
 
 public class DH implements com.jcraft.jsch.DH {
   BigInteger p;

--- a/src/main/java/com/jcraft/jsch/jce/DH.java
+++ b/src/main/java/com/jcraft/jsch/jce/DH.java
@@ -28,10 +28,14 @@ package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.JSchException;
 import java.math.BigInteger;
-import java.security.*;
-import javax.crypto.*;
-import javax.crypto.interfaces.*;
-import javax.crypto.spec.*;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import javax.crypto.KeyAgreement;
+import javax.crypto.interfaces.DHPublicKey;
+import javax.crypto.spec.DHParameterSpec;
+import javax.crypto.spec.DHPublicKeySpec;
 
 public class DH implements com.jcraft.jsch.DH {
   BigInteger p;

--- a/src/main/java/com/jcraft/jsch/jce/ECDH256.java
+++ b/src/main/java/com/jcraft/jsch/jce/ECDH256.java
@@ -26,7 +26,7 @@
 
 package com.jcraft.jsch.jce;
 
-public class ECDH256 extends ECDHN implements com.jcraft.jsch.ECDH {
+public class ECDH256 extends ECDHN {
   public void init() throws Exception {
     super.init(256);
   }

--- a/src/main/java/com/jcraft/jsch/jce/ECDH384.java
+++ b/src/main/java/com/jcraft/jsch/jce/ECDH384.java
@@ -26,7 +26,7 @@
 
 package com.jcraft.jsch.jce;
 
-public class ECDH384 extends ECDHN implements com.jcraft.jsch.ECDH {
+public class ECDH384 extends ECDHN {
   public void init() throws Exception {
     super.init(384);
   }

--- a/src/main/java/com/jcraft/jsch/jce/ECDH521.java
+++ b/src/main/java/com/jcraft/jsch/jce/ECDH521.java
@@ -26,7 +26,7 @@
 
 package com.jcraft.jsch.jce;
 
-public class ECDH521 extends ECDHN implements com.jcraft.jsch.ECDH {
+public class ECDH521 extends ECDHN {
   public void init() throws Exception {
     super.init(521);
   }

--- a/src/main/java/com/jcraft/jsch/jce/ECDHN.java
+++ b/src/main/java/com/jcraft/jsch/jce/ECDHN.java
@@ -28,9 +28,9 @@ package com.jcraft.jsch.jce;
 
 import java.math.BigInteger;
 import java.security.*;
-import javax.crypto.*;
 import java.security.spec.*;
 import java.security.interfaces.*;
+import javax.crypto.*;
 
 public class ECDHN implements com.jcraft.jsch.ECDH {
   byte[] Q_array;

--- a/src/main/java/com/jcraft/jsch/jce/ECDHN.java
+++ b/src/main/java/com/jcraft/jsch/jce/ECDHN.java
@@ -26,13 +26,19 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.ECDH;
 import java.math.BigInteger;
-import java.security.*;
-import java.security.spec.*;
-import java.security.interfaces.*;
-import javax.crypto.*;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.EllipticCurve;
+import javax.crypto.KeyAgreement;
 
-public class ECDHN implements com.jcraft.jsch.ECDH {
+public class ECDHN implements ECDH {
   byte[] Q_array;
   ECPublicKey publicKey;
 

--- a/src/main/java/com/jcraft/jsch/jce/HMAC.java
+++ b/src/main/java/com/jcraft/jsch/jce/HMAC.java
@@ -26,11 +26,12 @@
 
 package com.jcraft.jsch.jce;
 
+import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Logger;
 import com.jcraft.jsch.MAC;
-import javax.crypto.*;
-import javax.crypto.spec.*;
 
 abstract class HMAC implements MAC {
   protected String name;

--- a/src/main/java/com/jcraft/jsch/jce/HMAC.java
+++ b/src/main/java/com/jcraft/jsch/jce/HMAC.java
@@ -26,12 +26,12 @@
 
 package com.jcraft.jsch.jce;
 
-import javax.crypto.Mac;
-import javax.crypto.ShortBufferException;
-import javax.crypto.spec.SecretKeySpec;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Logger;
 import com.jcraft.jsch.MAC;
+import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
 
 abstract class HMAC implements MAC {
   protected String name;

--- a/src/main/java/com/jcraft/jsch/jce/HMACMD5.java
+++ b/src/main/java/com/jcraft/jsch/jce/HMACMD5.java
@@ -26,10 +26,6 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.MAC;
-import javax.crypto.*;
-import javax.crypto.spec.*;
-
 public class HMACMD5 extends HMAC {
   public HMACMD5() {
     name = "hmac-md5";

--- a/src/main/java/com/jcraft/jsch/jce/HMACMD5ETM.java
+++ b/src/main/java/com/jcraft/jsch/jce/HMACMD5ETM.java
@@ -26,10 +26,6 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.MAC;
-import javax.crypto.*;
-import javax.crypto.spec.*;
-
 public class HMACMD5ETM extends HMACMD5 {
   public HMACMD5ETM() {
     name = "hmac-md5-etm@openssh.com";

--- a/src/main/java/com/jcraft/jsch/jce/KeyPairGenDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/KeyPairGenDSA.java
@@ -26,8 +26,15 @@
 
 package com.jcraft.jsch.jce;
 
-import java.security.*;
-import java.security.interfaces.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.interfaces.DSAKey;
+import java.security.interfaces.DSAParams;
+import java.security.interfaces.DSAPrivateKey;
+import java.security.interfaces.DSAPublicKey;
 
 public class KeyPairGenDSA implements com.jcraft.jsch.KeyPairGenDSA {
   byte[] x; // private

--- a/src/main/java/com/jcraft/jsch/jce/KeyPairGenECDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/KeyPairGenECDSA.java
@@ -26,10 +26,10 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.JSchException;
 import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
-import com.jcraft.jsch.JSchException;
 
 public class KeyPairGenECDSA implements com.jcraft.jsch.KeyPairGenECDSA {
   byte[] d;

--- a/src/main/java/com/jcraft/jsch/jce/KeyPairGenECDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/KeyPairGenECDSA.java
@@ -27,9 +27,13 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.JSchException;
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
 
 public class KeyPairGenECDSA implements com.jcraft.jsch.KeyPairGenECDSA {
   byte[] d;

--- a/src/main/java/com/jcraft/jsch/jce/KeyPairGenRSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/KeyPairGenRSA.java
@@ -26,8 +26,14 @@
 
 package com.jcraft.jsch.jce;
 
-import java.security.*;
-import java.security.interfaces.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 
 public class KeyPairGenRSA implements com.jcraft.jsch.KeyPairGenRSA {
   byte[] d; // private

--- a/src/main/java/com/jcraft/jsch/jce/MD5.java
+++ b/src/main/java/com/jcraft/jsch/jce/MD5.java
@@ -27,8 +27,7 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.HASH;
-
-import java.security.*;
+import java.security.MessageDigest;
 
 public class MD5 implements HASH {
   MessageDigest md;

--- a/src/main/java/com/jcraft/jsch/jce/PBKDF.java
+++ b/src/main/java/com/jcraft/jsch/jce/PBKDF.java
@@ -26,12 +26,10 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.HASH;
-
-import javax.crypto.spec.PBEKeySpec;
-import javax.crypto.SecretKeyFactory;
 import java.security.spec.InvalidKeySpecException;
 import java.security.NoSuchAlgorithmException;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.SecretKeyFactory;
 
 /**
  * Use PBKDF2 instead.

--- a/src/main/java/com/jcraft/jsch/jce/PBKDF.java
+++ b/src/main/java/com/jcraft/jsch/jce/PBKDF.java
@@ -26,14 +26,12 @@
 
 package com.jcraft.jsch.jce;
 
-import java.security.spec.InvalidKeySpecException;
 import java.security.NoSuchAlgorithmException;
-import javax.crypto.spec.PBEKeySpec;
+import java.security.spec.InvalidKeySpecException;
 import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 
-/**
- * Use PBKDF2 instead.
- */
+/** Use PBKDF2 instead. */
 @Deprecated
 public class PBKDF implements com.jcraft.jsch.PBKDF {
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/PBKDF2.java
+++ b/src/main/java/com/jcraft/jsch/jce/PBKDF2.java
@@ -26,10 +26,9 @@
 
 package com.jcraft.jsch.jce;
 
+import java.security.spec.InvalidKeySpecException;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.SecretKeyFactory;
-import java.security.spec.InvalidKeySpecException;
-import java.security.NoSuchAlgorithmException;
 
 abstract class PBKDF2 implements com.jcraft.jsch.PBKDF2 {
   private SecretKeyFactory skf;

--- a/src/main/java/com/jcraft/jsch/jce/PBKDF2.java
+++ b/src/main/java/com/jcraft/jsch/jce/PBKDF2.java
@@ -27,8 +27,8 @@
 package com.jcraft.jsch.jce;
 
 import java.security.spec.InvalidKeySpecException;
-import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 
 abstract class PBKDF2 implements com.jcraft.jsch.PBKDF2 {
   private SecretKeyFactory skf;

--- a/src/main/java/com/jcraft/jsch/jce/PBKDF2HMACSHA512224.java
+++ b/src/main/java/com/jcraft/jsch/jce/PBKDF2HMACSHA512224.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2013-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+public class PBKDF2HMACSHA512224 extends PBKDF2 {
+  @Override
+  String getName() {
+    return "PBKDF2WithHmacSHA512/224";
+  }
+}

--- a/src/main/java/com/jcraft/jsch/jce/PBKDF2HMACSHA512256.java
+++ b/src/main/java/com/jcraft/jsch/jce/PBKDF2HMACSHA512256.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2013-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+public class PBKDF2HMACSHA512256 extends PBKDF2 {
+  @Override
+  String getName() {
+    return "PBKDF2WithHmacSHA512/256";
+  }
+}

--- a/src/main/java/com/jcraft/jsch/jce/SHA1.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA1.java
@@ -27,8 +27,7 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.HASH;
-
-import java.security.*;
+import java.security.MessageDigest;
 
 public class SHA1 implements HASH {
   MessageDigest md;

--- a/src/main/java/com/jcraft/jsch/jce/SHA224.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA224.java
@@ -27,8 +27,7 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.HASH;
-
-import java.security.*;
+import java.security.MessageDigest;
 
 public class SHA224 implements HASH {
   MessageDigest md;

--- a/src/main/java/com/jcraft/jsch/jce/SHA256.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA256.java
@@ -27,8 +27,7 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.HASH;
-
-import java.security.*;
+import java.security.MessageDigest;
 
 public class SHA256 implements HASH {
   MessageDigest md;

--- a/src/main/java/com/jcraft/jsch/jce/SHA384.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA384.java
@@ -26,9 +26,10 @@
 
 package com.jcraft.jsch.jce;
 
-import java.security.*;
+import com.jcraft.jsch.HASH;
+import java.security.MessageDigest;
 
-public class SHA384 implements com.jcraft.jsch.HASH {
+public class SHA384 implements HASH {
   MessageDigest md;
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SHA512.java
+++ b/src/main/java/com/jcraft/jsch/jce/SHA512.java
@@ -26,9 +26,10 @@
 
 package com.jcraft.jsch.jce;
 
-import java.security.*;
+import com.jcraft.jsch.HASH;
+import java.security.MessageDigest;
 
-public class SHA512 implements com.jcraft.jsch.HASH {
+public class SHA512 implements HASH {
   MessageDigest md;
 
   @Override

--- a/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
@@ -26,11 +26,11 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.Buffer;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.*;
-import com.jcraft.jsch.Buffer;
 
 public class SignatureDSA implements com.jcraft.jsch.SignatureDSA {
 

--- a/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureDSA.java
@@ -29,17 +29,21 @@ package com.jcraft.jsch.jce;
 import com.jcraft.jsch.Buffer;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.security.*;
-import java.security.spec.*;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.DSAPrivateKeySpec;
+import java.security.spec.DSAPublicKeySpec;
 
 public class SignatureDSA implements com.jcraft.jsch.SignatureDSA {
 
-  java.security.Signature signature;
+  Signature signature;
   KeyFactory keyFactory;
 
   @Override
   public void init() throws Exception {
-    signature = java.security.Signature.getInstance("SHA1withDSA");
+    signature = Signature.getInstance("SHA1withDSA");
     keyFactory = KeyFactory.getInstance("DSA");
   }
 

--- a/src/main/java/com/jcraft/jsch/jce/SignatureECDSAN.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureECDSAN.java
@@ -27,11 +27,20 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Buffer;
+import com.jcraft.jsch.SignatureECDSA;
 import java.math.BigInteger;
-import java.security.*;
-import java.security.spec.*;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.ECPublicKeySpec;
 
-abstract class SignatureECDSAN implements com.jcraft.jsch.SignatureECDSA {
+abstract class SignatureECDSAN implements SignatureECDSA {
 
   Signature signature;
   KeyFactory keyFactory;
@@ -46,7 +55,7 @@ abstract class SignatureECDSAN implements com.jcraft.jsch.SignatureECDSA {
       foo = "SHA384withECDSA";
     else if (name.equals("ecdsa-sha2-nistp521"))
       foo = "SHA512withECDSA";
-    signature = java.security.Signature.getInstance(foo);
+    signature = Signature.getInstance(foo);
     keyFactory = KeyFactory.getInstance("EC");
   }
 

--- a/src/main/java/com/jcraft/jsch/jce/SignatureECDSAN.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureECDSAN.java
@@ -26,10 +26,10 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.Buffer;
 import java.math.BigInteger;
 import java.security.*;
 import java.security.spec.*;
-import com.jcraft.jsch.Buffer;
 
 abstract class SignatureECDSAN implements com.jcraft.jsch.SignatureECDSA {
 

--- a/src/main/java/com/jcraft/jsch/jce/SignatureECDSAN.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureECDSAN.java
@@ -108,7 +108,7 @@ abstract class SignatureECDSAN implements SignatureECDSA {
     // so we have to convert it.
     if (sig[0] == 0x30 && // in ASN.1
         ((sig[1] + 2 == sig.length)
-            || ((sig[1] & 0x80) != 0 && (sig[2] & 0xff) + 3 == sig.length))) {// 2bytes for len
+            || ((sig[1] & 0x80) != 0 && (sig[2] & 0xff) + 3 == sig.length))) { // 2bytes for len
 
       int index = 3;
       if ((sig[1] & 0x80) != 0 && (sig[2] & 0xff) + 3 == sig.length)

--- a/src/main/java/com/jcraft/jsch/jce/SignatureEd25519.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureEd25519.java
@@ -26,7 +26,9 @@
 
 package com.jcraft.jsch.jce;
 
-public class SignatureEd25519 implements com.jcraft.jsch.SignatureEdDSA {
+import com.jcraft.jsch.SignatureEdDSA;
+
+public class SignatureEd25519 implements SignatureEdDSA {
 
   public SignatureEd25519() {
     throw new UnsupportedOperationException("SignatureEd25519 requires Java15+.");

--- a/src/main/java/com/jcraft/jsch/jce/SignatureEd448.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureEd448.java
@@ -26,7 +26,9 @@
 
 package com.jcraft.jsch.jce;
 
-public class SignatureEd448 implements com.jcraft.jsch.SignatureEdDSA {
+import com.jcraft.jsch.SignatureEdDSA;
+
+public class SignatureEd448 implements SignatureEdDSA {
 
   public SignatureEd448() {
     throw new UnsupportedOperationException("SignatureEd448 requires Java15+.");

--- a/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
@@ -26,11 +26,11 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.Buffer;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.*;
-import com.jcraft.jsch.Buffer;
 
 abstract class SignatureRSAN implements com.jcraft.jsch.SignatureRSA {
 

--- a/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
+++ b/src/main/java/com/jcraft/jsch/jce/SignatureRSAN.java
@@ -27,14 +27,19 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Buffer;
+import com.jcraft.jsch.SignatureRSA;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.security.*;
-import java.security.spec.*;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.RSAPrivateKeySpec;
+import java.security.spec.RSAPublicKeySpec;
 
-abstract class SignatureRSAN implements com.jcraft.jsch.SignatureRSA {
+abstract class SignatureRSAN implements SignatureRSA {
 
-  java.security.Signature signature;
+  Signature signature;
   KeyFactory keyFactory;
 
   abstract String getName();
@@ -51,7 +56,7 @@ abstract class SignatureRSAN implements com.jcraft.jsch.SignatureRSA {
       foo = "SHA384withRSA";
     else if (name.equals("ssh-rsa-sha224@ssh.com"))
       foo = "SHA224withRSA";
-    signature = java.security.Signature.getInstance(foo);
+    signature = Signature.getInstance(foo);
     keyFactory = KeyFactory.getInstance("RSA");
   }
 

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
@@ -27,8 +27,10 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.*;
-import javax.crypto.spec.*;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.IvParameterSpec;
 
 public class TripleDESCBC implements Cipher {
   private static final int ivsize = 8;

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
@@ -49,8 +49,6 @@ public class TripleDESCBC implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
-    // if(padding) pad="PKCS5Padding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -64,7 +62,7 @@ public class TripleDESCBC implements Cipher {
     }
 
     try {
-      cipher = javax.crypto.Cipher.getInstance("DESede/CBC/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("DESede/CBC/NoPadding");
       /*
        * // The following code does not work on IBM's JDK 1.4.1 SecretKeySpec skeySpec = new
        * SecretKeySpec(key, "DESede"); cipher.init((mode==ENCRYPT_MODE?

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCBC.java
@@ -26,16 +26,16 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 
-public class TripleDESCBC implements Cipher {
+public class TripleDESCBC implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 8;
   private static final int bsize = 24;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -62,18 +62,18 @@ public class TripleDESCBC implements Cipher {
     }
 
     try {
-      cipher = javax.crypto.Cipher.getInstance("DESede/CBC/NoPadding");
+      cipher = Cipher.getInstance("DESede/CBC/NoPadding");
       /*
        * // The following code does not work on IBM's JDK 1.4.1 SecretKeySpec skeySpec = new
-       * SecretKeySpec(key, "DESede"); cipher.init((mode==ENCRYPT_MODE?
-       * javax.crypto.Cipher.ENCRYPT_MODE: javax.crypto.Cipher.DECRYPT_MODE), skeySpec, new
-       * IvParameterSpec(iv));
+       * SecretKeySpec(key, "DESede"); cipher.init((mode==com.jcraft.jsch.Cipher.ENCRYPT_MODE?
+       * Cipher.ENCRYPT_MODE: Cipher.DECRYPT_MODE), skeySpec, new IvParameterSpec(iv));
        */
       DESedeKeySpec keyspec = new DESedeKeySpec(key);
       SecretKeyFactory keyfactory = SecretKeyFactory.getInstance("DESede");
       SecretKey _key = keyfactory.generateSecret(keyspec);
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), _key, new IvParameterSpec(iv));
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          _key, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
@@ -27,8 +27,10 @@
 package com.jcraft.jsch.jce;
 
 import com.jcraft.jsch.Cipher;
-import javax.crypto.*;
-import javax.crypto.spec.*;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.IvParameterSpec;
 
 public class TripleDESCTR implements Cipher {
   private static final int ivsize = 8;

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
@@ -49,8 +49,6 @@ public class TripleDESCTR implements Cipher {
 
   @Override
   public void init(int mode, byte[] key, byte[] iv) throws Exception {
-    String pad = "NoPadding";
-    // if(padding) pad="PKCS5Padding";
     byte[] tmp;
     if (iv.length > ivsize) {
       tmp = new byte[ivsize];
@@ -64,7 +62,7 @@ public class TripleDESCTR implements Cipher {
     }
 
     try {
-      cipher = javax.crypto.Cipher.getInstance("DESede/CTR/" + pad);
+      cipher = javax.crypto.Cipher.getInstance("DESede/CTR/NoPadding");
       /*
        * // The following code does not work on IBM's JDK 1.4.1 SecretKeySpec skeySpec = new
        * SecretKeySpec(key, "DESede"); cipher.init((mode==ENCRYPT_MODE?

--- a/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
+++ b/src/main/java/com/jcraft/jsch/jce/TripleDESCTR.java
@@ -26,16 +26,16 @@
 
 package com.jcraft.jsch.jce;
 
-import com.jcraft.jsch.Cipher;
+import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 
-public class TripleDESCTR implements Cipher {
+public class TripleDESCTR implements com.jcraft.jsch.Cipher {
   private static final int ivsize = 8;
   private static final int bsize = 24;
-  private javax.crypto.Cipher cipher;
+  private Cipher cipher;
 
   @Override
   public int getIVSize() {
@@ -62,18 +62,18 @@ public class TripleDESCTR implements Cipher {
     }
 
     try {
-      cipher = javax.crypto.Cipher.getInstance("DESede/CTR/NoPadding");
+      cipher = Cipher.getInstance("DESede/CTR/NoPadding");
       /*
        * // The following code does not work on IBM's JDK 1.4.1 SecretKeySpec skeySpec = new
-       * SecretKeySpec(key, "DESede"); cipher.init((mode==ENCRYPT_MODE?
-       * javax.crypto.Cipher.ENCRYPT_MODE: javax.crypto.Cipher.DECRYPT_MODE), skeySpec, new
-       * IvParameterSpec(iv));
+       * SecretKeySpec(key, "DESede"); cipher.init((mode==com.jcraft.jsch.Cipher.ENCRYPT_MODE?
+       * Cipher.ENCRYPT_MODE: Cipher.DECRYPT_MODE), skeySpec, new IvParameterSpec(iv));
        */
       DESedeKeySpec keyspec = new DESedeKeySpec(key);
       SecretKeyFactory keyfactory = SecretKeyFactory.getInstance("DESede");
       SecretKey _key = keyfactory.generateSecret(keyspec);
-      cipher.init((mode == ENCRYPT_MODE ? javax.crypto.Cipher.ENCRYPT_MODE
-          : javax.crypto.Cipher.DECRYPT_MODE), _key, new IvParameterSpec(iv));
+      cipher.init(
+          (mode == com.jcraft.jsch.Cipher.ENCRYPT_MODE ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE),
+          _key, new IvParameterSpec(iv));
     } catch (Exception e) {
       cipher = null;
       throw e;

--- a/src/main/java/com/jcraft/jsch/jgss/GSSContextKrb5.java
+++ b/src/main/java/com/jcraft/jsch/jgss/GSSContextKrb5.java
@@ -27,7 +27,6 @@
 package com.jcraft.jsch.jgss;
 
 import com.jcraft.jsch.JSchException;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import org.ietf.jgss.GSSContext;

--- a/src/main/java/com/jcraft/jsch/juz/Compression.java
+++ b/src/main/java/com/jcraft/jsch/juz/Compression.java
@@ -1,7 +1,10 @@
 package com.jcraft.jsch.juz;
 
-import com.jcraft.jsch.*;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Logger;
+import com.jcraft.jsch.Session;
 import java.util.function.Supplier;
+import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 
@@ -115,7 +118,7 @@ public class Compression implements com.jcraft.jsch.Compression {
         System.arraycopy(tmpbuf, 0, inflated_buf, inflated_end, result);
         inflated_end += result;
       } while (inflater.getRemaining() > 0);
-    } catch (java.util.zip.DataFormatException e) {
+    } catch (DataFormatException e) {
       logMessage(Logger.WARN, () -> "an exception during uncompress\n" + e.toString());
     }
 

--- a/src/main/java/com/jcraft/jsch/juz/Compression.java
+++ b/src/main/java/com/jcraft/jsch/juz/Compression.java
@@ -11,6 +11,7 @@ import java.util.zip.Inflater;
 /**
  * This example demonstrates the packet compression without using jzlib[1].
  *
+ * <p>
  * The ssh protocol adopts zlib[2] for the packet compression. Fortunately, JDK has provided wrapper
  * classes for zlib(j.u.z.{Deflater, Inflater}), but it does not expose enough functionality of
  * zlib, unfortunately; it must not allow to compress data with SYNC_FLUSH. So, JSch has been using
@@ -18,12 +19,12 @@ import java.util.zip.Inflater;
  * j.u.z.Deflater, and SYNC_FLUSH has been supported at last. This example shows how to enable the
  * packet compression by using JDK's java.util.zip package.
  *
- *
+ * <p>
  * [1] http://www.jcraft.com/jzlib/ [2] http://www.zlib.net/ [3]
  * https://bugs.openjdk.java.net/browse/JDK-4206909
  */
 public class Compression implements com.jcraft.jsch.Compression {
-  static private final int BUF_SIZE = 4096;
+  private static final int BUF_SIZE = 4096;
   private final int buffer_margin = 32 + 20; // AES256 + HMACSHA1
   private Deflater deflater;
   private Inflater inflater;

--- a/src/main/java/com/jcraft/jsch/jzlib/Adler32.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Adler32.java
@@ -33,9 +33,9 @@ package com.jcraft.jsch.jzlib;
 final class Adler32 implements Checksum {
 
   // largest prime smaller than 65536
-  static final private int BASE = 65521;
+  private static final int BASE = 65521;
   // NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
-  static final private int NMAX = 5552;
+  private static final int NMAX = 5552;
 
   private long s1 = 1L;
   private long s2 = 0L;

--- a/src/main/java/com/jcraft/jsch/jzlib/CRC32.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/CRC32.java
@@ -37,6 +37,7 @@ final class CRC32 implements Checksum {
    */
   private int v = 0;
   private static int[] crc_table = null;
+
   static {
     crc_table = new int[256];
     for (int n = 0; n < 256; n++) {

--- a/src/main/java/com/jcraft/jsch/jzlib/Compression.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Compression.java
@@ -33,7 +33,7 @@ import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 
 public class Compression implements com.jcraft.jsch.Compression {
-  static private final int BUF_SIZE = 4096;
+  private static final int BUF_SIZE = 4096;
   private final int buffer_margin = 32 + 20; // AES256 + HMACSHA1
   private Deflater deflater;
   private Inflater inflater;

--- a/src/main/java/com/jcraft/jsch/jzlib/Compression.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Compression.java
@@ -26,11 +26,11 @@
 
 package com.jcraft.jsch.jzlib;
 
-import java.util.function.Supplier;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Logger;
 import com.jcraft.jsch.Session;
 import java.io.UncheckedIOException;
+import java.util.function.Supplier;
 
 public class Compression implements com.jcraft.jsch.Compression {
   static private final int BUF_SIZE = 4096;

--- a/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
@@ -32,12 +32,12 @@ package com.jcraft.jsch.jzlib;
 
 final class Deflate implements Cloneable {
 
-  static final private int MAX_MEM_LEVEL = 9;
+  private static final int MAX_MEM_LEVEL = 9;
 
-  static final private int Z_DEFAULT_COMPRESSION = -1;
+  private static final int Z_DEFAULT_COMPRESSION = -1;
 
-  static final private int MAX_WBITS = 15; // 32K LZ77 window
-  static final private int DEF_MEM_LEVEL = 8;
+  private static final int MAX_WBITS = 15; // 32K LZ77 window
+  private static final int DEF_MEM_LEVEL = 8;
 
   static class Config {
     int good_length; // reduce lazy search above this match length
@@ -55,10 +55,11 @@ final class Deflate implements Cloneable {
     }
   }
 
-  static final private int STORED = 0;
-  static final private int FAST = 1;
-  static final private int SLOW = 2;
-  static final private Config[] config_table;
+  private static final int STORED = 0;
+  private static final int FAST = 1;
+  private static final int SLOW = 2;
+  private static final Config[] config_table;
+
   static {
     config_table = new Config[10];
     // good lazy nice chain
@@ -75,7 +76,7 @@ final class Deflate implements Cloneable {
     config_table[9] = new Config(32, 258, 258, 4096, SLOW);
   }
 
-  static final private String[] z_errmsg = {"need dictionary", // Z_NEED_DICT 2
+  private static final String[] z_errmsg = {"need dictionary", // Z_NEED_DICT 2
       "stream end", // Z_STREAM_END 1
       "", // Z_OK 0
       "file error", // Z_ERRNO (-1)
@@ -87,80 +88,80 @@ final class Deflate implements Cloneable {
       ""};
 
   // block not completed, need more input or more output
-  static final private int NeedMore = 0;
+  private static final int NeedMore = 0;
 
   // block flush performed
-  static final private int BlockDone = 1;
+  private static final int BlockDone = 1;
 
   // finish started, need only more output at next deflate
-  static final private int FinishStarted = 2;
+  private static final int FinishStarted = 2;
 
   // finish done, accept no more input or output
-  static final private int FinishDone = 3;
+  private static final int FinishDone = 3;
 
   // preset dictionary flag in zlib header
-  static final private int PRESET_DICT = 0x20;
+  private static final int PRESET_DICT = 0x20;
 
-  static final private int Z_FILTERED = 1;
-  static final private int Z_HUFFMAN_ONLY = 2;
-  static final private int Z_DEFAULT_STRATEGY = 0;
+  private static final int Z_FILTERED = 1;
+  private static final int Z_HUFFMAN_ONLY = 2;
+  private static final int Z_DEFAULT_STRATEGY = 0;
 
-  static final private int Z_NO_FLUSH = 0;
-  static final private int Z_PARTIAL_FLUSH = 1;
-  static final private int Z_SYNC_FLUSH = 2;
-  static final private int Z_FULL_FLUSH = 3;
-  static final private int Z_FINISH = 4;
+  private static final int Z_NO_FLUSH = 0;
+  private static final int Z_PARTIAL_FLUSH = 1;
+  private static final int Z_SYNC_FLUSH = 2;
+  private static final int Z_FULL_FLUSH = 3;
+  private static final int Z_FINISH = 4;
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
-  static final private int INIT_STATE = 42;
-  static final private int BUSY_STATE = 113;
-  static final private int FINISH_STATE = 666;
+  private static final int INIT_STATE = 42;
+  private static final int BUSY_STATE = 113;
+  private static final int FINISH_STATE = 666;
 
   // The deflate compression method
-  static final private int Z_DEFLATED = 8;
+  private static final int Z_DEFLATED = 8;
 
-  static final private int STORED_BLOCK = 0;
-  static final private int STATIC_TREES = 1;
-  static final private int DYN_TREES = 2;
+  private static final int STORED_BLOCK = 0;
+  private static final int STATIC_TREES = 1;
+  private static final int DYN_TREES = 2;
 
   // The three kinds of block type
-  static final private int Z_BINARY = 0;
-  static final private int Z_ASCII = 1;
-  static final private int Z_UNKNOWN = 2;
+  private static final int Z_BINARY = 0;
+  private static final int Z_ASCII = 1;
+  private static final int Z_UNKNOWN = 2;
 
-  static final private int Buf_size = 8 * 2;
+  private static final int Buf_size = 8 * 2;
 
   // repeat previous bit length 3-6 times (2 bits of repeat count)
-  static final private int REP_3_6 = 16;
+  private static final int REP_3_6 = 16;
 
   // repeat a zero length 3-10 times (3 bits of repeat count)
-  static final private int REPZ_3_10 = 17;
+  private static final int REPZ_3_10 = 17;
 
   // repeat a zero length 11-138 times (7 bits of repeat count)
-  static final private int REPZ_11_138 = 18;
+  private static final int REPZ_11_138 = 18;
 
-  static final private int MIN_MATCH = 3;
-  static final private int MAX_MATCH = 258;
-  static final private int MIN_LOOKAHEAD = (MAX_MATCH + MIN_MATCH + 1);
+  private static final int MIN_MATCH = 3;
+  private static final int MAX_MATCH = 258;
+  private static final int MIN_LOOKAHEAD = (MAX_MATCH + MIN_MATCH + 1);
 
-  static final private int MAX_BITS = 15;
-  static final private int D_CODES = 30;
-  static final private int BL_CODES = 19;
-  static final private int LENGTH_CODES = 29;
-  static final private int LITERALS = 256;
-  static final private int L_CODES = (LITERALS + 1 + LENGTH_CODES);
-  static final private int HEAP_SIZE = (2 * L_CODES + 1);
+  private static final int MAX_BITS = 15;
+  private static final int D_CODES = 30;
+  private static final int BL_CODES = 19;
+  private static final int LENGTH_CODES = 29;
+  private static final int LITERALS = 256;
+  private static final int L_CODES = (LITERALS + 1 + LENGTH_CODES);
+  private static final int HEAP_SIZE = (2 * L_CODES + 1);
 
-  static final private int END_BLOCK = 256;
+  private static final int END_BLOCK = 256;
 
   ZStream strm; // pointer back to this zlib stream
   int status; // as the name implies
@@ -487,7 +488,6 @@ final class Deflate implements Cloneable {
     return max_blindex;
   }
 
-
   // Send the header for a block using dynamic Huffman trees: the counts, the
   // lengths of the bit length codes, the literal tree and the distance tree.
   // IN assertion: lcodes >= 257, dcodes >= 1, blcodes >= 4.
@@ -572,13 +572,13 @@ final class Deflate implements Cloneable {
   }
 
   final void put_short(int w) {
-    put_byte((byte) (w/* &0xff */));
+    put_byte((byte) (w /* &0xff */));
     put_byte((byte) (w >>> 8));
   }
 
   final void putShortMSB(int b) {
     put_byte((byte) (b >> 8));
-    put_byte((byte) (b/* &0xff */));
+    put_byte((byte) (b /* &0xff */));
   }
 
   final void send_code(int c, short[] tree) {
@@ -628,7 +628,6 @@ final class Deflate implements Cloneable {
     }
     last_eob_len = 7;
   }
-
 
   // Save the match info and tally the frequency counts. Return true if
   // the current block must be flushed.
@@ -835,7 +834,6 @@ final class Deflate implements Cloneable {
         flush_block_only(false);
         if (strm.avail_out == 0)
           return NeedMore;
-
       }
 
       // Flush if we may have to slide, otherwise block_start may become
@@ -869,7 +867,7 @@ final class Deflate implements Cloneable {
       int stored_len, // length of input block
       boolean eof // true if this is the last block for a file
   ) {
-    int opt_lenb, static_lenb;// opt_len and static_len in bytes
+    int opt_lenb, static_lenb; // opt_len and static_len in bytes
     int max_blindex = 0; // index of last bit length code of non zero freq
 
     // Build the Huffman trees unless a stored block is forced
@@ -1541,7 +1539,6 @@ final class Deflate implements Cloneable {
         status = BUSY_STATE;
         putShortMSB(header);
 
-
         // Save the adler32 of the preset dictionary:
         if (strstart != 0) {
           long adler = strm.adler.getValue();
@@ -1620,7 +1617,7 @@ final class Deflate implements Cloneable {
           // as a special marker by inflate_sync().
           if (flush == Z_FULL_FLUSH) {
             // state.head[s.hash_size-1]=0;
-            for (int i = 0; i < hash_size/*-1*/; i++) // forget history
+            for (int i = 0; i < hash_size /*-1*/; i++) // forget history
               head[i] = 0;
           }
         }

--- a/src/main/java/com/jcraft/jsch/jzlib/Deflater.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Deflater.java
@@ -32,26 +32,26 @@ package com.jcraft.jsch.jzlib;
 
 final class Deflater extends ZStream {
 
-  static final private int MAX_WBITS = 15; // 32K LZ77 window
-  static final private int DEF_WBITS = MAX_WBITS;
+  private static final int MAX_WBITS = 15; // 32K LZ77 window
+  private static final int DEF_WBITS = MAX_WBITS;
 
-  static final private int Z_NO_FLUSH = 0;
-  static final private int Z_PARTIAL_FLUSH = 1;
-  static final private int Z_SYNC_FLUSH = 2;
-  static final private int Z_FULL_FLUSH = 3;
-  static final private int Z_FINISH = 4;
+  private static final int Z_NO_FLUSH = 0;
+  private static final int Z_PARTIAL_FLUSH = 1;
+  private static final int Z_SYNC_FLUSH = 2;
+  private static final int Z_FULL_FLUSH = 3;
+  private static final int Z_FINISH = 4;
 
-  static final private int MAX_MEM_LEVEL = 9;
+  private static final int MAX_MEM_LEVEL = 9;
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
   private boolean finished = false;
 

--- a/src/main/java/com/jcraft/jsch/jzlib/DeflaterOutputStream.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/DeflaterOutputStream.java
@@ -26,7 +26,9 @@
 
 package com.jcraft.jsch.jzlib;
 
-import java.io.*;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 
 final class DeflaterOutputStream extends FilterOutputStream {
 

--- a/src/main/java/com/jcraft/jsch/jzlib/GZIPHeader.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/GZIPHeader.java
@@ -31,7 +31,6 @@
 package com.jcraft.jsch.jzlib;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 /**
  * @see <a href="http://www.ietf.org/rfc/rfc1952.txt">http://www.ietf.org/rfc/rfc1952.txt</a>

--- a/src/main/java/com/jcraft/jsch/jzlib/InfBlocks.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InfBlocks.java
@@ -31,10 +31,10 @@
 package com.jcraft.jsch.jzlib;
 
 final class InfBlocks {
-  static final private int MANY = 1440;
+  private static final int MANY = 1440;
 
   // And'ing with mask[n] masks the lower n bits
-  static final private int[] inflate_mask = {0x00000000, 0x00000001, 0x00000003, 0x00000007,
+  private static final int[] inflate_mask = {0x00000000, 0x00000001, 0x00000003, 0x00000007,
       0x0000000f, 0x0000001f, 0x0000003f, 0x0000007f, 0x000000ff, 0x000001ff, 0x000003ff,
       0x000007ff, 0x00000fff, 0x00001fff, 0x00003fff, 0x00007fff, 0x0000ffff};
 
@@ -42,26 +42,26 @@ final class InfBlocks {
   static final int[] border = { // Order of the bit length code lengths
       16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
-  static final private int TYPE = 0; // get type bits (3, including end bit)
-  static final private int LENS = 1; // get lengths for stored
-  static final private int STORED = 2;// processing stored block
-  static final private int TABLE = 3; // get table lengths
-  static final private int BTREE = 4; // get bit lengths tree for a dynamic block
-  static final private int DTREE = 5; // get length, distance trees for a dynamic block
-  static final private int CODES = 6; // processing fixed or dynamic block
-  static final private int DRY = 7; // output remaining window bytes
-  static final private int DONE = 8; // finished last block, done
-  static final private int BAD = 9; // ot a data error--stuck here
+  private static final int TYPE = 0; // get type bits (3, including end bit)
+  private static final int LENS = 1; // get lengths for stored
+  private static final int STORED = 2; // processing stored block
+  private static final int TABLE = 3; // get table lengths
+  private static final int BTREE = 4; // get bit lengths tree for a dynamic block
+  private static final int DTREE = 5; // get length, distance trees for a dynamic block
+  private static final int CODES = 6; // processing fixed or dynamic block
+  private static final int DRY = 7; // output remaining window bytes
+  private static final int DONE = 8; // finished last block, done
+  private static final int BAD = 9; // ot a data error--stuck here
 
   int mode; // current inflate_block mode
 
@@ -151,7 +151,6 @@ final class InfBlocks {
     while (true) {
       switch (mode) {
         case TYPE:
-
           while (k < (3)) {
             if (n != 0) {
               r = Z_OK;
@@ -197,7 +196,6 @@ final class InfBlocks {
               mode = CODES;
               break;
             case 2: // dynamic
-
             {
               b >>>= (3);
               k -= (3);
@@ -206,7 +204,6 @@ final class InfBlocks {
               mode = TABLE;
               break;
             case 3: // illegal
-
             {
               b >>>= (3);
               k -= (3);
@@ -225,7 +222,6 @@ final class InfBlocks {
           }
           break;
         case LENS:
-
           while (k < (32)) {
             if (n != 0) {
               r = Z_OK;
@@ -313,7 +309,6 @@ final class InfBlocks {
           mode = last != 0 ? DRY : TYPE;
           break;
         case TABLE:
-
           while (k < (14)) {
             if (n != 0) {
               r = Z_OK;

--- a/src/main/java/com/jcraft/jsch/jzlib/InfCodes.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InfCodes.java
@@ -32,33 +32,33 @@ package com.jcraft.jsch.jzlib;
 
 final class InfCodes {
 
-  static final private int[] inflate_mask = {0x00000000, 0x00000001, 0x00000003, 0x00000007,
+  private static final int[] inflate_mask = {0x00000000, 0x00000001, 0x00000003, 0x00000007,
       0x0000000f, 0x0000001f, 0x0000003f, 0x0000007f, 0x000000ff, 0x000001ff, 0x000003ff,
       0x000007ff, 0x00000fff, 0x00001fff, 0x00003fff, 0x00007fff, 0x0000ffff};
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
   // waiting for "i:"=input,
   // "o:"=output,
   // "x:"=nothing
-  static final private int START = 0; // x: set up for LEN
-  static final private int LEN = 1; // i: get length/literal/eob next
-  static final private int LENEXT = 2; // i: getting length extra (have base)
-  static final private int DIST = 3; // i: get distance next
-  static final private int DISTEXT = 4;// i: getting distance extra
-  static final private int COPY = 5; // o: copying bytes in window, waiting for space
-  static final private int LIT = 6; // o: got literal, waiting for output space
-  static final private int WASH = 7; // o: got eob, possibly still output waiting
-  static final private int END = 8; // x: got eob and all data flushed
-  static final private int BADCODE = 9;// x: got error
+  private static final int START = 0; // x: set up for LEN
+  private static final int LEN = 1; // i: get length/literal/eob next
+  private static final int LENEXT = 2; // i: getting length extra (have base)
+  private static final int DIST = 3; // i: get distance next
+  private static final int DISTEXT = 4; // i: getting distance extra
+  private static final int COPY = 5; // o: copying bytes in window, waiting for space
+  private static final int LIT = 6; // o: got literal, waiting for output space
+  private static final int WASH = 7; // o: got eob, possibly still output waiting
+  private static final int END = 8; // x: got eob and all data flushed
+  private static final int BADCODE = 9; // x: got error
 
   int mode; // current inflate_codes mode
 
@@ -433,7 +433,6 @@ final class InfCodes {
           return s.inflate_flush(r);
 
         case BADCODE: // x: got error
-
           r = Z_DATA_ERROR;
 
           s.bitb = b;
@@ -599,7 +598,6 @@ final class InfCodes {
                   }
                   r = 0; // copy rest from start of window
                 }
-
               }
 
               // copy all or what's left

--- a/src/main/java/com/jcraft/jsch/jzlib/InfTree.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InfTree.java
@@ -32,17 +32,17 @@ package com.jcraft.jsch.jzlib;
 
 final class InfTree {
 
-  static final private int MANY = 1440;
+  private static final int MANY = 1440;
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
   static final int fixed_bl = 9;
   static final int fixed_bd = 5;
@@ -77,7 +77,6 @@ final class InfTree {
       8, 135, 0, 8, 71, 0, 9, 238, 80, 7, 9, 0, 8, 95, 0, 8, 31, 0, 9, 158, 84, 7, 99, 0, 8, 127, 0,
       8, 63, 0, 9, 222, 82, 7, 27, 0, 8, 111, 0, 8, 47, 0, 9, 190, 0, 8, 15, 0, 8, 143, 0, 8, 79, 0,
       9, 254, 96, 7, 256, 0, 8, 80, 0, 8, 16, 84, 8, 115, 82, 7, 31, 0, 8, 112, 0, 8, 48, 0, 9, 193,
-
       80, 7, 10, 0, 8, 96, 0, 8, 32, 0, 9, 161, 0, 8, 0, 0, 8, 128, 0, 8, 64, 0, 9, 225, 80, 7, 6,
       0, 8, 88, 0, 8, 24, 0, 9, 145, 83, 7, 59, 0, 8, 120, 0, 8, 56, 0, 9, 209, 81, 7, 17, 0, 8,
       104, 0, 8, 40, 0, 9, 177, 0, 8, 8, 0, 8, 136, 0, 8, 72, 0, 9, 241, 80, 7, 4, 0, 8, 84, 0, 8,

--- a/src/main/java/com/jcraft/jsch/jzlib/Inflate.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Inflate.java
@@ -34,10 +34,10 @@ import java.io.ByteArrayOutputStream;
 
 final class Inflate {
 
-  static final private int MAX_WBITS = 15; // 32K LZ77 window
+  private static final int MAX_WBITS = 15; // 32K LZ77 window
 
   // preset dictionary flag in zlib header
-  static final private int PRESET_DICT = 0x20;
+  private static final int PRESET_DICT = 0x20;
 
   static final int Z_NO_FLUSH = 0;
   static final int Z_PARTIAL_FLUSH = 1;
@@ -45,43 +45,43 @@ final class Inflate {
   static final int Z_FULL_FLUSH = 3;
   static final int Z_FINISH = 4;
 
-  static final private int Z_DEFLATED = 8;
+  private static final int Z_DEFLATED = 8;
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
-  static final private int METHOD = 0; // waiting for method byte
-  static final private int FLAG = 1; // waiting for flag byte
-  static final private int DICT4 = 2; // four dictionary check bytes to go
-  static final private int DICT3 = 3; // three dictionary check bytes to go
-  static final private int DICT2 = 4; // two dictionary check bytes to go
-  static final private int DICT1 = 5; // one dictionary check byte to go
-  static final private int DICT0 = 6; // waiting for inflateSetDictionary
-  static final private int BLOCKS = 7; // decompressing blocks
-  static final private int CHECK4 = 8; // four check bytes to go
-  static final private int CHECK3 = 9; // three check bytes to go
-  static final private int CHECK2 = 10; // two check bytes to go
-  static final private int CHECK1 = 11; // one check byte to go
-  static final private int DONE = 12; // finished check, done
-  static final private int BAD = 13; // got an error--stay here
+  private static final int METHOD = 0; // waiting for method byte
+  private static final int FLAG = 1; // waiting for flag byte
+  private static final int DICT4 = 2; // four dictionary check bytes to go
+  private static final int DICT3 = 3; // three dictionary check bytes to go
+  private static final int DICT2 = 4; // two dictionary check bytes to go
+  private static final int DICT1 = 5; // one dictionary check byte to go
+  private static final int DICT0 = 6; // waiting for inflateSetDictionary
+  private static final int BLOCKS = 7; // decompressing blocks
+  private static final int CHECK4 = 8; // four check bytes to go
+  private static final int CHECK3 = 9; // three check bytes to go
+  private static final int CHECK2 = 10; // two check bytes to go
+  private static final int CHECK1 = 11; // one check byte to go
+  private static final int DONE = 12; // finished check, done
+  private static final int BAD = 13; // got an error--stay here
 
-  static final private int HEAD = 14;
-  static final private int LENGTH = 15;
-  static final private int TIME = 16;
-  static final private int OS = 17;
-  static final private int EXLEN = 18;
-  static final private int EXTRA = 19;
-  static final private int NAME = 20;
-  static final private int COMMENT = 21;
-  static final private int HCRC = 22;
-  static final private int FLAGS = 23;
+  private static final int HEAD = 14;
+  private static final int LENGTH = 15;
+  private static final int TIME = 16;
+  private static final int OS = 17;
+  private static final int EXLEN = 18;
+  private static final int EXTRA = 19;
+  private static final int NAME = 20;
+  private static final int COMMENT = 21;
+  private static final int HCRC = 22;
+  private static final int FLAGS = 23;
 
   static final int INFLATE_ANY = 0x40000000;
 
@@ -288,7 +288,6 @@ final class Inflate {
           }
           this.mode = DICT4;
         case DICT4:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -298,7 +297,6 @@ final class Inflate {
           this.need = ((z.next_in[z.next_in_index++] & 0xff) << 24) & 0xff000000L;
           this.mode = DICT3;
         case DICT3:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -308,7 +306,6 @@ final class Inflate {
           this.need += ((z.next_in[z.next_in_index++] & 0xff) << 16) & 0xff0000L;
           this.mode = DICT2;
         case DICT2:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -318,7 +315,6 @@ final class Inflate {
           this.need += ((z.next_in[z.next_in_index++] & 0xff) << 8) & 0xff00L;
           this.mode = DICT1;
         case DICT1:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -356,7 +352,6 @@ final class Inflate {
           }
           this.mode = CHECK4;
         case CHECK4:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -366,7 +361,6 @@ final class Inflate {
           this.need = ((z.next_in[z.next_in_index++] & 0xff) << 24) & 0xff000000L;
           this.mode = CHECK3;
         case CHECK3:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -376,7 +370,6 @@ final class Inflate {
           this.need += ((z.next_in[z.next_in_index++] & 0xff) << 16) & 0xff0000L;
           this.mode = CHECK2;
         case CHECK2:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -386,7 +379,6 @@ final class Inflate {
           this.need += ((z.next_in[z.next_in_index++] & 0xff) << 8) & 0xff00L;
           this.mode = CHECK1;
         case CHECK1:
-
           if (z.avail_in == 0)
             return r;
           r = f;
@@ -447,7 +439,6 @@ final class Inflate {
           return Z_DATA_ERROR;
 
         case FLAGS:
-
           try {
             r = readBytes(2, r, f);
           } catch (Return e) {
@@ -625,7 +616,7 @@ final class Inflate {
     return Z_OK;
   }
 
-  static private byte[] mark = {(byte) 0, (byte) 0, (byte) 0xff, (byte) 0xff};
+  private static byte[] mark = {(byte) 0, (byte) 0, (byte) 0xff, (byte) 0xff};
 
   int inflateSync() {
     int n; // number of bytes to look at

--- a/src/main/java/com/jcraft/jsch/jzlib/Inflater.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Inflater.java
@@ -32,26 +32,26 @@ package com.jcraft.jsch.jzlib;
 
 final class Inflater extends ZStream {
 
-  static final private int MAX_WBITS = 15; // 32K LZ77 window
-  static final private int DEF_WBITS = MAX_WBITS;
+  private static final int MAX_WBITS = 15; // 32K LZ77 window
+  private static final int DEF_WBITS = MAX_WBITS;
 
-  static final private int Z_NO_FLUSH = 0;
-  static final private int Z_PARTIAL_FLUSH = 1;
-  static final private int Z_SYNC_FLUSH = 2;
-  static final private int Z_FULL_FLUSH = 3;
-  static final private int Z_FINISH = 4;
+  private static final int Z_NO_FLUSH = 0;
+  private static final int Z_PARTIAL_FLUSH = 1;
+  private static final int Z_SYNC_FLUSH = 2;
+  private static final int Z_FULL_FLUSH = 3;
+  private static final int Z_FINISH = 4;
 
-  static final private int MAX_MEM_LEVEL = 9;
+  private static final int MAX_MEM_LEVEL = 9;
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
   private int param_w = -1;
   private JZlib.WrapperType param_wrapperType = null;

--- a/src/main/java/com/jcraft/jsch/jzlib/InflaterInputStream.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InflaterInputStream.java
@@ -26,7 +26,10 @@
 
 package com.jcraft.jsch.jzlib;
 
-import java.io.*;
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 final class InflaterInputStream extends FilterInputStream {

--- a/src/main/java/com/jcraft/jsch/jzlib/InflaterInputStream.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/InflaterInputStream.java
@@ -243,7 +243,7 @@ final class InflaterInputStream extends FilterInputStream {
         throw new IOException("no input");
       inflater.setInput(b1);
       err = inflater.inflate(JZlib.Z_NO_FLUSH);
-      if (err != 0/* Z_OK */)
+      if (err != 0 /* Z_OK */)
         throw new IOException(inflater.msg);
     } while (inflater.istate.inParsingHeader());
   }

--- a/src/main/java/com/jcraft/jsch/jzlib/StaticTree.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/StaticTree.java
@@ -31,13 +31,13 @@
 package com.jcraft.jsch.jzlib;
 
 final class StaticTree {
-  static final private int MAX_BITS = 15;
+  private static final int MAX_BITS = 15;
 
-  static final private int BL_CODES = 19;
-  static final private int D_CODES = 30;
-  static final private int LITERALS = 256;
-  static final private int LENGTH_CODES = 29;
-  static final private int L_CODES = (LITERALS + 1 + LENGTH_CODES);
+  private static final int BL_CODES = 19;
+  private static final int D_CODES = 30;
+  private static final int LITERALS = 256;
+  private static final int LENGTH_CODES = 29;
+  private static final int L_CODES = (LITERALS + 1 + LENGTH_CODES);
 
   // Bit length codes must not exceed MAX_BL_BITS bits
   static final int MAX_BL_BITS = 7;

--- a/src/main/java/com/jcraft/jsch/jzlib/Tree.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Tree.java
@@ -31,13 +31,13 @@
 package com.jcraft.jsch.jzlib;
 
 final class Tree {
-  static final private int MAX_BITS = 15;
-  static final private int BL_CODES = 19;
-  static final private int D_CODES = 30;
-  static final private int LITERALS = 256;
-  static final private int LENGTH_CODES = 29;
-  static final private int L_CODES = (LITERALS + 1 + LENGTH_CODES);
-  static final private int HEAP_SIZE = (2 * L_CODES + 1);
+  private static final int MAX_BITS = 15;
+  private static final int BL_CODES = 19;
+  private static final int D_CODES = 30;
+  private static final int LITERALS = 256;
+  private static final int LENGTH_CODES = 29;
+  private static final int L_CODES = (LITERALS + 1 + LENGTH_CODES);
+  private static final int HEAP_SIZE = (2 * L_CODES + 1);
 
   // Bit length codes must not exceed MAX_BL_BITS bits
   static final int MAX_BL_BITS = 7;
@@ -66,7 +66,6 @@ final class Tree {
   static final int[] extra_blbits = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 7};
 
   static final byte[] bl_order = {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
-
 
   // The lengths of the bit length codes are sent in order of decreasing
   // probability, to avoid transmitting the lengths for unused bit
@@ -304,7 +303,7 @@ final class Tree {
   // the given tree and the field len is set for all tree elements.
   // OUT assertion: the field code is set for all tree elements of non
   // zero code length.
-  private final static void gen_codes(short[] tree, // the tree to decorate
+  private static final void gen_codes(short[] tree, // the tree to decorate
       int max_code, // largest code with non zero frequency
       short[] bl_count, // number of codes at each bit length
       short[] next_code) {
@@ -337,7 +336,7 @@ final class Tree {
   // Reverse the first len bits of a code, using straightforward code (a faster
   // method would use a table)
   // IN assertion: 1 <= len <= 15
-  private final static int bi_reverse(int code, // the value to invert
+  private static final int bi_reverse(int code, // the value to invert
       int len // its bit length
   ) {
     int res = 0;
@@ -349,4 +348,3 @@ final class Tree {
     return res >>> 1;
   }
 }
-

--- a/src/main/java/com/jcraft/jsch/jzlib/ZStream.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/ZStream.java
@@ -32,26 +32,26 @@ package com.jcraft.jsch.jzlib;
 
 class ZStream {
 
-  static final private int MAX_WBITS = 15; // 32K LZ77 window
-  static final private int DEF_WBITS = MAX_WBITS;
+  private static final int MAX_WBITS = 15; // 32K LZ77 window
+  private static final int DEF_WBITS = MAX_WBITS;
 
-  static final private int Z_NO_FLUSH = 0;
-  static final private int Z_PARTIAL_FLUSH = 1;
-  static final private int Z_SYNC_FLUSH = 2;
-  static final private int Z_FULL_FLUSH = 3;
-  static final private int Z_FINISH = 4;
+  private static final int Z_NO_FLUSH = 0;
+  private static final int Z_PARTIAL_FLUSH = 1;
+  private static final int Z_SYNC_FLUSH = 2;
+  private static final int Z_FULL_FLUSH = 3;
+  private static final int Z_FINISH = 4;
 
-  static final private int MAX_MEM_LEVEL = 9;
+  private static final int MAX_MEM_LEVEL = 9;
 
-  static final private int Z_OK = 0;
-  static final private int Z_STREAM_END = 1;
-  static final private int Z_NEED_DICT = 2;
-  static final private int Z_ERRNO = -1;
-  static final private int Z_STREAM_ERROR = -2;
-  static final private int Z_DATA_ERROR = -3;
-  static final private int Z_MEM_ERROR = -4;
-  static final private int Z_BUF_ERROR = -5;
-  static final private int Z_VERSION_ERROR = -6;
+  private static final int Z_OK = 0;
+  private static final int Z_STREAM_END = 1;
+  private static final int Z_NEED_DICT = 2;
+  private static final int Z_ERRNO = -1;
+  private static final int Z_STREAM_ERROR = -2;
+  private static final int Z_DATA_ERROR = -3;
+  private static final int Z_MEM_ERROR = -4;
+  private static final int Z_BUF_ERROR = -5;
+  private static final int Z_VERSION_ERROR = -6;
 
   byte[] next_in; // next input byte
   int next_in_index;
@@ -358,7 +358,6 @@ class ZStream {
 
   int getAvailOut() {
     return avail_out;
-
   }
 
   void setAvailOut(int avail_out) {

--- a/src/main/java11/com/jcraft/jsch/jce/XDH.java
+++ b/src/main/java11/com/jcraft/jsch/jce/XDH.java
@@ -27,11 +27,15 @@
 package com.jcraft.jsch.jce;
 
 import java.math.BigInteger;
-import java.security.*;
-import java.security.spec.*;
-import java.security.interfaces.*;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.interfaces.XECPublicKey;
+import java.security.spec.NamedParameterSpec;
+import java.security.spec.XECPublicKeySpec;
 import java.util.Arrays;
-import javax.crypto.*;
+import javax.crypto.KeyAgreement;
 
 public class XDH implements com.jcraft.jsch.XDH {
   byte[] Q_array;

--- a/src/main/java15/com/jcraft/jsch/jce/KeyPairGenEdDSA.java
+++ b/src/main/java15/com/jcraft/jsch/jce/KeyPairGenEdDSA.java
@@ -26,9 +26,11 @@
 
 package com.jcraft.jsch.jce;
 
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.EdECPrivateKey;
+import java.security.interfaces.EdECPublicKey;
+import java.security.spec.EdECPoint;
 import java.util.Arrays;
 
 public class KeyPairGenEdDSA implements com.jcraft.jsch.KeyPairGenEdDSA {

--- a/src/main/java15/com/jcraft/jsch/jce/SignatureEdDSA.java
+++ b/src/main/java15/com/jcraft/jsch/jce/SignatureEdDSA.java
@@ -29,8 +29,14 @@ package com.jcraft.jsch.jce;
 import com.jcraft.jsch.Buffer;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.security.*;
-import java.security.spec.*;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.EdECPoint;
+import java.security.spec.EdECPrivateKeySpec;
+import java.security.spec.EdECPublicKeySpec;
+import java.security.spec.NamedParameterSpec;
 import java.util.Arrays;
 
 abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
@@ -46,7 +52,7 @@ abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
 
   @Override
   public void init() throws Exception {
-    signature = java.security.Signature.getInstance("EdDSA");
+    signature = Signature.getInstance("EdDSA");
     keyFactory = KeyFactory.getInstance("EdDSA");
   }
 

--- a/src/main/java15/com/jcraft/jsch/jce/SignatureEdDSA.java
+++ b/src/main/java15/com/jcraft/jsch/jce/SignatureEdDSA.java
@@ -26,12 +26,12 @@
 
 package com.jcraft.jsch.jce;
 
+import com.jcraft.jsch.Buffer;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.*;
 import java.util.Arrays;
-import com.jcraft.jsch.Buffer;
 
 abstract class SignatureEdDSA implements com.jcraft.jsch.SignatureEdDSA {
 

--- a/src/main/java16/com/jcraft/jsch/UnixDomainSocketFactory.java
+++ b/src/main/java16/com/jcraft/jsch/UnixDomainSocketFactory.java
@@ -26,9 +26,6 @@
 
 package com.jcraft.jsch;
 
-import com.jcraft.jsch.AgentProxyException;
-import com.jcraft.jsch.USocketFactory;
-
 import java.io.IOException;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,12 +1,12 @@
 module com.jcraft.jsch {
     exports com.jcraft.jsch;
 
-    requires static java.security.jgss;
-    requires static java.logging;
-    requires static org.apache.logging.log4j;
-    requires static org.slf4j;
-    requires static org.bouncycastle.provider;
-    requires static org.newsclub.net.unix;
     requires static com.sun.jna;
     requires static com.sun.jna.platform;
+    requires static java.logging;
+    requires static java.security.jgss;
+    requires static org.apache.logging.log4j;
+    requires static org.bouncycastle.provider;
+    requires static org.newsclub.net.unix;
+    requires static org.slf4j;
 }

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,12 +1,12 @@
 module com.jcraft.jsch {
-    exports com.jcraft.jsch;
+  exports com.jcraft.jsch;
 
-    requires static com.sun.jna;
-    requires static com.sun.jna.platform;
-    requires static java.logging;
-    requires static java.security.jgss;
-    requires static org.apache.logging.log4j;
-    requires static org.bouncycastle.provider;
-    requires static org.newsclub.net.unix;
-    requires static org.slf4j;
+  requires static com.sun.jna;
+  requires static com.sun.jna.platform;
+  requires static java.logging;
+  requires static java.security.jgss;
+  requires static org.apache.logging.log4j;
+  requires static org.bouncycastle.provider;
+  requires static org.newsclub.net.unix;
+  requires static org.slf4j;
 }

--- a/src/test/java/com/jcraft/jsch/Algorithms4IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms4IT.java
@@ -1,7 +1,6 @@
 package com.jcraft.jsch;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/com/jcraft/jsch/JSchTest.java
+++ b/src/test/java/com/jcraft/jsch/JSchTest.java
@@ -64,7 +64,7 @@ class JSchTest {
     assertSame(JSch.DEVNULL, jsch.getInstanceLogger(), "instance logger should be DEVNULL");
   }
 
-  final static class TestLogger implements Logger {
+  static final class TestLogger implements Logger {
     @Override
     public boolean isEnabled(int level) {
       return true;

--- a/src/test/java/com/jcraft/jsch/JSchTest.java
+++ b/src/test/java/com/jcraft/jsch/JSchTest.java
@@ -1,6 +1,7 @@
 package com.jcraft.jsch;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Hashtable;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/jcraft/jsch/JSchTest.java
+++ b/src/test/java/com/jcraft/jsch/JSchTest.java
@@ -1,11 +1,10 @@
 package com.jcraft.jsch;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Hashtable;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class JSchTest {
 

--- a/src/test/java/com/jcraft/jsch/KeyExchangeTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyExchangeTest.java
@@ -19,7 +19,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testNormalize1() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[1];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -29,7 +28,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testNormalize2() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[2];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -42,7 +40,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testNormalize3() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[3];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -58,7 +55,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testNormalizeRandom() {
-    KeyExchange kex = new TestKex();
     for (int i = 0; i < 1000000; i++) {
       byte[] secret = new byte[64];
       random.nextBytes(secret);
@@ -68,7 +64,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsMPInt1() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[1];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -78,7 +73,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsMPInt2() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[2];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -91,7 +85,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsMPInt3() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[3];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -107,7 +100,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsMPIntRandom() {
-    KeyExchange kex = new TestKex();
     for (int i = 0; i < 1000000; i++) {
       byte[] secret = new byte[64];
       random.nextBytes(secret);
@@ -117,14 +109,12 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsString0() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[0];
     doEncodeAsString(secret);
   }
 
   @Test
   public void testEncodeAsString1() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[1];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -134,7 +124,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsString2() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[2];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -147,7 +136,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsString3() {
-    KeyExchange kex = new TestKex();
     byte[] secret = new byte[3];
     for (int i = 0; i <= 0xff; i++) {
       secret[0] = (byte) i;
@@ -163,7 +151,6 @@ public class KeyExchangeTest {
 
   @Test
   public void testEncodeAsStringRandom() {
-    KeyExchange kex = new TestKex();
     for (int i = 0; i < 1000000; i++) {
       byte[] secret = new byte[64];
       random.nextBytes(secret);

--- a/src/test/java/com/jcraft/jsch/KeyPair2IT.java
+++ b/src/test/java/com/jcraft/jsch/KeyPair2IT.java
@@ -55,7 +55,6 @@ public class KeyPair2IT {
     } finally {
       session.disconnect();
     }
-
   }
 
   @ParameterizedTest
@@ -96,9 +95,7 @@ public class KeyPair2IT {
       }
 
       @Override
-      public void showMessage(String message) {
-
-      }
+      public void showMessage(String message) {}
     });
 
     if (keyType != null) {
@@ -110,7 +107,6 @@ public class KeyPair2IT {
     } finally {
       session.disconnect();
     }
-
   }
 
   private JSch createIdentity(String path, String password)

--- a/src/test/java/com/jcraft/jsch/KeyPair2IT.java
+++ b/src/test/java/com/jcraft/jsch/KeyPair2IT.java
@@ -1,16 +1,15 @@
 package com.jcraft.jsch;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import java.net.URISyntaxException;
-import java.nio.file.Paths;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
 public class KeyPair2IT {

--- a/src/test/java/com/jcraft/jsch/KeyPair2Test.java
+++ b/src/test/java/com/jcraft/jsch/KeyPair2Test.java
@@ -1,17 +1,16 @@
 package com.jcraft.jsch;
 
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class KeyPair2Test {
 

--- a/src/test/java/com/jcraft/jsch/KeyPair2Test.java
+++ b/src/test/java/com/jcraft/jsch/KeyPair2Test.java
@@ -1,6 +1,8 @@
 package com.jcraft.jsch;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URISyntaxException;

--- a/src/test/java/com/jcraft/jsch/KeyPairIT.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairIT.java
@@ -1,16 +1,15 @@
 package com.jcraft.jsch;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import java.net.URISyntaxException;
-import java.nio.file.Paths;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
 public class KeyPairIT {

--- a/src/test/java/com/jcraft/jsch/KeyPairIT.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairIT.java
@@ -38,7 +38,6 @@ public class KeyPairIT {
     } finally {
       session.disconnect();
     }
-
   }
 
   @ParameterizedTest
@@ -79,9 +78,7 @@ public class KeyPairIT {
       }
 
       @Override
-      public void showMessage(String message) {
-
-      }
+      public void showMessage(String message) {}
     });
 
     if (keyType != null) {
@@ -93,7 +90,6 @@ public class KeyPairIT {
     } finally {
       session.disconnect();
     }
-
   }
 
   private JSch createIdentity(String path, String password)

--- a/src/test/java/com/jcraft/jsch/KeyPairTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairTest.java
@@ -1,20 +1,19 @@
 package com.jcraft.jsch;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class KeyPairTest {
 

--- a/src/test/java/com/jcraft/jsch/KeyPairTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairTest.java
@@ -178,5 +178,4 @@ class KeyPairTest {
     assertTrue(identity.getKeyPair().decrypt((byte[]) null));
     assertTrue(identity.getKeyPair().decrypt((String) null));
   }
-
 }

--- a/src/test/java/com/jcraft/jsch/KeyPairTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyPairTest.java
@@ -1,7 +1,11 @@
 package com.jcraft.jsch;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URISyntaxException;

--- a/src/test/java/com/jcraft/jsch/KnownHostsTest.java
+++ b/src/test/java/com/jcraft/jsch/KnownHostsTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import com.jcraft.jsch.KnownHosts.HashedHostKey;
-import com.jcraft.jsch.jce.HMACSHA1;
 import com.jcraft.jsch.jce.HMACSHA256;
 import com.jcraft.jsch.jce.HMACSHA512;
 

--- a/src/test/java/com/jcraft/jsch/KnownHostsTest.java
+++ b/src/test/java/com/jcraft/jsch/KnownHostsTest.java
@@ -11,6 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.jcraft.jsch.KnownHosts.HashedHostKey;
+import com.jcraft.jsch.jce.HMACSHA256;
+import com.jcraft.jsch.jce.HMACSHA512;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -36,22 +39,19 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import com.jcraft.jsch.KnownHosts.HashedHostKey;
-import com.jcraft.jsch.jce.HMACSHA256;
-import com.jcraft.jsch.jce.HMACSHA512;
 
 class KnownHostsTest {
-  private final static String rsaKey =
+  private static final String rsaKey =
       "AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkc"
           + "cKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81e"
           + "FzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpI"
           + "oaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G"
           + "3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
-  private final static String hashValue =
+  private static final String hashValue =
       "|1|F1E1KeoE/eEWhi10WpGv4OdiO6Y=|3988QV0VE8wmZL7suNrYQLITLCg=";
-  private final static String hostLine = "ssh.example.com,192.168.1.61";
-  private final static byte[] dsaKeyBytes = Util.str2byte("    ssh-dsa");
-  private final static byte[] rsaKeyBytes = Util.str2byte("    ssh-rsa");
+  private static final String hostLine = "ssh.example.com,192.168.1.61";
+  private static final byte[] dsaKeyBytes = Util.str2byte("    ssh-dsa");
+  private static final byte[] rsaKeyBytes = Util.str2byte("    ssh-rsa");
   private LinkedList<String> messages;
   private JSch jsch;
   private Hashtable<String, String> orgConfig;
@@ -201,7 +201,6 @@ class KnownHostsTest {
     assertEquals(HMACSHA512.class.getName(), kh.hmacsha1.getClass().getName(),
         "hmac class mismatch");
     assertEquals("", messages.stream().collect(Collectors.joining("\r\n")));
-
   }
 
   @Test
@@ -977,7 +976,6 @@ class KnownHostsTest {
     assertEquals(1, hosts.length, "unexpected number of host keys: " + getHostKeysString(hosts));
     assertEquals("[192.277.325.5]:123: key type ssh-rsa", getHostKeysString(hosts),
         "unexpected hosts");
-
   }
 
   private String getMessagesAsString() {
@@ -1142,5 +1140,4 @@ class KnownHostsTest {
       return true;
     }
   }
-
 }

--- a/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
@@ -88,5 +88,4 @@ class OpenSSHConfigTest {
     ConfigRepository.Config kex = parse.getConfig("");
     assertEquals("diffie-hellman-group1-sha1", kex.getValue("kex"));
   }
-
 }

--- a/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
@@ -1,6 +1,7 @@
 package com.jcraft.jsch;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
+++ b/src/test/java/com/jcraft/jsch/OpenSSHConfigTest.java
@@ -1,8 +1,6 @@
 package com.jcraft.jsch;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -11,8 +9,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class OpenSSHConfigTest {
 

--- a/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
+++ b/src/test/java/com/jcraft/jsch/ServerSigAlgsIT.java
@@ -140,8 +140,8 @@ public class ServerSigAlgsIT {
     doSftp(session, true);
 
     String expectedKex = "kex: host key algorithm: rsa-sha2-512";
-    String expectedPubkeysNoServerSigs = String.format(Locale.ROOT,
-        "No server-sig-algs found, using PubkeyAcceptedAlgorithms = %s", algos);
+    // String expectedPubkeysNoServerSigs = String.format(Locale.ROOT,
+    // "No server-sig-algs found, using PubkeyAcceptedAlgorithms = %s", algos);
     String expectedPreauthFail1 = "ssh-rsa-sha512@ssh.com preauth failure";
     String expectedPreauthFail2 = "ssh-rsa-sha384@ssh.com preauth failure";
     String expectedPreauthFail3 = "ssh-rsa-sha256@ssh.com preauth failure";

--- a/src/test/java/com/jcraft/jsch/SessionTest.java
+++ b/src/test/java/com/jcraft/jsch/SessionTest.java
@@ -1,15 +1,13 @@
 package com.jcraft.jsch;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.jcraft.jsch.JSchTest.TestLogger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import com.jcraft.jsch.JSchTest.TestLogger;
-
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class SessionTest {
 

--- a/src/test/java/com/jcraft/jsch/SessionTest.java
+++ b/src/test/java/com/jcraft/jsch/SessionTest.java
@@ -36,7 +36,7 @@ class SessionTest {
         Arguments.of(":42 host:99", "0.0.0.0", "host", 99, null), // bind is empty
         Arguments.of("*:42 host:99", "0.0.0.0", "host", 99, null), // bind is asterisk
         Arguments.of("bind_adress:42 socket", "bind_adress", null, -1, "socket"), // socket
-        Arguments.of("42 socket", "127.0.0.1", null, -1, "socket")// socket wo bind
+        Arguments.of("42 socket", "127.0.0.1", null, -1, "socket") // socket wo bind
     );
   }
 

--- a/src/test/java/com/jcraft/jsch/SessionTest.java
+++ b/src/test/java/com/jcraft/jsch/SessionTest.java
@@ -1,6 +1,7 @@
 package com.jcraft.jsch;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.jcraft.jsch.JSchTest.TestLogger;
 import java.util.stream.Stream;

--- a/src/test/java/com/jcraft/jsch/SftpATTRSTest.java
+++ b/src/test/java/com/jcraft/jsch/SftpATTRSTest.java
@@ -1,0 +1,38 @@
+package com.jcraft.jsch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+public class SftpATTRSTest {
+
+  private final Random random = new Random();
+
+  @Test
+  public void testToDateString0() {
+    String expected = new Date(0L).toString();
+    String actual = SftpATTRS.toDateString(0L);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testToDateStringNow() {
+    long now = System.currentTimeMillis() / 1000L;
+    String expected = new Date(now * 1000L).toString();
+    String actual = SftpATTRS.toDateString(now);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testToDateStringRandom() {
+    for (int i = 0; i < 1000000; i++) {
+      int j = random.ints(Integer.MIN_VALUE, Integer.MAX_VALUE).findFirst().getAsInt();
+      long l = Integer.toUnsignedLong(j);
+      String expected = new Date(l * 1000L).toString();
+      String actual = SftpATTRS.toDateString(l);
+      assertEquals(expected, actual);
+    }
+  }
+}

--- a/src/test/java/com/jcraft/jsch/jbcrypt/BCryptTest.java
+++ b/src/test/java/com/jcraft/jsch/jbcrypt/BCryptTest.java
@@ -15,7 +15,9 @@
 package com.jcraft.jsch.jbcrypt;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/jcraft/jsch/jbcrypt/BCryptTest.java
+++ b/src/test/java/com/jcraft/jsch/jbcrypt/BCryptTest.java
@@ -71,9 +71,7 @@ public class BCryptTest {
       {"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$12$WApznUOJfkEGSmYRfnkrPO",
           "$2a$12$WApznUOJfkEGSmYRfnkrPOr466oFDCaj4b6HY3EXGvfxm43seyhgC"},};
 
-  /**
-   * Test method for 'BCrypt.hashpw(String, String)'
-   */
+  /** Test method for 'BCrypt.hashpw(String, String)' */
   @Test
   public void testHashpw() {
     // System.out.print("BCrypt.hashpw(): ");
@@ -88,9 +86,7 @@ public class BCryptTest {
     // System.out.println("");
   }
 
-  /**
-   * Test method for 'BCrypt.gensalt(int)'
-   */
+  /** Test method for 'BCrypt.gensalt(int)' */
   @Test
   public void testGensaltInt() {
     // System.out.print("BCrypt.gensalt(log_rounds):");
@@ -108,9 +104,7 @@ public class BCryptTest {
     // System.out.println("");
   }
 
-  /**
-   * Test method for 'BCrypt.gensalt()'
-   */
+  /** Test method for 'BCrypt.gensalt()' */
   @Test
   public void testGensalt() {
     // System.out.print("BCrypt.gensalt(): ");
@@ -125,9 +119,7 @@ public class BCryptTest {
     // System.out.println("");
   }
 
-  /**
-   * Test method for 'BCrypt.checkpw(String, String)' expecting success
-   */
+  /** Test method for 'BCrypt.checkpw(String, String)' expecting success */
   @Test
   public void testCheckpw_success() {
     // System.out.print("BCrypt.checkpw w/ good passwords: ");
@@ -140,9 +132,7 @@ public class BCryptTest {
     // System.out.println("");
   }
 
-  /**
-   * Test method for 'BCrypt.checkpw(String, String)' expecting failure
-   */
+  /** Test method for 'BCrypt.checkpw(String, String)' expecting failure */
   @Test
   public void testCheckpw_failure() {
     // System.out.print("BCrypt.checkpw w/ bad passwords: ");
@@ -156,9 +146,7 @@ public class BCryptTest {
     // System.out.println("");
   }
 
-  /**
-   * Test for correct hashing of non-US-ASCII passwords
-   */
+  /** Test for correct hashing of non-US-ASCII passwords */
   @Test
   public void testInternationalChars() {
     // System.out.print("BCrypt.hashpw w/ international chars: ");

--- a/src/test/java/com/jcraft/jsch/jzlib/Adler32Test.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/Adler32Test.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch.jzlib;
 
-import static com.jcraft.jsch.jzlib.Package.*;
+import static com.jcraft.jsch.jzlib.Package.randombuf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;

--- a/src/test/java/com/jcraft/jsch/jzlib/CRC32Test.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/CRC32Test.java
@@ -1,6 +1,6 @@
 package com.jcraft.jsch.jzlib;
 
-import static com.jcraft.jsch.jzlib.Package.*;
+import static com.jcraft.jsch.jzlib.Package.randombuf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;

--- a/src/test/java/com/jcraft/jsch/jzlib/DeflateInflateTest.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/DeflateInflateTest.java
@@ -1,6 +1,18 @@
 package com.jcraft.jsch.jzlib;
 
-import static com.jcraft.jsch.jzlib.JZlib.*;
+import static com.jcraft.jsch.jzlib.JZlib.Z_BEST_COMPRESSION;
+import static com.jcraft.jsch.jzlib.JZlib.Z_BEST_SPEED;
+import static com.jcraft.jsch.jzlib.JZlib.Z_DATA_ERROR;
+import static com.jcraft.jsch.jzlib.JZlib.Z_DEFAULT_COMPRESSION;
+import static com.jcraft.jsch.jzlib.JZlib.Z_DEFAULT_STRATEGY;
+import static com.jcraft.jsch.jzlib.JZlib.Z_FILTERED;
+import static com.jcraft.jsch.jzlib.JZlib.Z_FINISH;
+import static com.jcraft.jsch.jzlib.JZlib.Z_FULL_FLUSH;
+import static com.jcraft.jsch.jzlib.JZlib.Z_NEED_DICT;
+import static com.jcraft.jsch.jzlib.JZlib.Z_NO_COMPRESSION;
+import static com.jcraft.jsch.jzlib.JZlib.Z_NO_FLUSH;
+import static com.jcraft.jsch.jzlib.JZlib.Z_OK;
+import static com.jcraft.jsch.jzlib.JZlib.Z_STREAM_END;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/jcraft/jsch/jzlib/DeflaterInflaterStreamTest.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/DeflaterInflaterStreamTest.java
@@ -1,6 +1,9 @@
 package com.jcraft.jsch.jzlib;
 
-import static com.jcraft.jsch.jzlib.Package.*;
+import static com.jcraft.jsch.jzlib.Package.randombuf;
+import static com.jcraft.jsch.jzlib.Package.readArray;
+import static com.jcraft.jsch.jzlib.Package.readIS;
+import static com.jcraft.jsch.jzlib.Package.uncheckedConsumer;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/jcraft/jsch/jzlib/WrapperTypeTest.java
+++ b/src/test/java/com/jcraft/jsch/jzlib/WrapperTypeTest.java
@@ -1,12 +1,26 @@
 package com.jcraft.jsch.jzlib;
 
-import static com.jcraft.jsch.jzlib.JZlib.*;
-import static com.jcraft.jsch.jzlib.Package.*;
+import static com.jcraft.jsch.jzlib.JZlib.DEF_WBITS;
+import static com.jcraft.jsch.jzlib.JZlib.W_ANY;
+import static com.jcraft.jsch.jzlib.JZlib.W_GZIP;
+import static com.jcraft.jsch.jzlib.JZlib.W_NONE;
+import static com.jcraft.jsch.jzlib.JZlib.W_ZLIB;
+import static com.jcraft.jsch.jzlib.JZlib.Z_BEST_SPEED;
+import static com.jcraft.jsch.jzlib.JZlib.Z_DATA_ERROR;
+import static com.jcraft.jsch.jzlib.JZlib.Z_DEFAULT_COMPRESSION;
+import static com.jcraft.jsch.jzlib.JZlib.Z_NO_FLUSH;
+import static com.jcraft.jsch.jzlib.JZlib.Z_OK;
+import static com.jcraft.jsch.jzlib.JZlib.Z_STREAM_END;
+import static com.jcraft.jsch.jzlib.Package.readArray;
+import static com.jcraft.jsch.jzlib.Package.readIS;
+import static com.jcraft.jsch.jzlib.Package.uncheckedConsumer;
+import static com.jcraft.jsch.jzlib.Package.uncheckedFunction;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.jcraft.jsch.jzlib.JZlib.WrapperType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
- Organize imports and remove unused imports.
- Remove unneeded implements statements.
- Remove unused local variables.
- Skip flatten-maven-plugin during CI tests.
- Expand wildcard imports in order to better adhere to Google Java Style Guide.
- Add PBKDF2-HMAC-SHA512/256 & PBKDF2-HMAC-SHA512/224, which are both supported as of Java 21.
-- [JDK-8288050](https://bugs.openjdk.org/browse/JDK-8288050)
-- [JDK-8297538](https://bugs.openjdk.org/browse/JDK-8297538)
- Organize imports.
- Always embed NoPadding into Cipher string.
- Import javax.crypto.Cipher instead of com.jcraft.jsch.Cipher.
- Organize module-info.
- More formatting corrections to better adhere to Google Java Style Guide.
- Switch to using java.time classes & make work for dates past 2038.
