### PR TITLE
JSCH pins carrier threads when using virtual threads

### DIFF
--- a/src/main/java/com/jcraft/jsch/UserAuthPublicKey.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthPublicKey.java
@@ -41,7 +41,8 @@ class UserAuthPublicKey extends UserAuth {
 
     Vector<Identity> identities = session.getIdentityRepository().getIdentities();
 
-    synchronized (identities) {
+    session.getSessionLock().lock();
+    try {
       if (identities.size() <= 0) {
         return false;
       }
@@ -117,6 +118,8 @@ class UserAuthPublicKey extends UserAuth {
       }
 
       return _start(session, identities, pkmethods, not_available_pks);
+    } finally {
+      session.getSessionLock().unlock();
     }
   }
 


### PR DESCRIPTION
Virtual threads pin to carrier threads when a synchronized block has blocking code in it. We've come across 2 major occurrences of this so far. Using explicit locks is the way to resolve this.