### PR TITLE
support get new format fingerprint from HostKey

### DIFF
--- a/src/main/java/com/jcraft/jsch/HostKey.java
+++ b/src/main/java/com/jcraft/jsch/HostKey.java
@@ -118,6 +118,10 @@ public class HostKey {
   }
 
   public String getFingerPrint(JSch jsch) {
+    return getFingerPrint(jsch, false);
+  }
+
+  public String getFingerPrint(JSch jsch, boolean isNewFormat) {
     HASH hash = null;
     try {
       String _c = JSch.getConfig("FingerprintHash").toLowerCase(Locale.ROOT);
@@ -128,7 +132,7 @@ public class HostKey {
         jsch.getInstanceLogger().log(Logger.ERROR, "getFingerPrint: " + e.getMessage(), e);
       }
     }
-    return Util.getFingerPrint(hash, key, false, true);
+    return Util.getFingerPrint(hash, key, isNewFormat, !isNewFormat);
   }
 
   public String getComment() {

--- a/src/test/java/com/jcraft/jsch/KnownHostsTest.java
+++ b/src/test/java/com/jcraft/jsch/KnownHostsTest.java
@@ -1057,6 +1057,8 @@ class KnownHostsTest {
     assertEquals(
         "9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f",
         key.getFingerPrint(jsch), "fingerprint mismatch");
+    assertEquals("SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8",
+        key.getFingerPrint(jsch, true), "fingerprint mismatch");
     assertEquals(expectedHostResult, key.getHost(), "host mismatch");
     assertEquals(rsaKey, key.getKey(), "key mismatch");
     assertEquals(expectedMarker, key.getMarker(), "marker mismatch");


### PR DESCRIPTION
The PR make `HostKey.getFingerPrint` method support new format fingerprint, and keeping original method return old format.