### PR TITLE
0.2.19 changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 25
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "weekly"      
+      interval: "weekly"
+    open-pull-requests-limit: 25

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@dbb049abf0d677abbd7f7eee0375145b417fdd34 # v2.2.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,18 +31,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Setup JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'zulu'
         java-version: '21'
-        check-latest: true    
+        check-latest: true
         cache: 'maven'
         
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,15 +7,15 @@ jobs:
   coverity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Set up build JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'zulu'
         java-version: '21'
-        check-latest: true    
+        check-latest: true
         cache: 'maven'
-    - uses: vapier/coverity-scan-action@v1
+    - uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1.8.0
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up build JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -21,7 +21,7 @@ jobs:
       - name: Build Javadoc
         run: ./mvnw -B -V -e javadoc:javadoc
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@94f3c658273cf92fb48ef99e5fbc02bd2dc642b2 # v4.6.3
         with:
           folder: target/site/apidocs
           target-folder: ${{github.ref_name}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,42 +15,67 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: ['8', '11', '17', '21']
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Cache local Maven repository
       uses: actions/cache@v4
       with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+        path: |
+          ~/.m2/repository
+          ~/.m2/wrapper
+        key: ${{ runner.os }}-build-maven-${{ hashFiles('**/pom.xml', '**/maven-wrapper.properties') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.java }}-maven-
-    - name: Set up build JDK
+          ${{ runner.os }}-build-maven-
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '21'
         check-latest: true
     - name: Build with Maven
-      run: ./mvnw -B -V -e -DskipTests=true package
-    - uses: actions/upload-artifact@v4
+      run: ./mvnw -B -V -e verify -DskipTests=true -DskipITs=true
+    - name: Archive target directory
+      run: tar -cf target.tar target
+    - name: Upload target directory archive
+      uses: actions/upload-artifact@v4
       with:
-        name: java-${{ matrix.java }}-jars
+        name: build_target
+        path: target.tar
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: ['8', '11', '17', '21']
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Cache local Maven repository
+      uses: actions/cache@v4
+      with:
         path: |
-          **/target/*.jar
-          **/target/bom.*
-      if: always()
-    - name: Set up test JDK ${{ matrix.java }}
+          ~/.m2/repository
+          ~/.m2/wrapper
+        key: ${{ runner.os }}-test-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml', '**/maven-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-test-${{ matrix.java }}-maven-
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
         check-latest: true
+    - name: Download target directory archive
+      uses: actions/download-artifact@v4
+      with:
+        name: build_target
+    - name: Extract target directory archive
+      run: tar -xf target.tar
     - name: Test with Maven
-      run: ./mvnw -B -V -e -P coverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -DskipITs=false
-    - uses: actions/upload-artifact@v4
+      run: ./mvnw -B -V -e -Pcoverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dformatter.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
       with:
         name: java-${{ matrix.java }}-testresults
         path: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17', '21']
+        java: ['8', '11', '17', '21', '22']
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Cache local Maven repository
-      uses: actions/cache@v4
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           ~/.m2/repository
@@ -28,7 +28,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-maven-
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'zulu'
         java-version: '21'
@@ -38,7 +38,7 @@ jobs:
     - name: Archive target directory
       run: tar -cf target.tar target
     - name: Upload target directory archive
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: build_target
         path: target.tar
@@ -50,9 +50,9 @@ jobs:
         java: ['8', '11', '17', '21', '22']
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Cache local Maven repository
-      uses: actions/cache@v4
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           ~/.m2/repository
@@ -61,13 +61,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-test-${{ matrix.java }}-maven-
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Download target directory archive
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: build_target
     - name: Extract target directory archive
@@ -75,7 +75,7 @@ jobs:
     - name: Test with Maven
       run: ./mvnw -B -V -e -Pcoverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dformatter.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: java-${{ matrix.java }}-testresults
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     # Runs a set of commands using the runners shell
     - name: Release

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.geany
 nb-configuration.xml
 .flattened-pom.xml
+target.tar
 
 # Created by https://www.toptal.com/developers/gitignore/api/intellij+all,netbeans,eclipse,visualstudiocode,vim,emacs,macos,windows,linux,java,maven
 # Edit at https://www.toptal.com/developers/gitignore?templates=intellij+all,netbeans,eclipse,visualstudiocode,vim,emacs,macos,windows,linux,java,maven

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-wrapperVersion=3.3.1
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21.0.2-tem
-maven=3.9.6
+java=21.0.3-tem
+maven=3.9.8

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+* [0.2.19](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.19)
+   * Enforce DHGEX prime modulus bit length meets configured constraints.
 * [0.2.18](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.18)
    * Handle negated patterns according to ssh_config(5) by @bmiddaugh in https://github.com/mwiede/jsch/pull/565
 * [0.2.17](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.17)

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.1
+# Apache Maven Wrapper startup batch script, version 3.3.2
 #
 # Optional ENV vars
 # -----------------
@@ -97,11 +97,19 @@ die() {
   exit 1
 }
 
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
-  distributionUrl) distributionUrl="${value-}" ;;
-  distributionSha256Sum) distributionSha256Sum="${value-}" ;;
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
 done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
 [ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
@@ -131,7 +139,8 @@ esac
 distributionUrlName="${distributionUrl##*/}"
 distributionUrlNameMain="${distributionUrlName%.*}"
 distributionUrlNameMain="${distributionUrlNameMain%-bin}"
-MAVEN_HOME="$HOME/.m2/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
 
 exec_maven() {
   unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.3.1
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution
@@ -79,6 +79,9 @@ if ($env:MVNW_REPOURL) {
 $distributionUrlName = $distributionUrl -replace '^.*/',''
 $distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
 $MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
 $MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
 $MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 

--- a/src/main/java/com/jcraft/jsch/DHGEX.java
+++ b/src/main/java/com/jcraft/jsch/DHGEX.java
@@ -26,6 +26,8 @@
 
 package com.jcraft.jsch;
 
+import java.math.BigInteger;
+
 abstract class DHGEX extends KeyExchange {
 
   private static final int SSH_MSG_KEX_DH_GEX_GROUP = 31;
@@ -79,8 +81,7 @@ abstract class DHGEX extends KeyExchange {
       min = Integer.parseInt(session.getConfig("dhgex_min"));
       max = Integer.parseInt(session.getConfig("dhgex_max"));
       preferred = Integer.parseInt(session.getConfig("dhgex_preferred"));
-      if (checkInvalidSize(min) || checkInvalidSize(max) || checkInvalidSize(preferred)
-          || preferred < min || max < preferred) {
+      if (min <= 0 || max <= 0 || preferred <= 0 || preferred < min || preferred > max) {
         throw new JSchException(
             "Invalid DHGEX sizes: min=" + min + " max=" + max + " preferred=" + preferred);
       }
@@ -126,6 +127,11 @@ abstract class DHGEX extends KeyExchange {
 
         p = _buf.getMPInt();
         g = _buf.getMPInt();
+
+        int bits = new BigInteger(1, p).bitLength();
+        if (bits < min || bits > max) {
+          return false;
+        }
 
         dh.setP(p);
         dh.setG(g);
@@ -236,9 +242,5 @@ abstract class DHGEX extends KeyExchange {
   @Override
   public int getState() {
     return state;
-  }
-
-  static boolean checkInvalidSize(int size) {
-    return (size < 1024 || size > 8192 || size % 1024 != 0);
   }
 }


### PR DESCRIPTION
- Update to latest Maven (3.9.8), Maven Wrapper (3.3.2) & Java (21.0.3) releases.
- Only execute build once during CI and then run distinct jobs to run tests for each Java version.
-- This will require changes to the expected checks for PRs.
- Run tests on Java 22.
-- I'm envisioning we will update this every 6 months to follow the latest Java release.
- Harden CI workflows by pinning action versions to specific commit hashes.
-- See [security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommendations.
- Increase Dependabot open PR limit.
-- Since there may be a larger volumes of update PRs incoming for GHA workflows now that they are pinned.
- Enforce DHGEX prime modulus bit length meets configured constraints
-- This should match OpenSSH behavior, as seen [here](https://github.com/openssh/openssh-portable/blob/7717b9e9155209916cc6b4b4b54f4e8fa578e889/kexgexc.c#L109).