### PR TITLE
Add logging stack trace on auth failure

### DIFF
--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -500,8 +500,8 @@ public class Session {
               // SSH_MSG_DISCONNECT: Too many authentication failures
               // System.err.println("ee: " + ee);
               if (getLogger().isEnabled(Logger.WARN)) {
-                getLogger().log(Logger.WARN,
-                    "an exception during authentication\n" + ee.toString());
+                getLogger().log(Logger.WARN, "an exception during authentication\n" + ee.toString(),
+                    ee);
               }
               break loop;
             }


### PR DESCRIPTION
When authentication fails, logger only saves the exception message. This is often not enough to understand what caused the failure.
This change adds the stack trace to the error message.