### PR TITLE
Single authentication attempt and time out.

### DIFF
--- a/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
@@ -72,7 +72,15 @@ class UserAuthKeyboardInteractive extends UserAuth {
       session.write(packet);
 
       boolean firsttime = true;
+      final long timeout = System.currentTimeMillis() + session.getTimeout();
       loop: while (true) {
+        if (session.getTimeout() > 0 && System.currentTimeMillis() > timeout) {
+          throw new JSchAuthCancelException("keyboard-interactive");
+        }
+        if (session.auth_failures >= session.max_auth_tries) {
+          return false;
+        }
+
         buf = session.read(buf);
         int command = buf.getCommand() & 0xff;
 


### PR DESCRIPTION
When authenticating with a script which uses the same password every time, the consecutive attempts with the incorrect password give the same result.
This change adds a preference for a single authentication attempt. When enabled, authentication ends after the first failure and doesn't ask to retry.

Additionally, when time out is set in the session, authentication shouldn't take longer than this time out. 