### PR TITLE
Replace old Hashtable with modern data structures.

### DIFF
--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -36,7 +36,8 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 
 public class ChannelSftp extends ChannelSession {
@@ -135,7 +136,7 @@ public class ChannelSftp extends ChannelSession {
   private int server_version = 3;
   private String version = String.valueOf(client_version);
 
-  private Hashtable<String, String> extensions = null;
+  private Map<String, String> extensions = null;
   private InputStream io_in = null;
 
   private boolean extension_posix_rename = false;
@@ -255,7 +256,7 @@ public class ChannelSftp extends ChannelSession {
       type = header.type; // 2 -> SSH_FXP_VERSION
       server_version = header.rid;
       // System.err.println("SFTP protocol server-version="+server_version);
-      extensions = new Hashtable<>();
+      extensions = new HashMap<>();
       if (length > 0) {
         // extension data
         fill(buf, length);

--- a/src/main/java/com/jcraft/jsch/ChannelX11.java
+++ b/src/main/java/com/jcraft/jsch/ChannelX11.java
@@ -28,7 +28,8 @@ package com.jcraft.jsch;
 
 import java.io.IOException;
 import java.net.Socket;
-import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 class ChannelX11 extends Channel {
 
@@ -45,8 +46,8 @@ class ChannelX11 extends Channel {
   static byte[] cookie = null;
   private static byte[] cookie_hex = null;
 
-  private static Hashtable<Session, byte[]> faked_cookie_pool = new Hashtable<>();
-  private static Hashtable<Session, byte[]> faked_cookie_hex_pool = new Hashtable<>();
+  private static final Map<Session, byte[]> faked_cookie_pool = new ConcurrentHashMap<>();
+  private static final Map<Session, byte[]> faked_cookie_hex_pool = new ConcurrentHashMap<>();
 
   private static byte[] table = {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x61,
       0x62, 0x63, 0x64, 0x65, 0x66};
@@ -219,11 +220,8 @@ class ChannelX11 extends Channel {
 
       byte[] bar = new byte[dlen];
       System.arraycopy(foo, s + 12 + plen + ((-plen) & 3), bar, 0, dlen);
-      byte[] faked_cookie = null;
 
-      synchronized (faked_cookie_pool) {
-        faked_cookie = faked_cookie_pool.get(_session);
-      }
+      byte[] faked_cookie = faked_cookie_pool.get(_session);
 
       /*
        * System.err.print("faked_cookie: "); for(int i=0; i<faked_cookie.length; i++){

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -27,15 +27,15 @@
 package com.jcraft.jsch;
 
 import java.io.InputStream;
-import java.util.Enumeration;
-import java.util.Hashtable;
+import java.util.Map;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class JSch {
   /** The version number. */
   public static final String VERSION = Version.getVersion();
 
-  static Hashtable<String, String> config = new Hashtable<>();
+  static Map<String, String> config = new ConcurrentHashMap<>();
 
   static {
     config.put("kex", Util.getSystemProperty("jsch.kex",
@@ -608,14 +608,10 @@ public class JSch {
    *
    * @param newconf configurations
    */
-  public static void setConfig(Hashtable<String, String> newconf) {
+  public static void setConfig(Map<String, String> newconf) {
     synchronized (config) {
-      for (Enumeration<String> e = newconf.keys(); e.hasMoreElements();) {
-        String newkey = e.nextElement();
-        String key =
-            (newkey.equals("PubkeyAcceptedKeyTypes") ? "PubkeyAcceptedAlgorithms" : newkey);
-        config.put(key, newconf.get(newkey));
-      }
+      newconf.forEach((key, value) -> config
+          .put(key.equals("PubkeyAcceptedKeyTypes") ? "PubkeyAcceptedAlgorithms" : key, value));
     }
   }
 

--- a/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
+++ b/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
@@ -34,9 +34,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 import java.util.stream.Collectors;
@@ -113,7 +114,7 @@ public class OpenSSHConfig implements ConfigRepository {
     _parse(br);
   }
 
-  private final Hashtable<String, Vector<String[]>> config = new Hashtable<>();
+  private final Map<String, Vector<String[]>> config = new HashMap<>();
   private final Vector<String> hosts = new Vector<>();
 
   private void _parse(BufferedReader br) throws IOException {
@@ -156,11 +157,11 @@ public class OpenSSHConfig implements ConfigRepository {
    *
    * @return map
    */
-  static Hashtable<String, String> getKeymap() {
+  static Map<String, String> getKeymap() {
     return keymap;
   }
 
-  private static final Hashtable<String, String> keymap = new Hashtable<>();
+  private static final Map<String, String> keymap = new HashMap<>();
 
   static {
     keymap.put("kex", "KexAlgorithms");

--- a/src/test/java/com/jcraft/jsch/JSchTest.java
+++ b/src/test/java/com/jcraft/jsch/JSchTest.java
@@ -3,9 +3,11 @@ package com.jcraft.jsch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import java.util.Hashtable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 class JSchTest {
 
@@ -29,8 +31,8 @@ class JSchTest {
   }
 
   @Test
-  void setPubkeyAcceptedKeyTypesHashtable() throws JSchException {
-    Hashtable<String, String> newconf = new Hashtable<>();
+  void setPubkeyAcceptedKeyTypesHashtable() {
+    Map<String, String> newconf = new HashMap<>();
     newconf.put("PubkeyAcceptedKeyTypes", "JSchTest333");
     JSch.setConfig(newconf);
     assertEquals("JSchTest333", JSch.getConfig("PubkeyAcceptedKeyTypes"));

--- a/src/test/java/com/jcraft/jsch/KnownHostsTest.java
+++ b/src/test/java/com/jcraft/jsch/KnownHostsTest.java
@@ -25,8 +25,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -54,7 +55,7 @@ class KnownHostsTest {
   private static final byte[] rsaKeyBytes = Util.str2byte("    ssh-rsa");
   private LinkedList<String> messages;
   private JSch jsch;
-  private Hashtable<String, String> orgConfig;
+  private Map<String, String> orgConfig;
   private Properties orgProps;
 
   @BeforeEach
@@ -62,7 +63,7 @@ class KnownHostsTest {
     orgProps = System.getProperties();
     Properties myProps = new Properties(orgProps);
     System.setProperties(myProps);
-    orgConfig = new Hashtable<>(JSch.config);
+    orgConfig = new HashMap<>(JSch.config);
     messages = new LinkedList<>();
     jsch = new JSch();
     jsch.setInstanceLogger(new TestLogger(messages));


### PR DESCRIPTION
This PR replaces the old Hashtable with modern data structures. Hashtable is no longer maintained and is not optimised for better performance.

I replaced type declaration with the interface. Since Hashtable is-a Map, this is seamless.
I replaced Hashtable with ConcurrentHashMap where multiple threads is expected to access the map, but ConcurrentHashMap handles it better (this could be improved further, but one step at a time).
I replaced Hashtable with HashMap where synchronisation was unnecessary.