### PR TITLE
0.2.20 changes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,7 +71,7 @@ jobs:
       with:
         name: build_target
     - name: Extract target directory archive
-      run: tar -xf target.tar
+      run: tar -xmf target.tar
     - name: Test with Maven
       run: ./mvnw -B -V -e -Pcoverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dformatter.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
     - name: Upload test results

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=21.0.4-tem
-maven=3.9.8
+maven=3.9.9

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 * [0.2.20](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.20)
   * [#529](https://github.com/mwiede/jsch/pull/529) Update `Hostkey.getFingerprint()` method to output more moden format first introduced with OpenSSH 6.8.
+  * [#622](https://github.com/mwiede/jsch/pull/622) Add stack trace to log message when an exception occurs during authentication.
 * [0.2.19](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.19)
   * Enforce DHGEX prime modulus bit length meets configured constraints.
   * #604 Fix possible rekeying timeouts.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,5 @@
+* [0.2.20](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.20)
+  * [#529](https://github.com/mwiede/jsch/pull/529) Update `Hostkey.getFingerprint()` method to output more moden format first introduced with OpenSSH 6.8.
 * [0.2.19](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.19)
   * Enforce DHGEX prime modulus bit length meets configured constraints.
   * #604 Fix possible rekeying timeouts.

--- a/pom.xml
+++ b/pom.xml
@@ -668,6 +668,18 @@
             </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <linkOnly>true</linkOnly>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
     <profiles>
         <profile>
             <id>release</id>

--- a/src/main/java/com/jcraft/jsch/HostKey.java
+++ b/src/main/java/com/jcraft/jsch/HostKey.java
@@ -128,7 +128,7 @@ public class HostKey {
         jsch.getInstanceLogger().log(Logger.ERROR, "getFingerPrint: " + e.getMessage(), e);
       }
     }
-    return Util.getFingerPrint(hash, key, false, true);
+    return Util.getFingerPrint(hash, key, true, false);
   }
 
   public String getComment() {

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -500,8 +500,8 @@ public class Session {
               // SSH_MSG_DISCONNECT: Too many authentication failures
               // System.err.println("ee: " + ee);
               if (getLogger().isEnabled(Logger.WARN)) {
-                getLogger().log(Logger.WARN,
-                    "an exception during authentication\n" + ee.toString());
+                getLogger().log(Logger.WARN, "an exception during authentication\n" + ee.toString(),
+                    ee);
               }
               break loop;
             }

--- a/src/test/java/com/jcraft/jsch/KnownHostsTest.java
+++ b/src/test/java/com/jcraft/jsch/KnownHostsTest.java
@@ -454,9 +454,8 @@ class KnownHostsTest {
         "|1|AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=|mie6rcAf1aPGk6d+HxnkpvO4HaOAH/Y6YWegs+Xog/s=",
         hhk.getHost(), "host mismatch");
     assertEquals("", hhk.getMarker(), "marker mismatch");
-    assertEquals(
-        "9c:fb:7f:99:79:01:6d:46:68:87:39:15:4f:f5:cc:9d:71:7a:8b:5a:4a:c1:c7:4b:9c:20:a5:91:c2:6a:ff:5a",
-        hhk.getFingerPrint(jsch));
+    assertEquals("SHA256:nPt/mXkBbUZohzkVT/XMnXF6i1pKwcdLnCClkcJq/1o", hhk.getFingerPrint(jsch),
+        "fingerprint mismatch");
     assertEquals(null, hhk.getComment(), "comment mismatch");
     assertEquals("ICAgIHNzaC1yc2E=", hhk.getKey(), "key mismatch");
     assertEquals("ssh-rsa", hhk.getType(), "type mismatch");
@@ -1006,9 +1005,8 @@ class KnownHostsTest {
       String expectedType, String expectedComment) {
     assertEquals(expctedHost, hhk.getHost(), "host mismatch");
     assertEquals(expectedMarker, hhk.getMarker(), "marker mismatch");
-    assertEquals(
-        "1e:b5:70:92:65:6e:6a:f9:d6:7a:a9:43:00:40:a2:e7:c8:51:35:df:ee:60:19:b7:4b:18:1d:eb:46:48:28:4b",
-        hhk.getFingerPrint(jsch));
+    assertEquals("SHA256:HrVwkmVuavnWeqlDAECi58hRNd/uYBm3Sxgd60ZIKEs", hhk.getFingerPrint(jsch),
+        "fingerprint mismatch");
     assertEquals(expectedComment, hhk.getComment(), "comment mismatch");
     assertEquals("ICAgIHNzaC1kc2E=", hhk.getKey(), "key mismatch");
     assertEquals(expectedType, hhk.getType(), "type mismatch");
@@ -1022,9 +1020,8 @@ class KnownHostsTest {
     assertEquals("|1|AAECAwQFBgcICQoLDA0ODxAREhM=|/pE4peaossRYDRp6bEWa348eFLI=", hhk.getHost(),
         "host mismatch");
     assertEquals(expectedMarker, hhk.getMarker(), "marker mismatch");
-    assertEquals(
-        "1e:b5:70:92:65:6e:6a:f9:d6:7a:a9:43:00:40:a2:e7:c8:51:35:df:ee:60:19:b7:4b:18:1d:eb:46:48:28:4b",
-        hhk.getFingerPrint(jsch));
+    assertEquals("SHA256:HrVwkmVuavnWeqlDAECi58hRNd/uYBm3Sxgd60ZIKEs", hhk.getFingerPrint(jsch),
+        "fingerprint mismatch");
     assertEquals(expectedComment, hhk.getComment(), "comment mismatch");
     assertEquals("ICAgIHNzaC1kc2E=", hhk.getKey(), "key mismatch");
     assertEquals(expectedType, hhk.getType(), "type mismatch");
@@ -1054,9 +1051,8 @@ class KnownHostsTest {
     assertEquals(1, keys.length, "1 key expected");
     HostKey key = keys[0];
     assertEquals("some comment", key.getComment(), "comment mismatch");
-    assertEquals(
-        "9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f",
-        key.getFingerPrint(jsch), "fingerprint mismatch");
+    assertEquals("SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8", key.getFingerPrint(jsch),
+        "fingerprint mismatch");
     assertEquals(expectedHostResult, key.getHost(), "host mismatch");
     assertEquals(rsaKey, key.getKey(), "key mismatch");
     assertEquals(expectedMarker, key.getMarker(), "marker mismatch");


### PR DESCRIPTION
- Fix site generation warnings.
- #529 Update `Hostkey.getFingerprint()` method to output more moden format first introduced with OpenSSH 6.8.
- #622 Add stack trace to log message when an exception occurs during authentication.
- Update to latest Maven (3.9.9) release.
- Don't extract file modification time to prevent Maven recompilation.