### PR TITLE
Update Deflate.java

### DIFF
--- a/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
+++ b/src/main/java/com/jcraft/jsch/jzlib/Deflate.java
@@ -1309,7 +1309,9 @@ final class Deflate implements Cloneable {
           && window[++scan] == window[++match] && window[++scan] == window[++match]
           && scan < strend);
 
-      len = MAX_MATCH - strend - scan;
+      // len here is set to MAX_MATCH minus (strend minus scan, i.e. the distance between scan and
+      // strend) to ensure that best_len is set to the best possible length to lookahead
+      len = MAX_MATCH - (strend - scan);
       scan = strend - MAX_MATCH;
 
       if (len > best_len) {


### PR DESCRIPTION
Updates back to match the logic from jzlib's Deflate class to set len, minus jzlib's unnecessary cast to (int)

`len = MAX_MATCH - (int)(strend - scan);`

All tests are passing.  I did not add a test to the codebase, but with a 105mb XML file, compression level 6

before this update:
- time to deflate: 119.6 seconds
- deflated size: 70mb

after this update:
- time to deflate: 2.4 seconds
- deflated size: 6.2mb