### PR TITLE
0.2.23 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -865,7 +865,7 @@
                                 </goals>
                                 <configuration>
                                     <bundledSignatures combine.children="append">
-                                        <bundledSignature>commons-io-unsafe-2.14.0</bundledSignature>
+                                        <bundledSignature>commons-io-unsafe-2.17.0</bundledSignature>
                                     </bundledSignatures>
                                 </configuration>
                             </execution>

--- a/src/test/java/com/jcraft/jsch/SftpATTRSTest.java
+++ b/src/test/java/com/jcraft/jsch/SftpATTRSTest.java
@@ -2,13 +2,29 @@ package com.jcraft.jsch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Random;
+import java.util.TimeZone;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class SftpATTRSTest {
 
+  private static TimeZone timezone;
   private final Random random = new Random();
+
+  @BeforeAll
+  public static void beforeAll() {
+    timezone = TimeZone.getDefault();
+    TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    TimeZone.setDefault(timezone);
+  }
 
   @Test
   public void testToDateString0() {

--- a/src/test/resources/docker/Dockerfile.openssh99
+++ b/src/test/resources/docker/Dockerfile.openssh99
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.21
 RUN apk update && \
     apk upgrade && \
     apk add openssh && \


### PR DESCRIPTION
- Switch to Alpine 3.21 now that it is released.
- Fix unit tests when run in certain timezones.
-- I ran into problems running unit tests locally using Java 23+ when my local timezone wasn't UTC, so added this workaround to force UTC timezone in the failing tests.
- Update forbiddenapis to use latest commons-io signatures