### PR TITLE
SSH server comparison the channel id from INT_MAX for a signed value.

### DIFF
--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,9 +138,9 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
+      id = index++;
       // OpenSSH rejects channels with an id that exceeds INT_MAX
       index &= Integer.MAX_VALUE;
-      index++;
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,6 +138,7 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
+      /* Restrict sender channel ID to be within INT_MAX */
       if (index == Integer.MAX_VALUE) {
         index = 0;
       }    

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,7 +139,7 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index;
-      index = (index == Integer.MAX_VALUE) ? 0 : ++index; 
+      index = index == Integer.MAX_VALUE ? 0 : ++index; 
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -140,6 +140,7 @@ public abstract class Channel {
     synchronized (pool) {
       // OpenSSH rejects channels with an id that exceeds INT_MAX
       index &= Integer.MAX_VALUE;
+      index++;
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,7 +138,7 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
-      /* Restrict sender channel ID to be within INT_MAX */
+      /* Restrict sender channel ID to be within INT_MAX value */
       if (index == Integer.MAX_VALUE) {
         index = 0;
       }    

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -143,7 +143,7 @@ public abstract class Channel {
         index = 0;
       } else {
         ++index;
-      }  
+      }
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,11 +138,11 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
-      if (index == Integer.MAX_VALUE) {
+      if (index == 2147483647) {
         index = 0;
       }
       id = index++;
-      pool.addElement(this);      
+      pool.addElement(this);
     }
   }
 

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,13 +139,11 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index++;
-      
       // OpenSSH 8.0 introduced a bug that rejected channels with an ID that exceeds INT_MAX.
       // See https://github.com/openssh/openssh-portable/commit/7ec5cb4.
       // This bug was later resolved in OpenSSH 8.2.
       // See https://github.com/openssh/openssh-portable/commit/0ecd20b.
       // To allow compability, cap the ID value to not exceed INT_MAX.
-      
       index &= Integer.MAX_VALUE;
       pool.addElement(this);
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,10 +138,10 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
+      id = index++;
       if (index == Integer.MAX_VALUE) {
         index = 0;
       }
-      id = index++;
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,6 +138,9 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
+      if (index == Integer.MAX_VALUE) {
+        index = 0;
+      }    
       id = index++;
       pool.addElement(this);
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,7 +139,11 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index;
-      index = index == Integer.MAX_VALUE ? 0 : ++index; 
+      if (index == Integer.MAX_VALUE) {
+        index = 0;
+      } else {
+        ++index;
+      }  
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,7 +139,8 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index++;
-      // OpenSSH rejects channels with an id that exceeds INT_MAX
+      // OpenSSH versions 8.0 and 8.1 reject channels with an ID that exceeds INT_MAX.
+      // It had resolved it in OpenSSH versions after to 8.1(https://github.com/openssh/openssh-portable/commit/0ecd20bc9f0b9c7c697c9eb014613516c8f65834).
       index &= Integer.MAX_VALUE;
       pool.addElement(this);
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -32,7 +32,6 @@ import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.Vector;
-import java.util.I
   
 public abstract class Channel {
 

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -145,7 +145,7 @@ public abstract class Channel {
        * This bug was later resolved in OpenSSH 8.2.
        * See https://github.com/openssh/openssh-portable/commit/0ecd20bc9f0b9c7c697c9eb014613516c8f65834.
        * To ensure compatibility, clamp the ID value JSch uses to not exceed INT_MAX.
-      */
+       */
       index &= Integer.MAX_VALUE;
       pool.addElement(this);
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,10 +138,8 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
-      id = index++;
-      if (index == Integer.MAX_VALUE) {
-        index = 0;
-      }
+      id = index;
+      index = (index == Integer.MAX_VALUE) ? 0 : ++index; 
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,11 +139,7 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index;
-      if (index == Integer.MAX_VALUE) {
-        index = 0;
-      } else {
-        ++index;
-      }
+      index = index == Integer.MAX_VALUE ? 0 : ++index;
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,8 +139,13 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index++;
-      // OpenSSH versions prior to 8.2 reject channels with an ID that exceeds INT_MAX.
-      // It had resolved it in OpenSSH versions after to 8.1(openssh/openssh-portable@0ecd20b).
+      /*
+       * OpenSSH 8.0 introduced a bug that rejected channels with an ID that exceeds INT_MAX.
+       * See https://github.com/openssh/openssh-portable/commit/7ec5cb4d15ed2f2c5c9f5d00e6b361d136fc1e2d.
+       * This bug was later resolved in OpenSSH 8.2.
+       * See https://github.com/openssh/openssh-portable/commit/0ecd20bc9f0b9c7c697c9eb014613516c8f65834.
+       * To ensure compatibility, clamp the ID value JSch uses to not exceed INT_MAX.
+      */
       index &= Integer.MAX_VALUE;
       pool.addElement(this);
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,7 +138,7 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
-      /* Restrict sender channel ID to be within INT_MAX value */
+      
       if (index == Integer.MAX_VALUE) {
         index = 0;
       }    

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -138,8 +138,8 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
-      id = index;
-      index = index == Integer.MAX_VALUE ? 0 : ++index;
+      // OpenSSH rejects channels with an id that exceeds INT_MAX
+      index &= Integer.MAX_VALUE;
       pool.addElement(this);
     }
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,6 +139,7 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index++;
+      
       /*
        * OpenSSH 8.0 introduced a bug that rejected channels with an ID that exceeds INT_MAX.
        * See https://github.com/openssh/openssh-portable/commit/7ec5cb4d15ed2f2c5c9f5d00e6b361d136fc1e2d.
@@ -146,6 +147,7 @@ public abstract class Channel {
        * See https://github.com/openssh/openssh-portable/commit/0ecd20bc9f0b9c7c697c9eb014613516c8f65834.
        * To ensure compatibility, clamp the ID value JSch uses to not exceed INT_MAX.
        */
+      
       index &= Integer.MAX_VALUE;
       pool.addElement(this);
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -140,7 +140,7 @@ public abstract class Channel {
     synchronized (pool) {
       id = index++;
       // OpenSSH versions 8.0 and 8.1 reject channels with an ID that exceeds INT_MAX.
-      // It had resolved it in OpenSSH versions after to 8.1(https://github.com/openssh/openssh-portable/commit/0ecd20bc9f0b9c7c697c9eb014613516c8f65834).
+      // It had resolved it in OpenSSH versions after to 8.1(openssh/openssh-portable@0ecd20b).
       index &= Integer.MAX_VALUE;
       pool.addElement(this);
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -32,7 +32,7 @@ import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.Vector;
-  
+
 public abstract class Channel {
 
   static final int SSH_MSG_CHANNEL_OPEN_CONFIRMATION = 91;

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,7 +139,7 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index++;
-      //  OpenSSH versions prior to 8.2 reject channels with an ID that exceeds INT_MAX.
+      // OpenSSH versions prior to 8.2 reject channels with an ID that exceeds INT_MAX.
       // It had resolved it in OpenSSH versions after to 8.1(openssh/openssh-portable@0ecd20b).
       index &= Integer.MAX_VALUE;
       pool.addElement(this);

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -73,7 +73,7 @@ public abstract class Channel {
     if (type.equals("sftp")) {
       ChannelSftp sftp = new ChannelSftp();
       boolean useWriteFlushWorkaround =
-        session.getConfig("use_sftp_write_flush_workaround").equals("yes");
+          session.getConfig("use_sftp_write_flush_workaround").equals("yes");
       sftp.setUseWriteFlushWorkaround(useWriteFlushWorkaround);
       ret = sftp;
     }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -73,7 +73,7 @@ public abstract class Channel {
     if (type.equals("sftp")) {
       ChannelSftp sftp = new ChannelSftp();
       boolean useWriteFlushWorkaround =
-          session.getConfig("use_sftp_write_flush_workaround").equals("yes");
+              session.getConfig("use_sftp_write_flush_workaround").equals("yes");
       sftp.setUseWriteFlushWorkaround(useWriteFlushWorkaround);
       ret = sftp;
     }
@@ -138,12 +138,11 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
-      
       if (index == Integer.MAX_VALUE) {
         index = 0;
-      }    
+      }
       id = index++;
-      pool.addElement(this);
+      pool.addElement(this);      
     }
   }
 
@@ -227,7 +226,7 @@ public abstract class Channel {
     } catch (Exception e) {
     }
     PipedInputStream in = new MyPipedInputStream(32 * 1024, // this value should be customizable.
-        max_input_buffer_size);
+            max_input_buffer_size);
     boolean resizable = 32 * 1024 < max_input_buffer_size;
     io.setOutputStream(new PassiveOutputStream(in, resizable), false);
     return in;
@@ -237,7 +236,7 @@ public abstract class Channel {
     Session _session = this.session;
     if (_session != null && isConnected() && _session.getLogger().isEnabled(Logger.WARN)) {
       _session.getLogger().log(Logger.WARN,
-          "getExtInputStream() should be called before connect()");
+              "getExtInputStream() should be called before connect()");
     }
 
     int max_input_buffer_size = 32 * 1024;
@@ -246,7 +245,7 @@ public abstract class Channel {
     } catch (Exception e) {
     }
     PipedInputStream in = new MyPipedInputStream(32 * 1024, // this value should be customizable.
-        max_input_buffer_size);
+            max_input_buffer_size);
     boolean resizable = 32 * 1024 < max_input_buffer_size;
     io.setExtOutputStream(new PassiveOutputStream(in, resizable), false);
     return in;
@@ -450,7 +449,7 @@ public abstract class Channel {
           } else {
             System.arraycopy(buffer, 0, tmp, 0, in);
             System.arraycopy(buffer, out, tmp, tmp.length - (buffer.length - out),
-                (buffer.length - out));
+                    (buffer.length - out));
             out = tmp.length - (buffer.length - out);
           }
         } else if (in == out) {

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -32,7 +32,8 @@ import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.Vector;
-
+import java.util.I
+  
 public abstract class Channel {
 
   static final int SSH_MSG_CHANNEL_OPEN_CONFIRMATION = 91;
@@ -73,7 +74,7 @@ public abstract class Channel {
     if (type.equals("sftp")) {
       ChannelSftp sftp = new ChannelSftp();
       boolean useWriteFlushWorkaround =
-              session.getConfig("use_sftp_write_flush_workaround").equals("yes");
+        session.getConfig("use_sftp_write_flush_workaround").equals("yes");
       sftp.setUseWriteFlushWorkaround(useWriteFlushWorkaround);
       ret = sftp;
     }
@@ -138,7 +139,7 @@ public abstract class Channel {
 
   Channel() {
     synchronized (pool) {
-      if (index == 2147483647) {
+      if (index == Integer.MAX_VALUE) {
         index = 0;
       }
       id = index++;
@@ -226,7 +227,7 @@ public abstract class Channel {
     } catch (Exception e) {
     }
     PipedInputStream in = new MyPipedInputStream(32 * 1024, // this value should be customizable.
-            max_input_buffer_size);
+        max_input_buffer_size);
     boolean resizable = 32 * 1024 < max_input_buffer_size;
     io.setOutputStream(new PassiveOutputStream(in, resizable), false);
     return in;
@@ -236,7 +237,7 @@ public abstract class Channel {
     Session _session = this.session;
     if (_session != null && isConnected() && _session.getLogger().isEnabled(Logger.WARN)) {
       _session.getLogger().log(Logger.WARN,
-              "getExtInputStream() should be called before connect()");
+          "getExtInputStream() should be called before connect()");
     }
 
     int max_input_buffer_size = 32 * 1024;
@@ -245,7 +246,7 @@ public abstract class Channel {
     } catch (Exception e) {
     }
     PipedInputStream in = new MyPipedInputStream(32 * 1024, // this value should be customizable.
-            max_input_buffer_size);
+        max_input_buffer_size);
     boolean resizable = 32 * 1024 < max_input_buffer_size;
     io.setExtOutputStream(new PassiveOutputStream(in, resizable), false);
     return in;
@@ -449,7 +450,7 @@ public abstract class Channel {
           } else {
             System.arraycopy(buffer, 0, tmp, 0, in);
             System.arraycopy(buffer, out, tmp, tmp.length - (buffer.length - out),
-                    (buffer.length - out));
+                (buffer.length - out));
             out = tmp.length - (buffer.length - out);
           }
         } else if (in == out) {

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -139,7 +139,7 @@ public abstract class Channel {
   Channel() {
     synchronized (pool) {
       id = index++;
-      // OpenSSH versions 8.0 and 8.1 reject channels with an ID that exceeds INT_MAX.
+      //  OpenSSH versions prior to 8.2 reject channels with an ID that exceeds INT_MAX.
       // It had resolved it in OpenSSH versions after to 8.1(openssh/openssh-portable@0ecd20b).
       index &= Integer.MAX_VALUE;
       pool.addElement(this);

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -140,13 +140,11 @@ public abstract class Channel {
     synchronized (pool) {
       id = index++;
       
-      /*
-       * OpenSSH 8.0 introduced a bug that rejected channels with an ID that exceeds INT_MAX.
-       * See https://github.com/openssh/openssh-portable/commit/7ec5cb4d15ed2f2c5c9f5d00e6b361d136fc1e2d.
-       * This bug was later resolved in OpenSSH 8.2.
-       * See https://github.com/openssh/openssh-portable/commit/0ecd20bc9f0b9c7c697c9eb014613516c8f65834.
-       * To ensure compatibility, clamp the ID value JSch uses to not exceed INT_MAX.
-       */
+      // OpenSSH 8.0 introduced a bug that rejected channels with an ID that exceeds INT_MAX.
+      // See https://github.com/openssh/openssh-portable/commit/7ec5cb4.
+      // This bug was later resolved in OpenSSH 8.2.
+      // See https://github.com/openssh/openssh-portable/commit/0ecd20b.
+      // To allow compability, cap the ID value to not exceed INT_MAX.
       
       index &= Integer.MAX_VALUE;
       pool.addElement(this);


### PR DESCRIPTION
The problem is related to the checking of what is called a sender channel ID (which is set to a unsigned INT random number by the originator of the connection). However, in the versions mentioned above the daemon is making a comparison using INT_MAX for a signed value. This means that valid channel numbers are being rejected and the connection is not established.