### PR TITLE
Support custom ThreadFactory.

### DIFF
--- a/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
@@ -63,7 +63,7 @@ public class ChannelDirectTCPIP extends Channel {
       }
 
       if (io.in != null) {
-        thread = new Thread(this::run);
+        thread = session.jsch.getThreadFactory().newThread(this::run);
         thread.setName("DirectTCPIP thread " + _session.getHost());
         if (_session.daemon_thread) {
           thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
@@ -63,7 +63,7 @@ public class ChannelDirectTCPIP extends Channel {
       }
 
       if (io.in != null) {
-        thread = _session.jsch.getThreadFactory().newThread(this::run);
+        thread = _session.getThreadFactory().newThread(this::run);
         thread.setName("DirectTCPIP thread " + _session.getHost());
         if (_session.daemon_thread) {
           thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelDirectTCPIP.java
@@ -63,7 +63,7 @@ public class ChannelDirectTCPIP extends Channel {
       }
 
       if (io.in != null) {
-        thread = session.jsch.getThreadFactory().newThread(this::run);
+        thread = _session.jsch.getThreadFactory().newThread(this::run);
         thread.setName("DirectTCPIP thread " + _session.getHost());
         if (_session.daemon_thread) {
           thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelExec.java
+++ b/src/main/java/com/jcraft/jsch/ChannelExec.java
@@ -48,7 +48,7 @@ public class ChannelExec extends ChannelSession {
     }
 
     if (io.in != null) {
-      thread = session.jsch.getThreadFactory().newThread(this::run);
+      thread = _session.jsch.getThreadFactory().newThread(this::run);
       thread.setName("Exec thread " + _session.getHost());
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelExec.java
+++ b/src/main/java/com/jcraft/jsch/ChannelExec.java
@@ -48,7 +48,7 @@ public class ChannelExec extends ChannelSession {
     }
 
     if (io.in != null) {
-      thread = _session.jsch.getThreadFactory().newThread(this::run);
+      thread = _session.getThreadFactory().newThread(this::run);
       thread.setName("Exec thread " + _session.getHost());
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelExec.java
+++ b/src/main/java/com/jcraft/jsch/ChannelExec.java
@@ -48,7 +48,7 @@ public class ChannelExec extends ChannelSession {
     }
 
     if (io.in != null) {
-      thread = new Thread(this::run);
+      thread = session.jsch.getThreadFactory().newThread(this::run);
       thread.setName("Exec thread " + _session.getHost());
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
@@ -67,7 +67,7 @@ public class ChannelForwardedTCPIP extends Channel {
 
         daemon.setChannel(this, getInputStream(), out);
         daemon.setArg(_config.arg);
-        new Thread(daemon).start();
+        session.jsch.getThreadFactory().newThread(daemon).start();
       } else {
         ConfigLHost _config = (ConfigLHost) config;
         socket =

--- a/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
@@ -67,7 +67,7 @@ public class ChannelForwardedTCPIP extends Channel {
 
         daemon.setChannel(this, getInputStream(), out);
         daemon.setArg(_config.arg);
-        session.jsch.getThreadFactory().newThread(daemon).start();
+        getSession().jsch.getThreadFactory().newThread(daemon).start();
       } else {
         ConfigLHost _config = (ConfigLHost) config;
         socket =

--- a/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
+++ b/src/main/java/com/jcraft/jsch/ChannelForwardedTCPIP.java
@@ -67,7 +67,7 @@ public class ChannelForwardedTCPIP extends Channel {
 
         daemon.setChannel(this, getInputStream(), out);
         daemon.setArg(_config.arg);
-        getSession().jsch.getThreadFactory().newThread(daemon).start();
+        getSession().getThreadFactory().newThread(daemon).start();
       } else {
         ConfigLHost _config = (ConfigLHost) config;
         socket =

--- a/src/main/java/com/jcraft/jsch/ChannelShell.java
+++ b/src/main/java/com/jcraft/jsch/ChannelShell.java
@@ -48,7 +48,7 @@ public class ChannelShell extends ChannelSession {
     }
 
     if (io.in != null) {
-      thread = new Thread(this::run);
+      thread = session.jsch.getThreadFactory().newThread(this::run);
       thread.setName("Shell for " + _session.host);
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelShell.java
+++ b/src/main/java/com/jcraft/jsch/ChannelShell.java
@@ -48,7 +48,7 @@ public class ChannelShell extends ChannelSession {
     }
 
     if (io.in != null) {
-      thread = _session.jsch.getThreadFactory().newThread(this::run);
+      thread = _session.getThreadFactory().newThread(this::run);
       thread.setName("Shell for " + _session.host);
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelShell.java
+++ b/src/main/java/com/jcraft/jsch/ChannelShell.java
@@ -48,7 +48,7 @@ public class ChannelShell extends ChannelSession {
     }
 
     if (io.in != null) {
-      thread = session.jsch.getThreadFactory().newThread(this::run);
+      thread = _session.jsch.getThreadFactory().newThread(this::run);
       thread.setName("Shell for " + _session.host);
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
@@ -64,7 +64,7 @@ public class ChannelSubsystem extends ChannelSession {
       throw new JSchException("ChannelSubsystem", e);
     }
     if (io.in != null) {
-      thread = session.jsch.getThreadFactory().newThread(this::run);
+      thread = _session.jsch.getThreadFactory().newThread(this::run);
       thread.setName("Subsystem for " + _session.host);
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
@@ -64,7 +64,7 @@ public class ChannelSubsystem extends ChannelSession {
       throw new JSchException("ChannelSubsystem", e);
     }
     if (io.in != null) {
-      thread = new Thread(this::run);
+      thread = session.jsch.getThreadFactory().newThread(this::run);
       thread.setName("Subsystem for " + _session.host);
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSubsystem.java
@@ -64,7 +64,7 @@ public class ChannelSubsystem extends ChannelSession {
       throw new JSchException("ChannelSubsystem", e);
     }
     if (io.in != null) {
-      thread = _session.jsch.getThreadFactory().newThread(this::run);
+      thread = _session.getThreadFactory().newThread(this::run);
       thread.setName("Subsystem for " + _session.host);
       if (_session.daemon_thread) {
         thread.setDaemon(_session.daemon_thread);

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -33,8 +33,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Vector;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 public class JSch {
   /** The version number. */

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Vector;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 public class JSch {
   /** The version number. */
@@ -270,6 +272,8 @@ public class JSch {
   private IdentityRepository identityRepository = defaultIdentityRepository;
 
   private ConfigRepository configRepository = null;
+
+  private ThreadFactory threadFactory = null;
 
   /**
    * Sets the <code>identityRepository</code>, which will be referred in the public key
@@ -689,6 +693,28 @@ public class JSch {
    */
   public void setInstanceLogger(Logger logger) {
     instLogger.setLogger(logger);
+  }
+
+  /**
+   * Sets the thread factory to be used for this instance.
+   *
+   * @param threadFactory The thread factory to be used, or <code>null</code> to reset to the
+   *        default thread factory.
+   */
+  public void setThreadFactory(ThreadFactory threadFactory) {
+    this.threadFactory = threadFactory;
+  }
+
+  /**
+   * Returns the thread factory used by this instance.
+   *
+   * @return The thread factory associated with this instance. If no specific thread factory has
+   *         been set, a default thread factory is created and returned.
+   */
+  public ThreadFactory getThreadFactory() {
+    if (threadFactory == null)
+      threadFactory = Executors.defaultThreadFactory();
+    return threadFactory;
   }
 
   /**

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -273,8 +273,6 @@ public class JSch {
 
   private ConfigRepository configRepository = null;
 
-  private ThreadFactory threadFactory = null;
-
   /**
    * Sets the <code>identityRepository</code>, which will be referred in the public key
    * authentication.
@@ -693,28 +691,6 @@ public class JSch {
    */
   public void setInstanceLogger(Logger logger) {
     instLogger.setLogger(logger);
-  }
-
-  /**
-   * Sets the thread factory to be used for this instance.
-   *
-   * @param threadFactory The thread factory to be used, or <code>null</code> to reset to the
-   *        default thread factory.
-   */
-  public void setThreadFactory(ThreadFactory threadFactory) {
-    this.threadFactory = threadFactory;
-  }
-
-  /**
-   * Returns the thread factory used by this instance.
-   *
-   * @return The thread factory associated with this instance. If no specific thread factory has
-   *         been set, a default thread factory is created and returned.
-   */
-  public ThreadFactory getThreadFactory() {
-    if (threadFactory == null)
-      threadFactory = Executors.defaultThreadFactory();
-    return threadFactory;
   }
 
   /**

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -38,10 +38,10 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Vector;
 import java.util.concurrent.ThreadFactory;
-import java.util.Objects;
 import javax.crypto.AEADBadTagException;
 
 public class Session {

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -528,7 +528,7 @@ public class Session {
 
       synchronized (lock) {
         if (isConnected) {
-          connectThread = new Thread(this::run);
+          connectThread = jsch.getThreadFactory().newThread(this::run);
           connectThread.setName("Connect thread " + host + " session");
           if (daemon_thread) {
             connectThread.setDaemon(daemon_thread);
@@ -2005,7 +2005,7 @@ public class Session {
               channel.getData(buf);
               channel.init();
 
-              Thread tmp = new Thread(channel::run);
+              Thread tmp = jsch.getThreadFactory().newThread(channel::run);
               tmp.setName("Channel " + ctyp + " " + host);
               if (daemon_thread) {
                 tmp.setDaemon(daemon_thread);
@@ -2230,7 +2230,7 @@ public class Session {
       ServerSocketFactory ssf, int connectTimeout) throws JSchException {
     PortWatcher pw = PortWatcher.addPort(this, bind_address, lport, host, rport, ssf);
     pw.setConnectTimeout(connectTimeout);
-    Thread tmp = new Thread(pw::run);
+    Thread tmp = jsch.getThreadFactory().newThread(pw::run);
     tmp.setName("PortWatcher Thread for " + host);
     if (daemon_thread) {
       tmp.setDaemon(daemon_thread);
@@ -2243,7 +2243,7 @@ public class Session {
       ServerSocketFactory ssf, int connectTimeout) throws JSchException {
     PortWatcher pw = PortWatcher.addSocket(this, bindAddress, lport, socketPath, ssf);
     pw.setConnectTimeout(connectTimeout);
-    Thread tmp = new Thread(pw::run);
+    Thread tmp = jsch.getThreadFactory().newThread(pw::run);
     tmp.setName("PortWatcher Thread for " + host);
     if (daemon_thread) {
       tmp.setDaemon(daemon_thread);

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -2175,7 +2175,7 @@ public class Session {
    * Returns the thread factory used by this instance.
    *
    * @return The thread factory associated with this instance. If no specific thread factory has
-   *         been set, a default thread factory is created and returned.
+   *         been set, a default thread factory is returned.
    */
   public ThreadFactory getThreadFactory() {
     return threadFactory;


### PR DESCRIPTION
This PR adds support for a custom `ThreadFactory` in JSch. Users can now provide their own `ThreadFactory`, which is particularly useful in Java 21, as it allows leveraging virtual threads for better concurrency and resource management.