### PR TITLE
0.2.25 changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         distribution: 'zulu'
-        java-version: '21'
+        java-version: '24'
         check-latest: true
         cache: 'maven'
         

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         distribution: 'zulu'
-        java-version: '21'
+        java-version: '24'
         check-latest: true
         cache: 'maven'
     - uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1.8.0

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: '24'
           check-latest: true
       - name: Build Javadoc
         run: ./mvnw -B -V -e javadoc:javadoc

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         distribution: 'zulu'
-        java-version: '21'
+        java-version: '24'
         check-latest: true
     - name: Build with Maven
       run: ./mvnw -B -V -e verify -DskipTests=true -DskipITs=true
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17', '21', '23']
+        java: ['8', '11', '17', '21', '24']
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21.0.4-tem
+java=24-tem
 maven=3.9.9

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>17</version>
+                                    <version>24</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence />
                                 <banDuplicatePomDependencyVersions />
@@ -402,6 +402,19 @@
                             <release>16</release>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>default-compile-24</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java24</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                            <release>24</release>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -529,7 +542,7 @@
                     <doclint>none</doclint>
                     <subpackages>com.jcraft.jsch</subpackages>
                     <excludePackageNames>com.jcraft.jsch.*</excludePackageNames>
-                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java10:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16</sourcepath>
+                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java10:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16:${project.basedir}/src/main/java24</sourcepath>
                 </configuration>
                 <executions>
                     <execution>
@@ -608,6 +621,7 @@
                         <sourceDirectory>${project.basedir}/src/main/java11</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java15</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java16</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java24</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java-templates</sourceDirectory>
                     </sourceDirectories>
                 </configuration>
@@ -628,6 +642,7 @@
                         <directory>${project.basedir}/src/main/java11</directory>
                         <directory>${project.basedir}/src/main/java15</directory>
                         <directory>${project.basedir}/src/main/java16</directory>
+                        <directory>${project.basedir}/src/main/java24</directory>
                         <directory>${project.basedir}/src/main/java-templates</directory>
                     </directories>
                 </configuration>
@@ -642,6 +657,8 @@
                         <exclude>com/jcraft/jsch/JplLogger.class</exclude>
                         <exclude>com/jcraft/jsch/UnixDomainSocketFactory.class</exclude>
                         <exclude>com/jcraft/jsch/jce/KeyPairGenEdDSA.class</exclude>
+                        <exclude>com/jcraft/jsch/jce/MLKEM1024.class</exclude>
+                        <exclude>com/jcraft/jsch/jce/MLKEM768.class</exclude>
                         <exclude>com/jcraft/jsch/jce/SignatureEd25519.class</exclude>
                         <exclude>com/jcraft/jsch/jce/SignatureEd448.class</exclude>
                         <exclude>com/jcraft/jsch/jce/XDH.class</exclude>
@@ -836,7 +853,7 @@
         <profile>
             <id>forbiddenapis</id>
             <activation>
-                <jdk>[16,)</jdk>
+                <jdk>[24,)</jdk>
             </activation>
             <build>
                 <plugins>
@@ -844,7 +861,7 @@
                         <groupId>de.thetaphi</groupId>
                         <artifactId>forbiddenapis</artifactId>
                         <configuration>
-                            <releaseVersion>16</releaseVersion>
+                            <releaseVersion>24</releaseVersion>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -882,7 +882,7 @@
                                 </goals>
                                 <configuration>
                                     <bundledSignatures combine.children="append">
-                                        <bundledSignature>commons-io-unsafe-2.17.0</bundledSignature>
+                                        <bundledSignature>commons-io-unsafe-2.18.0</bundledSignature>
                                     </bundledSignatures>
                                 </configuration>
                             </execution>

--- a/src/main/java/com/jcraft/jsch/DHECN.java
+++ b/src/main/java/com/jcraft/jsch/DHECN.java
@@ -133,7 +133,7 @@ abstract class DHECN extends KeyExchange {
           return false;
         }
 
-        K = encodeAsMPInt(normalize(ecdh.getSecret(r_s[0], r_s[1])));
+        K = encodeAsMPInt(normalize(ecdh.getSecret(r_s[0], r_s[1])), true);
 
         byte[] sig_of_H = _buf.getString();
 
@@ -150,18 +150,21 @@ abstract class DHECN extends KeyExchange {
 
         // This value is called the exchange hash, and it is used to authenti-
         // cate the key exchange.
-        buf.reset();
-        buf.putString(V_C);
-        buf.putString(V_S);
-        buf.putString(I_C);
-        buf.putString(I_S);
-        buf.putString(K_S);
-        buf.putString(Q_C);
-        buf.putString(Q_S);
-        byte[] foo = new byte[buf.getLength()];
-        buf.getByte(foo);
-
+        byte[] foo = encodeAsString(V_C, false);
         sha.update(foo, 0, foo.length);
+        foo = encodeAsString(V_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(K_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(Q_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(Q_S, false);
+        sha.update(foo, 0, foo.length);
+
         sha.update(K, 0, K.length);
         H = sha.digest();
 

--- a/src/main/java/com/jcraft/jsch/DHECNKEM.java
+++ b/src/main/java/com/jcraft/jsch/DHECNKEM.java
@@ -169,7 +169,7 @@ abstract class DHECNKEM extends KeyExchange {
         } finally {
           Util.bzero(tmp);
         }
-        K = encodeAsString(sha.digest());
+        K = encodeAsString(sha.digest(), true);
 
         byte[] sig_of_H = _buf.getString();
 
@@ -196,18 +196,21 @@ abstract class DHECNKEM extends KeyExchange {
         // string using the process described in Section 5 of [RFC4251] and is
         // then fed along with other data in H to the key exchange method's HASH
         // function to generate encryption keys.
-        buf.reset();
-        buf.putString(V_C);
-        buf.putString(V_S);
-        buf.putString(I_C);
-        buf.putString(I_S);
-        buf.putString(K_S);
-        buf.putString(C_INIT);
-        buf.putString(S_REPLY);
-        byte[] foo = new byte[buf.getLength()];
-        buf.getByte(foo);
-
+        byte[] foo = encodeAsString(V_C, false);
         sha.update(foo, 0, foo.length);
+        foo = encodeAsString(V_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(K_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(C_INIT, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(S_REPLY, false);
+        sha.update(foo, 0, foo.length);
+
         sha.update(K, 0, K.length);
         H = sha.digest();
 

--- a/src/main/java/com/jcraft/jsch/DHECNKEM.java
+++ b/src/main/java/com/jcraft/jsch/DHECNKEM.java
@@ -164,7 +164,7 @@ abstract class DHECNKEM extends KeyExchange {
           Util.bzero(tmp);
         }
         try {
-          tmp = normalize(ecdh.getSecret(r_s[0], r_s[1]));
+          tmp = ecdh.getSecret(r_s[0], r_s[1]);
           sha.update(tmp, 0, tmp.length);
         } finally {
           Util.bzero(tmp);

--- a/src/main/java/com/jcraft/jsch/DHGEX.java
+++ b/src/main/java/com/jcraft/jsch/DHGEX.java
@@ -181,7 +181,7 @@ abstract class DHGEX extends KeyExchange {
 
         dh.checkRange();
 
-        K = encodeAsMPInt(normalize(dh.getK()));
+        K = encodeAsMPInt(normalize(dh.getK()), true);
 
         // The hash H is computed as the HASH hash of the concatenation of the
         // following:
@@ -200,26 +200,32 @@ abstract class DHGEX extends KeyExchange {
         // mpint K, the shared secret
         // This value is called the exchange hash, and it is used to authenti-
         // cate the key exchange.
-
-        buf.reset();
-        buf.putString(V_C);
-        buf.putString(V_S);
-        buf.putString(I_C);
-        buf.putString(I_S);
-        buf.putString(K_S);
-        buf.putInt(min);
-        buf.putInt(preferred);
-        buf.putInt(max);
-        buf.putMPInt(p);
-        buf.putMPInt(g);
-        buf.putMPInt(e);
-        buf.putMPInt(f);
-
-        byte[] foo = new byte[buf.getLength()];
-        buf.getByte(foo);
+        byte[] foo = encodeAsString(V_C, false);
         sha.update(foo, 0, foo.length);
-        sha.update(K, 0, K.length);
+        foo = encodeAsString(V_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(K_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeInt(min);
+        sha.update(foo, 0, foo.length);
+        foo = encodeInt(preferred);
+        sha.update(foo, 0, foo.length);
+        foo = encodeInt(max);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsMPInt(p, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsMPInt(g, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsMPInt(e, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsMPInt(f, false);
+        sha.update(foo, 0, foo.length);
 
+        sha.update(K, 0, K.length);
         H = sha.digest();
 
         // System.err.print("H -> "); dump(H, 0, H.length);

--- a/src/main/java/com/jcraft/jsch/DHGN.java
+++ b/src/main/java/com/jcraft/jsch/DHGN.java
@@ -134,7 +134,7 @@ abstract class DHGN extends KeyExchange {
 
         dh.checkRange();
 
-        K = encodeAsMPInt(normalize(dh.getK()));
+        K = encodeAsMPInt(normalize(dh.getK()), true);
 
         // The hash H is computed as the HASH hash of the concatenation of the
         // following:
@@ -148,18 +148,21 @@ abstract class DHGN extends KeyExchange {
         // mpint K, the shared secret
         // This value is called the exchange hash, and it is used to authenti-
         // cate the key exchange.
-        buf.reset();
-        buf.putString(V_C);
-        buf.putString(V_S);
-        buf.putString(I_C);
-        buf.putString(I_S);
-        buf.putString(K_S);
-        buf.putMPInt(e);
-        buf.putMPInt(f);
-        byte[] foo = new byte[buf.getLength()];
-        buf.getByte(foo);
-
+        byte[] foo = encodeAsString(V_C, false);
         sha.update(foo, 0, foo.length);
+        foo = encodeAsString(V_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(K_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsMPInt(e, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsMPInt(f, false);
+        sha.update(foo, 0, foo.length);
+
         sha.update(K, 0, K.length);
         H = sha.digest();
         // System.err.print("H -> "); //dump(H, 0, H.length);

--- a/src/main/java/com/jcraft/jsch/DHXEC.java
+++ b/src/main/java/com/jcraft/jsch/DHXEC.java
@@ -131,7 +131,7 @@ abstract class DHXEC extends KeyExchange {
           return false;
         }
 
-        K = encodeAsMPInt(normalize(xdh.getSecret(Q_S)));
+        K = encodeAsMPInt(normalize(xdh.getSecret(Q_S)), true);
 
         byte[] sig_of_H = _buf.getString();
 
@@ -162,18 +162,21 @@ abstract class DHXEC extends KeyExchange {
         // of [RFC4251], and the resulting bytes are fed as described in
         // [RFC4253] to the key exchange method's hash function to generate
         // encryption keys.
-        buf.reset();
-        buf.putString(V_C);
-        buf.putString(V_S);
-        buf.putString(I_C);
-        buf.putString(I_S);
-        buf.putString(K_S);
-        buf.putString(Q_C);
-        buf.putString(Q_S);
-        byte[] foo = new byte[buf.getLength()];
-        buf.getByte(foo);
-
+        byte[] foo = encodeAsString(V_C, false);
         sha.update(foo, 0, foo.length);
+        foo = encodeAsString(V_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(K_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(Q_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(Q_S, false);
+        sha.update(foo, 0, foo.length);
+
         sha.update(K, 0, K.length);
         H = sha.digest();
 

--- a/src/main/java/com/jcraft/jsch/DHXECKEM.java
+++ b/src/main/java/com/jcraft/jsch/DHXECKEM.java
@@ -161,7 +161,7 @@ abstract class DHXECKEM extends KeyExchange {
           Util.bzero(tmp);
         }
         try {
-          tmp = normalize(xdh.getSecret(xec_public_key_S));
+          tmp = xdh.getSecret(xec_public_key_S);
           sha.update(tmp, 0, tmp.length);
         } finally {
           Util.bzero(tmp);

--- a/src/main/java/com/jcraft/jsch/DHXECKEM.java
+++ b/src/main/java/com/jcraft/jsch/DHXECKEM.java
@@ -166,7 +166,7 @@ abstract class DHXECKEM extends KeyExchange {
         } finally {
           Util.bzero(tmp);
         }
-        K = encodeAsString(sha.digest());
+        K = encodeAsString(sha.digest(), true);
 
         byte[] sig_of_H = _buf.getString();
 
@@ -192,18 +192,21 @@ abstract class DHXECKEM extends KeyExchange {
         // output from the key encapsulation mechanism of sntrup761 concatenated
         // with the 32-byte octet string of X25519(a, X25519(b, 9)) = X25519(b,
         // X25519(a, 9)).
-        buf.reset();
-        buf.putString(V_C);
-        buf.putString(V_S);
-        buf.putString(I_C);
-        buf.putString(I_S);
-        buf.putString(K_S);
-        buf.putString(Q_C);
-        buf.putString(Q_S);
-        byte[] foo = new byte[buf.getLength()];
-        buf.getByte(foo);
-
+        byte[] foo = encodeAsString(V_C, false);
         sha.update(foo, 0, foo.length);
+        foo = encodeAsString(V_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(I_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(K_S, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(Q_C, false);
+        sha.update(foo, 0, foo.length);
+        foo = encodeAsString(Q_S, false);
+        sha.update(foo, 0, foo.length);
+
         sha.update(K, 0, K.length);
         H = sha.digest();
 

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -42,7 +42,7 @@ public class JSch {
 
   static {
     config.put("kex", Util.getSystemProperty("jsch.kex",
-        "curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256"));
+        "mlkem768x25519-sha256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256"));
     config.put("server_host_key", Util.getSystemProperty("jsch.server_host_key",
         "ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256"));
     config.put("prefer_known_host_key_types",
@@ -111,8 +111,13 @@ public class JSch {
     config.put("sntrup761x25519-sha512", "com.jcraft.jsch.DH25519SNTRUP761");
     config.put("sntrup761x25519-sha512@openssh.com", "com.jcraft.jsch.DH25519SNTRUP761");
 
-    config.put("mlkem768", "com.jcraft.jsch.bc.MLKEM768");
-    config.put("mlkem1024", "com.jcraft.jsch.bc.MLKEM1024");
+    if (JavaVersion.getVersion() >= 24) {
+      config.put("mlkem768", "com.jcraft.jsch.jce.MLKEM768");
+      config.put("mlkem1024", "com.jcraft.jsch.jce.MLKEM1024");
+    } else {
+      config.put("mlkem768", "com.jcraft.jsch.bc.MLKEM768");
+      config.put("mlkem1024", "com.jcraft.jsch.bc.MLKEM1024");
+    }
     config.put("sntrup761", "com.jcraft.jsch.bc.SNTRUP761");
 
     config.put("dh", "com.jcraft.jsch.jce.DH");

--- a/src/main/java/com/jcraft/jsch/KeyExchange.java
+++ b/src/main/java/com/jcraft/jsch/KeyExchange.java
@@ -473,7 +473,20 @@ public abstract class KeyExchange {
     return result;
   }
 
+  protected byte[] encodeInt(int raw) {
+    byte[] foo = new byte[4];
+    foo[0] = (byte) (raw >>> 24);
+    foo[1] = (byte) (raw >>> 16);
+    foo[2] = (byte) (raw >>> 8);
+    foo[3] = (byte) (raw);
+    return foo;
+  }
+
   protected byte[] encodeAsMPInt(byte[] raw) {
+    return encodeAsMPInt(raw, true);
+  }
+
+  protected byte[] encodeAsMPInt(byte[] raw, boolean bzero) {
     int i = (raw[0] & 0x80) >>> 7;
     int len = raw.length + i;
     byte[] foo = new byte[len + 4];
@@ -484,11 +497,17 @@ public abstract class KeyExchange {
     foo[2] = (byte) (len >>> 8);
     foo[3] = (byte) (len);
     System.arraycopy(raw, 0, foo, 4 + i, len - i);
-    Util.bzero(raw);
+    if (bzero) {
+      Util.bzero(raw);
+    }
     return foo;
   }
 
   protected byte[] encodeAsString(byte[] raw) {
+    return encodeAsString(raw, true);
+  }
+
+  protected byte[] encodeAsString(byte[] raw, boolean bzero) {
     int len = raw.length;
     byte[] foo = new byte[len + 4];
     foo[0] = (byte) (len >>> 24);
@@ -496,7 +515,9 @@ public abstract class KeyExchange {
     foo[2] = (byte) (len >>> 8);
     foo[3] = (byte) (len);
     System.arraycopy(raw, 0, foo, 4, len);
-    Util.bzero(raw);
+    if (bzero) {
+      Util.bzero(raw);
+    }
     return foo;
   }
 }

--- a/src/main/java/com/jcraft/jsch/jce/MLKEM1024.java
+++ b/src/main/java/com/jcraft/jsch/jce/MLKEM1024.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+import com.jcraft.jsch.KEM;
+
+public class MLKEM1024 implements KEM {
+
+  public MLKEM1024() {
+    throw new UnsupportedOperationException("MLKEM1024 requires Java24+.");
+  }
+
+  @Override
+  public void init() throws Exception {
+    throw new UnsupportedOperationException("MLKEM1024 requires Java24+.");
+  }
+
+  @Override
+  public byte[] getPublicKey() throws Exception {
+    throw new UnsupportedOperationException("MLKEM1024 requires Java24+.");
+  }
+
+  @Override
+  public byte[] decapsulate(byte[] encapsulation) throws Exception {
+    throw new UnsupportedOperationException("MLKEM1024 requires Java24+.");
+  }
+}

--- a/src/main/java/com/jcraft/jsch/jce/MLKEM768.java
+++ b/src/main/java/com/jcraft/jsch/jce/MLKEM768.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+import com.jcraft.jsch.KEM;
+
+public class MLKEM768 implements KEM {
+
+  public MLKEM768() {
+    throw new UnsupportedOperationException("MLKEM768 requires Java24+.");
+  }
+
+  @Override
+  public void init() throws Exception {
+    throw new UnsupportedOperationException("MLKEM768 requires Java24+.");
+  }
+
+  @Override
+  public byte[] getPublicKey() throws Exception {
+    throw new UnsupportedOperationException("MLKEM768 requires Java24+.");
+  }
+
+  @Override
+  public byte[] decapsulate(byte[] encapsulation) throws Exception {
+    throw new UnsupportedOperationException("MLKEM768 requires Java24+.");
+  }
+}

--- a/src/main/java24/com/jcraft/jsch/jce/MLKEM.java
+++ b/src/main/java24/com/jcraft/jsch/jce/MLKEM.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.NamedParameterSpec;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import javax.crypto.KEM;
+
+abstract class MLKEM implements com.jcraft.jsch.KEM {
+  protected NamedParameterSpec params;
+  protected byte[] algorithmIdentifier;
+  protected int publicKeyLen;
+  KEM.Decapsulator decapsulator;
+  byte[] publicKey;
+
+  @Override
+  public void init() throws Exception {
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM");
+    kpg.initialize(params);
+    KeyPair kp = kpg.generateKeyPair();
+    KEM kem = KEM.getInstance("ML-KEM");
+    decapsulator = kem.newDecapsulator(kp.getPrivate());
+    publicKey = com.jcraft.jsch.KeyPair.extractX509SubjectPublicKeyInfo(kp.getPublic().getEncoded(),
+        algorithmIdentifier, publicKeyLen);
+  }
+
+  @Override
+  public byte[] getPublicKey() throws Exception {
+    return publicKey;
+  }
+
+  @Override
+  public byte[] decapsulate(byte[] encapsulation) throws Exception {
+    return decapsulator.decapsulate(encapsulation).getEncoded();
+  }
+}

--- a/src/main/java24/com/jcraft/jsch/jce/MLKEM1024.java
+++ b/src/main/java24/com/jcraft/jsch/jce/MLKEM1024.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+import java.security.spec.NamedParameterSpec;
+
+public class MLKEM1024 extends MLKEM {
+  private static final byte[] pkMlKem1024 = {(byte) 0x60, (byte) 0x86, (byte) 0x48, (byte) 0x01,
+      (byte) 0x65, (byte) 0x03, (byte) 0x04, (byte) 0x04, (byte) 0x03};
+
+  public MLKEM1024() {
+    params = NamedParameterSpec.ML_KEM_1024;
+    algorithmIdentifier = pkMlKem1024;
+    publicKeyLen = 1568;
+  }
+}

--- a/src/main/java24/com/jcraft/jsch/jce/MLKEM768.java
+++ b/src/main/java24/com/jcraft/jsch/jce/MLKEM768.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015-2018 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch.jce;
+
+import java.security.spec.NamedParameterSpec;
+
+public class MLKEM768 extends MLKEM {
+  private static final byte[] pkMlKem768 = {(byte) 0x60, (byte) 0x86, (byte) 0x48, (byte) 0x01,
+      (byte) 0x65, (byte) 0x03, (byte) 0x04, (byte) 0x04, (byte) 0x02};
+
+  public MLKEM768() {
+    params = NamedParameterSpec.ML_KEM_768;
+    algorithmIdentifier = pkMlKem768;
+    publicKeyLen = 1184;
+  }
+}

--- a/src/test/java/com/jcraft/jsch/Algorithms2IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms2IT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 import static org.junit.jupiter.api.condition.JRE.JAVA_15;
+import static org.junit.jupiter.api.condition.JRE.JAVA_24;
 
 import com.github.valfirst.slf4jtest.LoggingEvent;
 import com.github.valfirst.slf4jtest.TestLogger;
@@ -108,7 +109,7 @@ public class Algorithms2IT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"mlkem768nistp256-sha256", "mlkem1024nistp384-sha384", "curve448-sha512"})
+  @ValueSource(strings = {"curve448-sha512"})
   @EnabledForJreRange(min = JAVA_11)
   public void testJava11KEXs(String kex) throws Exception {
     JSch ssh = createRSAIdentity();
@@ -122,10 +123,27 @@ public class Algorithms2IT {
   }
 
   @ParameterizedTest
+  @ValueSource(strings = {"mlkem768nistp256-sha256", "mlkem1024nistp384-sha384"})
+  @EnabledForJreRange(min = JAVA_24)
+  public void testJava24KEXs(String kex) throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+    session.setConfig("mlkem768", "com.jcraft.jsch.jce.MLKEM768");
+    session.setConfig("mlkem1024", "com.jcraft.jsch.jce.MLKEM1024");
+    session.setConfig("kex", kex);
+    doSftp(session, true);
+
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
+    checkLogs(expected);
+  }
+
+  @ParameterizedTest
   @ValueSource(strings = {"mlkem768nistp256-sha256", "mlkem1024nistp384-sha384", "curve448-sha512"})
   public void testBCKEXs(String kex) throws Exception {
     JSch ssh = createRSAIdentity();
     Session session = createSession(ssh);
+    session.setConfig("mlkem768", "com.jcraft.jsch.bc.MLKEM768");
+    session.setConfig("mlkem1024", "com.jcraft.jsch.bc.MLKEM1024");
     session.setConfig("xdh", "com.jcraft.jsch.bc.XDH");
     session.setConfig("kex", kex);
     doSftp(session, true);

--- a/src/test/java/com/jcraft/jsch/Algorithms4IT.java
+++ b/src/test/java/com/jcraft/jsch/Algorithms4IT.java
@@ -3,6 +3,8 @@ package com.jcraft.jsch;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.condition.JRE.JAVA_11;
+import static org.junit.jupiter.api.condition.JRE.JAVA_24;
 
 import com.github.valfirst.slf4jtest.LoggingEvent;
 import com.github.valfirst.slf4jtest.TestLogger;
@@ -21,6 +23,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -100,9 +103,57 @@ public class Algorithms4IT {
   @ParameterizedTest
   @ValueSource(strings = {"mlkem768x25519-sha256", "sntrup761x25519-sha512",
       "sntrup761x25519-sha512@openssh.com"})
+  @EnabledForJreRange(min = JAVA_11)
+  public void testJava11KEXs(String kex) throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+    session.setConfig("mlkem768", "com.jcraft.jsch.bc.MLKEM768");
+    session.setConfig("xdh", "com.jcraft.jsch.jce.XDH");
+    session.setConfig("kex", kex);
+    doSftp(session, true);
+
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
+    checkLogs(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"mlkem768x25519-sha256"})
+  @EnabledForJreRange(min = JAVA_24)
+  public void testJava24KEXs(String kex) throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+    session.setConfig("mlkem768", "com.jcraft.jsch.jce.MLKEM768");
+    session.setConfig("xdh", "com.jcraft.jsch.jce.XDH");
+    session.setConfig("kex", kex);
+    doSftp(session, true);
+
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
+    checkLogs(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"mlkem768x25519-sha256", "sntrup761x25519-sha512",
+      "sntrup761x25519-sha512@openssh.com"})
   public void testBCKEXs(String kex) throws Exception {
     JSch ssh = createRSAIdentity();
     Session session = createSession(ssh);
+    session.setConfig("mlkem768", "com.jcraft.jsch.bc.MLKEM768");
+    session.setConfig("xdh", "com.jcraft.jsch.bc.XDH");
+    session.setConfig("kex", kex);
+    doSftp(session, true);
+
+    String expected = String.format(Locale.ROOT, "kex: algorithm: %s.*", kex);
+    checkLogs(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"mlkem768x25519-sha256"})
+  @EnabledForJreRange(min = JAVA_24)
+  public void testJava24BCKEXs(String kex) throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+    session.setConfig("mlkem768", "com.jcraft.jsch.jce.MLKEM768");
+    session.setConfig("xdh", "com.jcraft.jsch.bc.XDH");
     session.setConfig("kex", kex);
     doSftp(session, true);
 

--- a/src/test/java/com/jcraft/jsch/KeyExchangeTest.java
+++ b/src/test/java/com/jcraft/jsch/KeyExchangeTest.java
@@ -63,6 +63,13 @@ public class KeyExchangeTest {
   }
 
   @Test
+  public void testEncodeIntRandom() {
+    for (int i = 0; i < 1000000; i++) {
+      doEncodeInt(random.nextInt());
+    }
+  }
+
+  @Test
   public void testEncodeAsMPInt1() {
     byte[] secret = new byte[1];
     for (int i = 0; i <= 0xff; i++) {
@@ -183,12 +190,28 @@ public class KeyExchangeTest {
     }
   }
 
+  private void doEncodeInt(int secret) {
+    Buffer b = new Buffer();
+    b.putInt(secret);
+    byte[] expected = new byte[b.getLength()];
+    b.getByte(expected);
+    byte[] actual = kex.encodeInt(secret);
+    try {
+      assertArrayEquals(expected, actual);
+    } catch (Throwable t) {
+      System.out.println("  secret = " + secret);
+      System.out.println("expected = " + Arrays.toString(expected));
+      System.out.println("  actual = " + Arrays.toString(actual));
+      throw t;
+    }
+  }
+
   private void doEncodeAsMPInt(byte[] secret) {
     Buffer b = new Buffer();
     b.putMPInt(secret);
     byte[] expected = new byte[b.getLength()];
     b.getByte(expected);
-    byte[] actual = kex.encodeAsMPInt(Arrays.copyOf(secret, secret.length));
+    byte[] actual = kex.encodeAsMPInt(Arrays.copyOf(secret, secret.length), true);
     try {
       assertArrayEquals(expected, actual);
     } catch (Throwable t) {
@@ -204,7 +227,7 @@ public class KeyExchangeTest {
     b.putString(secret);
     byte[] expected = new byte[b.getLength()];
     b.getByte(expected);
-    byte[] actual = kex.encodeAsString(Arrays.copyOf(secret, secret.length));
+    byte[] actual = kex.encodeAsString(Arrays.copyOf(secret, secret.length), true);
     try {
       assertArrayEquals(expected, actual);
     } catch (Throwable t) {


### PR DESCRIPTION
- Add support for mlkem768x25519-sha256, mlkem768nistp256-sha256 & mlkem1024nistp384-sha384 KEX algorithms using JEP 496.
- Stop abusing the packet buffer for signature verification.
- Fix intermittent KEX errors with hybrid PQ/EC algorithms: the EC shared secret should not be stripped of unnecessary leading zero bytes since they are concatenated with the PQ secret and encoded as a string.
- Update forbiddenapis to use latest commons-io signatures.