### PR TITLE
0.2.26 changes

### DIFF
--- a/src/main/java/com/jcraft/jsch/DHXEC.java
+++ b/src/main/java/com/jcraft/jsch/DHXEC.java
@@ -79,7 +79,7 @@ abstract class DHXEC extends KeyExchange {
 
       Q_C = xdh.getQ();
       buf.putString(Q_C);
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       throw new JSchException(e.toString(), e);
     }
 

--- a/src/main/java/com/jcraft/jsch/DHXECKEM.java
+++ b/src/main/java/com/jcraft/jsch/DHXECKEM.java
@@ -93,7 +93,7 @@ abstract class DHXECKEM extends KeyExchange {
       System.arraycopy(kem_public_key_C, 0, Q_C, 0, kem_pubkey_len);
       System.arraycopy(xec_public_key_C, 0, Q_C, kem_pubkey_len, xec_key_len);
       buf.putString(Q_C);
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       throw new JSchException(e.toString(), e);
     }
 

--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -54,9 +54,9 @@ public class JSch {
     config.put("enable_ext_info_in_auth",
         Util.getSystemProperty("jsch.enable_ext_info_in_auth", "yes"));
     config.put("cipher.s2c", Util.getSystemProperty("jsch.cipher",
-        "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com"));
+        "aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr"));
     config.put("cipher.c2s", Util.getSystemProperty("jsch.cipher",
-        "aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com"));
+        "aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr"));
     config.put("mac.s2c", Util.getSystemProperty("jsch.mac",
         "hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1"));
     config.put("mac.c2s", Util.getSystemProperty("jsch.mac",

--- a/src/main/java/com/jcraft/jsch/JUnixSocketFactory.java
+++ b/src/main/java/com/jcraft/jsch/JUnixSocketFactory.java
@@ -40,7 +40,7 @@ public class JUnixSocketFactory implements USocketFactory {
   public JUnixSocketFactory() throws AgentProxyException {
     // Check to confirm that junixsocket library is available
     try (AFUNIXSocketChannel foo = AFUNIXSocketChannel.open()) {
-    } catch (IOException | NoClassDefFoundError e) {
+    } catch (IOException | LinkageError e) {
       throw new AgentProxyException("junixsocket library unavailable", e);
     }
   }

--- a/src/main/java/com/jcraft/jsch/KeyExchange.java
+++ b/src/main/java/com/jcraft/jsch/KeyExchange.java
@@ -176,7 +176,7 @@ public abstract class KeyExchange {
       if (_c2sAEAD) {
         guess[PROPOSAL_MAC_ALGS_CTOS] = null;
       }
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       throw new JSchException(e.toString(), e);
     }
 
@@ -451,7 +451,7 @@ public abstract class KeyExchange {
             Class.forName(session.getConfig(alg)).asSubclass(SignatureEdDSA.class);
         sig = c.getDeclaredConstructor().newInstance();
         sig.init();
-      } catch (Exception | NoClassDefFoundError e) {
+      } catch (Exception | LinkageError e) {
         throw new JSchException(e.toString(), e);
       }
 

--- a/src/main/java/com/jcraft/jsch/KeyPair.java
+++ b/src/main/java/com/jcraft/jsch/KeyPair.java
@@ -1136,7 +1136,7 @@ public abstract class KeyPair {
       }
 
       return kpair;
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       Util.bzero(data);
       if (e instanceof JSchException)
         throw (JSchException) e;
@@ -1188,7 +1188,7 @@ public abstract class KeyPair {
                 Class.forName(JSch.getConfig(cipherName)).asSubclass(Cipher.class);
             kpair.cipher = c.getDeclaredConstructor().newInstance();
             kpair.iv = new byte[kpair.cipher.getIVSize()];
-          } catch (Exception | NoClassDefFoundError e) {
+          } catch (Exception | LinkageError e) {
             throw new JSchException("cipher " + cipherName + " is not available", e);
           }
         } else {
@@ -1204,7 +1204,7 @@ public abstract class KeyPair {
           BCrypt bcrypt = c.getDeclaredConstructor().newInstance();
           bcrypt.init(salt, rounds);
           kpair.kdf = bcrypt;
-        } catch (Exception | NoClassDefFoundError e) {
+        } catch (Exception | LinkageError e) {
           throw new JSchException("kdf " + kdfName + " is not available", e);
         }
       }
@@ -1364,7 +1364,7 @@ public abstract class KeyPair {
                 Class.forName(JSch.getConfig("aes256-cbc")).asSubclass(Cipher.class);
             kpair.cipher = c.getDeclaredConstructor().newInstance();
             kpair.iv = new byte[kpair.cipher.getIVSize()];
-          } catch (Exception | NoClassDefFoundError e) {
+          } catch (Exception | LinkageError e) {
             throw new JSchException("The cipher 'aes256-cbc' is required, but it is not available.",
                 e);
           }
@@ -1378,7 +1378,7 @@ public abstract class KeyPair {
             HASH sha1 = c.getDeclaredConstructor().newInstance();
             sha1.init();
             kpair.sha1 = sha1;
-          } catch (Exception | NoClassDefFoundError e) {
+          } catch (Exception | LinkageError e) {
             throw new JSchException("'sha-1' is required, but it is not available.", e);
           }
         } else {
@@ -1423,7 +1423,7 @@ public abstract class KeyPair {
             kpair.kdf = argon2;
           } catch (NumberFormatException e) {
             throw new JSchException("Invalid argon2 params.", e);
-          } catch (Exception | NoClassDefFoundError e) {
+          } catch (Exception | LinkageError e) {
             throw new JSchException("'argon2' is required, but it is not available.", e);
           }
         }

--- a/src/main/java/com/jcraft/jsch/KeyPairEdDSA.java
+++ b/src/main/java/com/jcraft/jsch/KeyPairEdDSA.java
@@ -53,7 +53,7 @@ abstract class KeyPairEdDSA extends KeyPair {
       prv_array = keypairgen.getPrv();
 
       keypairgen = null;
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       throw new JSchException(e.toString(), e);
     }
   }
@@ -125,7 +125,7 @@ abstract class KeyPairEdDSA extends KeyPair {
         pub_array = keypairgen.getPub();
         prv_array = keypairgen.getPrv();
         return true;
-      } catch (Exception | NoClassDefFoundError e) {
+      } catch (Exception | LinkageError e) {
         if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
           instLogger.getLogger().log(Logger.ERROR, "failed to parse key", e);
         }
@@ -178,7 +178,7 @@ abstract class KeyPairEdDSA extends KeyPair {
       tmp[0] = Util.str2byte(alg);
       tmp[1] = sig;
       return Buffer.fromBytes(tmp).buffer;
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
         instLogger.getLogger().log(Logger.ERROR, "failed to generate signature", e);
       }
@@ -207,7 +207,7 @@ abstract class KeyPairEdDSA extends KeyPair {
 
       eddsa.setPubKey(pub_array);
       return eddsa;
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       if (instLogger.getLogger().isEnabled(Logger.ERROR)) {
         instLogger.getLogger().log(Logger.ERROR, "failed to create verifier", e);
       }

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -58,7 +58,7 @@ public class PageantConnector implements AgentConnector {
     try {
       user32 = User32.INSTANCE;
       kernel32 = Kernel32.INSTANCE;
-    } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
+    } catch (LinkageError e) {
       throw new AgentProxyException(e.toString(), e);
     }
   }

--- a/src/main/java/com/jcraft/jsch/SSHAgentConnector.java
+++ b/src/main/java/com/jcraft/jsch/SSHAgentConnector.java
@@ -98,7 +98,7 @@ public class SSHAgentConnector implements AgentConnector {
     } catch (AgentProxyException e) {
       try {
         return new JUnixSocketFactory();
-      } catch (NoClassDefFoundError ee) {
+      } catch (LinkageError ee) {
         AgentProxyException eee = new AgentProxyException("junixsocket library unavailable");
         eee.addSuppressed(e);
         eee.addSuppressed(ee);

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -635,7 +635,7 @@ public class Session {
       Class<? extends KeyExchange> c = Class
           .forName(getConfig(guess[KeyExchange.PROPOSAL_KEX_ALGS])).asSubclass(KeyExchange.class);
       kex = c.getDeclaredConstructor().newInstance();
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       throw new JSchException(e.toString(), e);
     }
 
@@ -1592,7 +1592,7 @@ public class Session {
 
       method = guess[KeyExchange.PROPOSAL_COMP_ALGS_STOC];
       initInflater(method);
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       if (e instanceof JSchException)
         throw e;
       throw new JSchException(e.toString(), e);
@@ -3012,7 +3012,7 @@ public class Session {
       Cipher _c = c.getDeclaredConstructor().newInstance();
       _c.init(Cipher.ENCRYPT_MODE, new byte[_c.getBlockSize()], new byte[_c.getIVSize()]);
       return true;
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       return false;
     }
   }
@@ -3058,7 +3058,7 @@ public class Session {
       MAC _c = c.getDeclaredConstructor().newInstance();
       _c.init(new byte[_c.getBlockSize()]);
       return true;
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       return false;
     }
   }
@@ -3098,7 +3098,7 @@ public class Session {
       KeyExchange _c = c.getDeclaredConstructor().newInstance();
       _c.doInit(s, null, null, null, null);
       return true;
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (Exception | LinkageError e) {
       return false;
     }
   }
@@ -3119,7 +3119,7 @@ public class Session {
             Class.forName(JSch.getConfig(_sigs[i])).asSubclass(Signature.class);
         final Signature sig = c.getDeclaredConstructor().newInstance();
         sig.init();
-      } catch (Exception | NoClassDefFoundError e) {
+      } catch (Exception | LinkageError e) {
         result.addElement(_sigs[i]);
       }
     }

--- a/src/main/java/com/jcraft/jsch/bc/Argon2.java
+++ b/src/main/java/com/jcraft/jsch/bc/Argon2.java
@@ -67,7 +67,7 @@ public class Argon2 implements com.jcraft.jsch.Argon2 {
           .withMemoryAsKB(memory).withParallelism(parallelism).withVersion(version).build();
       generator = new Argon2BytesGenerator();
       generator.init(params);
-    } catch (NoClassDefFoundError e) {
+    } catch (LinkageError e) {
       throw new JSchException("argon2 unavailable", e);
     }
   }

--- a/src/main/java/com/jcraft/jsch/bc/SCrypt.java
+++ b/src/main/java/com/jcraft/jsch/bc/SCrypt.java
@@ -43,7 +43,7 @@ public class SCrypt implements com.jcraft.jsch.SCrypt {
       this.cost = cost;
       this.blocksize = blocksize;
       this.parallel = parallel;
-    } catch (NoClassDefFoundError e) {
+    } catch (LinkageError e) {
       throw new JSchException("scrypt unavailable", e);
     }
   }


### PR DESCRIPTION
- Follow lead from OpenSSH and prefer AES-GCM ciphers to AES-CTR ciphers.
- Catch LinkageError in order to better handle cases in which classes cannot be loaded via reflection. (#811)