### PR TITLE
2.27.3 changes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 			"version": "latest",
 			"jdkDistro": "tem",
 			"installMaven": "true",
-			"mavenVersion": "3.9.10",
+			"mavenVersion": "3.9.11",
 			"installGradle": "false"
 		},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "wednesday"
     open-pull-requests-limit: 25
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -16,4 +17,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
     open-pull-requests-limit: 25

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=24.0.1-tem
+java=24.0.2-tem
 maven=3.9.11

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=24.0.1-tem
-maven=3.9.10
+maven=3.9.11

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,7 @@
                 <version>7.1.0</version>
                 <configuration>
                     <bnd><![CDATA[
+                        -noimportjava: true
                         -noextraheaders: false
                         -removeheaders: \
                             Bnd-LastModified,\

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
                                     <version>24</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>3.9.10</version>
+                                    <version>3.9.11</version>
                                 </requireMavenVersion>
                                 <dependencyConvergence />
                                 <banDuplicatePomDependencyVersions />


### PR DESCRIPTION
- Update to Maven 3.9.11.
- Update to latest Java (24.0.2) release.
- Ensure that bnd-maven-plugin doesn't add java package imports into OSGi imports.
- Run Dependabot on Wednesdays since Github is frequently overloaded on Mondays & fails.