### PR TITLE
2.27.3 changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: '24'
         check-latest: true
         cache: 'maven'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up build JDK
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: '24'
         check-latest: true
         cache: 'maven'

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up build JDK
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '24'
           check-latest: true
       - name: Build Javadoc

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Extract target directory archive
       run: tar -xmf target.tar
     - name: Test with Maven
-      run: ./mvnw -B -V -e -Pcoverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dformatter.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
+      run: ./mvnw -B -V -e -Pcoverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dspdx.skip=true -Dformatter.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
     - name: Upload test results
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,11 +60,20 @@ jobs:
         key: ${{ runner.os }}-test-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml', '**/maven-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-test-${{ matrix.java }}-maven-
+    - name: Generate list of JDKs to install
+      id: jdks_to_install
+      run: |
+        maven_jdk=24
+        matrix_java="${{ matrix.java }}"
+        echo 'list<<EOF' >> "$GITHUB_OUTPUT"
+        echo "$matrix_java" >> "$GITHUB_OUTPUT"
+        [ "$maven_jdk" != "$matrix_java" ] && echo "$maven_jdk" >> "$GITHUB_OUTPUT"
+        echo 'EOF' >> "$GITHUB_OUTPUT"
     - name: Set up JDK
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.java }}
+        java-version: ${{ steps.jdks_to_install.outputs.list }}
         check-latest: true
     - name: Download target directory archive
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -73,7 +82,10 @@ jobs:
     - name: Extract target directory archive
       run: tar -xmf target.tar
     - name: Test with Maven
-      run: ./mvnw -B -V -e -Pcoverage verify -Denforcer.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dspdx.skip=true -Dformatter.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
+      run: |
+        LOWER_JDK="${{ matrix.java }}"
+        UPPER_JDK=$((LOWER_JDK+1))
+        ./mvnw -B -V -e -Pcoverage verify -Dtoolchain.jdk.version="[$LOWER_JDK,$UPPER_JDK)" -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dspdx.skip=true -Dformatter.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
     - name: Upload test results
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: '24'
         check-latest: true
     - name: Build with Maven
@@ -63,7 +63,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Download target directory archive

--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${surefire.version}</version>
                 <configuration>
+                    <argLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED</argLine>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <log4j.version>2.25.1</log4j.version>
         <errorprone.version>2.41.0</errorprone.version>
         <surefire.version>3.5.3</surefire.version>
+        <toolchain.jdk.version>[24,)</toolchain.jdk.version>
     </properties>
     <dependencies>
         <dependency>
@@ -266,6 +267,18 @@
                                 <requireUpperBoundDeps />
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>select-jdk-toolchain</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,17 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.spdx</groupId>
+                <artifactId>spdx-maven-plugin</artifactId>
+                <version>1.0.3</version>
+                <configuration>
+                    <includeProvidedScope>false</includeProvidedScope>
+                    <includeSystemScope>false</includeSystemScope>
+                    <includeTestScope>false</includeTestScope>
+                    <sbomType>build</sbomType>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.1.1</version>
@@ -906,6 +917,28 @@
                                 <phase>process-classes</phase>
                                 <goals>
                                     <goal>bnd-process</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>spdx</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.spdx</groupId>
+                        <artifactId>spdx-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>createSPDX</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -175,8 +175,24 @@
                     <artifactId>maven-core</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-model</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.assertj</groupId>
                     <artifactId>assertj-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.awaitility</groupId>
+                    <artifactId>awaitility</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,13 +89,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.kohlschutter</groupId>
-            <artifactId>compiler-annotations</artifactId>
-            <version>1.8.2</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-jpms</artifactId>
             <version>${jna.version}</version>

--- a/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
+++ b/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
@@ -96,7 +96,7 @@ class ChannelAgentForwarding extends Channel {
       packet = new Packet(wbuf);
     }
 
-    rbuf.shift();
+    rbuf.reset();
     if (rbuf.buffer.length < rbuf.index + l) {
       byte[] newbuf = new byte[rbuf.s + l];
       System.arraycopy(rbuf.buffer, 0, newbuf, 0, rbuf.buffer.length);


### PR DESCRIPTION
- Drop unneeded compiler-annotations dependency.
- Generate SPDX SBOM.
- #852 Fix ChannelAgentForwarding when an unknown agent message type is received immediately preceding a known agent message type.
- Consistently use Temurin JDK for all Github workflows.
- Add --enable-native-access=ALL-UNNAMED that will be required for JNA and junixsocket to function in future Java releases.
- Remove additional extraneous dependencies for log4j-core-test.
- Use toolchains plugin to select JDK to allow eventual Maven 4 support.
-- Maven 4 will only run on Java 17+, so in order to execute tests with Java 8 & 11 in GHA, we'll need to use the toolchains plugin to allow executing tests with a different JDK than used to execute Maven itself.