### PR TITLE
Throw JSchException if an incorrect passphrase is provided to `JSch.addIdentity()`

### DIFF
--- a/src/main/java/com/jcraft/jsch/JSch.java
+++ b/src/main/java/com/jcraft/jsch/JSch.java
@@ -525,7 +525,9 @@ public class JSch {
         byte[] goo = new byte[passphrase.length];
         System.arraycopy(passphrase, 0, goo, 0, passphrase.length);
         passphrase = goo;
-        identity.setPassphrase(passphrase);
+        if (!identity.setPassphrase(passphrase)) {
+          throw new JSchException("Incorrect passphrase provided.");
+        }
       } finally {
         Util.bzero(passphrase);
       }


### PR DESCRIPTION
#929: throw JSchException if an incorrect passphrase is provided to `JSch.addIdentity()`.