### PR TITLE
Fix logging a 'port is null' error when parsing openssh config file

### DIFF
--- a/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
+++ b/src/main/java/com/jcraft/jsch/OpenSSHConfig.java
@@ -308,13 +308,14 @@ public class OpenSSHConfig implements ConfigRepository {
     public int getPort() {
       String foo = find("Port");
       int port = -1;
-      // Port is not required and we don't want to log a failure if its simply missing from the OpenSSH config
+      // Port is not required and we don't want to log a failure if its simply missing from the
+      // OpenSSH config
       if (foo != null) {
-          try {
-              port = Integer.parseInt(foo);
-          } catch (NumberFormatException e) {
-              logError("Port", e);
-          }
+        try {
+          port = Integer.parseInt(foo);
+        } catch (NumberFormatException e) {
+          logError("Port", e);
+        }
       }
       return port;
     }


### PR DESCRIPTION
OpenSSH config parsing is logging an "error" when the Port is not defined in the openssh config file (which is optional). While it doesn't affect functionality, it looks very important and is considered an ERROR in the logs when using this library. This checks for a null first before logging the error if the port really is bad.