### PR TITLE
SftpATTRS constructor should be public

### DIFF
--- a/src/main/java/com/jcraft/jsch/SftpATTRS.java
+++ b/src/main/java/com/jcraft/jsch/SftpATTRS.java
@@ -166,11 +166,6 @@ public class SftpATTRS {
   int mtime;
   String[] extended = null;
 
-  /**
-   * Can be public since setting attributes via SFTP does not require reading them from the remote
-   * side first. You can safely set just a subset of attributes at a time, thus the default instance
-   * of SftpATTRS is safe to use.
-   */
   public SftpATTRS() {}
 
   static SftpATTRS getATTR(Buffer buf) {


### PR DESCRIPTION
The constructor for SftpATTRS is currently private, but I cannot figure out any valid reason why it should be. SFTP allows you to set file attributes (such as atime or mtime) w/o actually having any of the other attributes.  It intelligently lets you set only a subset of attributes at a time. By making this constructor private, you are forced to read the ATTRS from the remote, so then update them. But that's not actually a real requirement.  I currently had to resort of Reflection in my own project to create an instance of ATTRs.