### PR TITLE
Add FFM version of Pageant AgentConnector

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
         LOWER_JDK="${{ matrix.java }}"
         UPPER_JDK=$((LOWER_JDK+1))
-        ./mvnw -B -V -e -Pcoverage verify -Dtoolchain.jdk.version="[$LOWER_JDK,$UPPER_JDK)" -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dspdx.skip=true -Dformatter.skip=true -Dimpsort.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
+        ./mvnw -B -V -e -Pcoverage verify -Dtoolchain.jdk.version="[$LOWER_JDK,$UPPER_JDK)" -Dwindowsapi.skip=true -Dmaven.resources.skip=true -Dflatten.skip=true -Dmaven.main.skip=true -Dbnd.skip=true -Dassembly.skipAssembly=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dspdx.skip=true -Dformatter.skip=true -Dimpsort.skip=true -Dforbiddenapis.skip=true -DskipTests=false -DskipITs=false
     - name: Upload test results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,7 @@
                         <function>CreateFileMappingA</function>
                         <function>FindWindowA</function>
                         <function>GetCurrentProcessId</function>
+                        <function>GetCurrentThreadId</function>
                         <function>MapViewOfFile</function>
                         <function>SendMessageA</function>
                         <function>UnmapViewOfFile</function>

--- a/pom.xml
+++ b/pom.xml
@@ -281,23 +281,38 @@
                     <addAsSourceRoot>false</addAsSourceRoot>
                     <functions>
                         <function>CloseHandle</function>
+                        <function>CopySid</function>
                         <function>CreateFileMappingA</function>
                         <function>FindWindowA</function>
                         <function>GetCurrentProcessId</function>
-                        <function>GetCurrentThreadId</function>
+                        <function>GetLengthSid</function>
+                        <function>GetTokenInformation</function>
+                        <function>InitializeSecurityDescriptor</function>
+                        <function>IsValidSid</function>
                         <function>MapViewOfFile</function>
+                        <function>OpenProcess</function>
+                        <function>OpenProcessToken</function>
                         <function>SendMessageA</function>
+                        <function>SetSecurityDescriptorOwner</function>
                         <function>UnmapViewOfFile</function>
                     </functions>
                     <structs>
                         <struct>COPYDATASTRUCT</struct>
+                        <struct>SECURITY_ATTRIBUTES</struct>
+                        <struct>SECURITY_DESCRIPTOR</struct>
+                        <struct>SID_AND_ATTRIBUTES</struct>
+                        <struct>TOKEN_USER</struct>
                     </structs>
                     <enumerations>
                         <enumeration>FILE_MAP</enumeration>
                         <enumeration>PAGE_PROTECTION_FLAGS</enumeration>
+                        <enumeration>TOKEN_ACCESS_MASK</enumeration>
+                        <enumeration>TOKEN_INFORMATION_CLASS</enumeration>
                     </enumerations>
                     <constants>
                         <constant>INVALID_HANDLE_VALUE</constant>
+                        <constant>MAXIMUM_ALLOWED</constant>
+                        <constant>SECURITY_DESCRIPTOR_REVISION</constant>
                         <constant>WM_COPYDATA</constant>
                     </constants>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,19 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>default-compile-19</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java19</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                            <release>19</release>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>default-compile-24</id>
                         <goals>
                             <goal>compile</goal>
@@ -560,7 +573,7 @@
                     <doclint>none</doclint>
                     <subpackages>com.jcraft.jsch</subpackages>
                     <excludePackageNames>com.jcraft.jsch.*</excludePackageNames>
-                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java10:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16:${project.basedir}/src/main/java24</sourcepath>
+                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java10:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16:${project.basedir}/src/main/java19:${project.basedir}/src/main/java24</sourcepath>
                 </configuration>
                 <executions>
                     <execution>
@@ -658,6 +671,7 @@
                         <sourceDirectory>${project.basedir}/src/main/java11</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java15</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java16</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java19</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java24</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java-templates</sourceDirectory>
                     </sourceDirectories>
@@ -679,6 +693,7 @@
                         <directory>${project.basedir}/src/main/java11</directory>
                         <directory>${project.basedir}/src/main/java15</directory>
                         <directory>${project.basedir}/src/main/java16</directory>
+                        <directory>${project.basedir}/src/main/java19</directory>
                         <directory>${project.basedir}/src/main/java24</directory>
                         <directory>${project.basedir}/src/main/java-templates</directory>
                     </directories>
@@ -699,6 +714,7 @@
                         <directory>${project.basedir}/src/main/java11</directory>
                         <directory>${project.basedir}/src/main/java15</directory>
                         <directory>${project.basedir}/src/main/java16</directory>
+                        <directory>${project.basedir}/src/main/java19</directory>
                         <directory>${project.basedir}/src/main/java24</directory>
                         <directory>${project.basedir}/src/main/java-templates</directory>
                     </directories>
@@ -710,6 +726,7 @@
                 <version>0.8.15</version>
                 <configuration>
                     <excludes>
+                        <exclude>com/jcraft/jsch/JavaThreadId.class</exclude>
                         <exclude>com/jcraft/jsch/JavaVersion.class</exclude>
                         <exclude>com/jcraft/jsch/JplLogger.class</exclude>
                         <exclude>com/jcraft/jsch/UnixDomainSocketFactory.class</exclude>
@@ -723,6 +740,7 @@
                         <exclude>com/jcraft/jsch/jce/XDH.class</exclude>
                         <exclude>META-INF/versions/9/com/jcraft/jsch/JavaVersion.class</exclude>
                         <exclude>META-INF/versions/10/com/jcraft/jsch/JavaVersion.class</exclude>
+                        <exclude>META-INF/versions/19/com/jcraft/jsch/JavaThreadId.class</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,36 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>net.codecrete.windows-api</groupId>
+                <artifactId>windowsapi-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <configuration>
+                    <sourceDirectory>.</sourceDirectory>
+                    <basePackage>com.jcraft.jsch.windowsapi</basePackage>
+                    <addAsSourceRoot>false</addAsSourceRoot>
+                    <functions>
+                        <function>CloseHandle</function>
+                        <function>CreateFileMappingA</function>
+                        <function>FindWindowA</function>
+                        <function>GetCurrentProcessId</function>
+                        <function>MapViewOfFile</function>
+                        <function>SendMessageA</function>
+                        <function>UnmapViewOfFile</function>
+                    </functions>
+                    <structs>
+                        <struct>COPYDATASTRUCT</struct>
+                    </structs>
+                    <enumerations>
+                        <enumeration>FILE_MAP</enumeration>
+                        <enumeration>PAGE_PROTECTION_FLAGS</enumeration>
+                    </enumerations>
+                    <constants>
+                        <constant>INVALID_HANDLE_VALUE</constant>
+                        <constant>WM_COPYDATA</constant>
+                    </constants>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-toolchains-plugin</artifactId>
                 <version>3.2.0</version>
@@ -432,6 +462,23 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>default-compile-23</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java23</compileSourceRoot>
+                                <compileSourceRoot>${project.build.directory}/generated-sources/windows-api</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                            <release>23</release>
+                            <compilerArgs>
+                                <arg>-Xlint:all,-processing,-classfile,-options,-restricted</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>default-compile-24</id>
                         <goals>
                             <goal>compile</goal>
@@ -572,8 +619,8 @@
                     <quiet>true</quiet>
                     <doclint>none</doclint>
                     <subpackages>com.jcraft.jsch</subpackages>
-                    <excludePackageNames>com.jcraft.jsch.*</excludePackageNames>
-                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java10:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16:${project.basedir}/src/main/java19:${project.basedir}/src/main/java24</sourcepath>
+                    <excludePackageNames>com.jcraft.jsch.*,com.jcraft.jsch.windowsapi.windows.win32.*,com.jcraft.jsch.windowsapi.windows.win32.system.*,com.jcraft.jsch.windowsapi.windows.win32.ui.*</excludePackageNames>
+                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/java-templates:${project.basedir}/src/main/java9:${project.basedir}/src/main/java10:${project.basedir}/src/main/java11:${project.basedir}/src/main/java15:${project.basedir}/src/main/java16:${project.basedir}/src/main/java19:${project.basedir}/src/main/java23:${project.build.directory}/generated-sources/windows-api:${project.basedir}/src/main/java24</sourcepath>
                 </configuration>
                 <executions>
                     <execution>
@@ -672,6 +719,7 @@
                         <sourceDirectory>${project.basedir}/src/main/java15</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java16</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java19</sourceDirectory>
+                        <sourceDirectory>${project.basedir}/src/main/java23</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java24</sourceDirectory>
                         <sourceDirectory>${project.basedir}/src/main/java-templates</sourceDirectory>
                     </sourceDirectories>
@@ -694,6 +742,7 @@
                         <directory>${project.basedir}/src/main/java15</directory>
                         <directory>${project.basedir}/src/main/java16</directory>
                         <directory>${project.basedir}/src/main/java19</directory>
+                        <directory>${project.basedir}/src/main/java23</directory>
                         <directory>${project.basedir}/src/main/java24</directory>
                         <directory>${project.basedir}/src/main/java-templates</directory>
                     </directories>
@@ -715,6 +764,7 @@
                         <directory>${project.basedir}/src/main/java15</directory>
                         <directory>${project.basedir}/src/main/java16</directory>
                         <directory>${project.basedir}/src/main/java19</directory>
+                        <directory>${project.basedir}/src/main/java23</directory>
                         <directory>${project.basedir}/src/main/java24</directory>
                         <directory>${project.basedir}/src/main/java-templates</directory>
                     </directories>
@@ -729,6 +779,7 @@
                         <exclude>com/jcraft/jsch/JavaThreadId.class</exclude>
                         <exclude>com/jcraft/jsch/JavaVersion.class</exclude>
                         <exclude>com/jcraft/jsch/JplLogger.class</exclude>
+                        <exclude>com/jcraft/jsch/PageantFFMConnector.class</exclude>
                         <exclude>com/jcraft/jsch/UnixDomainSocketFactory.class</exclude>
                         <exclude>com/jcraft/jsch/jce/KeyPairGenEdDSA.class</exclude>
                         <exclude>com/jcraft/jsch/jce/MLKEM.class</exclude>
@@ -1042,6 +1093,31 @@
                                 <phase>package</phase>
                                 <goals>
                                     <goal>createSPDX</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>windowsapi</id>
+            <activation>
+                <jdk>[21,)</jdk>
+                <property>
+                    <name>windowsapi.skip</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.codecrete.windows-api</groupId>
+                        <artifactId>windowsapi-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>windows-api</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/src/assembly/sources.xml
+++ b/src/assembly/sources.xml
@@ -63,6 +63,13 @@
       </includes>
     </fileSet>
     <fileSet>
+      <directory>${project.basedir}/src/main/java19</directory>
+      <outputDirectory>META-INF/versions/19</outputDirectory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet>
       <directory>${project.basedir}/src/main/java24</directory>
       <outputDirectory>META-INF/versions/24</outputDirectory>
       <includes>

--- a/src/assembly/sources.xml
+++ b/src/assembly/sources.xml
@@ -70,6 +70,20 @@
       </includes>
     </fileSet>
     <fileSet>
+      <directory>${project.basedir}/src/main/java23</directory>
+      <outputDirectory>META-INF/versions/23</outputDirectory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/generated-sources/windows-api</directory>
+      <outputDirectory>META-INF/versions/23</outputDirectory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
+    <fileSet>
       <directory>${project.basedir}/src/main/java24</directory>
       <outputDirectory>META-INF/versions/24</outputDirectory>
       <includes>

--- a/src/main/java/com/jcraft/jsch/JavaThreadId.java
+++ b/src/main/java/com/jcraft/jsch/JavaThreadId.java
@@ -1,0 +1,11 @@
+package com.jcraft.jsch;
+
+import com.jcraft.jsch.annotations.SuppressForbiddenApi;
+
+final class JavaThreadId {
+
+  @SuppressForbiddenApi("jdk-deprecated")
+  static long get() {
+    return Thread.currentThread().getId();
+  }
+}

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -85,8 +85,8 @@ public class PageantConnector implements AgentConnector {
       throw new AgentProxyException("Pageant is not runnning.");
     }
 
-    String mapname =
-        String.format(Locale.ROOT, "PageantRequest%08x", kernel32.GetCurrentThreadId());
+    String mapname = String.format(Locale.ROOT, "JSchPageantRequest%08x%08x",
+        kernel32.GetCurrentProcessId(), JavaThreadId.get());
 
     HANDLE sharedFile = null;
     Pointer sharedMemory = null;

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -102,7 +102,7 @@ public class PageantConnector implements AgentConnector {
       int lastError = kernel32.GetLastError();
       if (sharedFile == null) {
         throw new AgentProxyException(
-            "Unable to create shared file mapping: GetLastError() = " + lastError);
+            "Unable to CreateFileMapping(): GetLastError() = " + lastError);
       }
       if (lastError == WinError.ERROR_ALREADY_EXISTS) {
         throw new AgentProxyException("Shared file mapping already exists");
@@ -111,7 +111,7 @@ public class PageantConnector implements AgentConnector {
       sharedMemory = kernel32.MapViewOfFile(sharedFile, WinBase.FILE_MAP_WRITE, 0, 0, 0);
       if (sharedMemory == null) {
         throw new AgentProxyException(
-            "Unable to create shared memory mapping: GetLastError() = " + kernel32.GetLastError());
+            "Unable to MapViewOfFile(): GetLastError() = " + kernel32.GetLastError());
       }
 
       sharedMemory.write(0, buffer.buffer, 0, buffer.getLength());

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -100,7 +100,7 @@ public class PageantConnector implements AgentConnector {
         throw new AgentProxyException("Unable to create shared file mapping.");
       }
 
-      sharedMemory = kernel32.MapViewOfFile(sharedFile, WinNT.SECTION_MAP_WRITE, 0, 0, 0);
+      sharedMemory = kernel32.MapViewOfFile(sharedFile, WinBase.FILE_MAP_WRITE, 0, 0, 0);
       if (sharedMemory == null) {
         throw new AgentProxyException("Unable to create shared file mapping.");
       }

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -129,7 +129,7 @@ public class PageantConnector implements AgentConnector {
     } finally {
       if (sharedMemory != null)
         kernel32.UnmapViewOfFile(sharedMemory);
-      if (sharedFile != null)
+      if (sharedFile != null && sharedFile != WinBase.INVALID_HANDLE_VALUE)
         kernel32.CloseHandle(sharedFile);
     }
   }

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -97,12 +97,14 @@ public class PageantConnector implements AgentConnector {
       sharedFile = kernel32.CreateFileMapping(WinBase.INVALID_HANDLE_VALUE, psa,
           WinNT.PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapname);
       if (sharedFile == null || sharedFile == WinBase.INVALID_HANDLE_VALUE) {
-        throw new AgentProxyException("Unable to create shared file mapping.");
+        throw new AgentProxyException(
+            "Unable to create shared file mapping: GetLastError() = " + kernel32.GetLastError());
       }
 
       sharedMemory = kernel32.MapViewOfFile(sharedFile, WinBase.FILE_MAP_WRITE, 0, 0, 0);
       if (sharedMemory == null) {
-        throw new AgentProxyException("Unable to create shared file mapping.");
+        throw new AgentProxyException(
+            "Unable to create shared memory mapping: GetLastError() = " + kernel32.GetLastError());
       }
 
       sharedMemory.write(0, buffer.buffer, 0, buffer.getLength());
@@ -124,7 +126,7 @@ public class PageantConnector implements AgentConnector {
         sharedMemory.read(4, buffer.buffer, 0, i);
       } else {
         throw new AgentProxyException(
-            "User32.SendMessage() returned 0 with cds.dwData: " + Long.toHexString(foo));
+            "SendMessage() returned 0 with cds.dwData: " + Long.toHexString(foo));
       }
     } finally {
       if (sharedMemory != null)

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -98,7 +98,7 @@ public class PageantConnector implements AgentConnector {
       sharedFile = kernel32.CreateFileMapping(WinBase.INVALID_HANDLE_VALUE, psa,
           WinNT.PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapname);
       int lastError = kernel32.GetLastError();
-      if (sharedFile == null || sharedFile == WinBase.INVALID_HANDLE_VALUE) {
+      if (sharedFile == null) {
         throw new AgentProxyException(
             "Unable to create shared file mapping: GetLastError() = " + lastError);
       }
@@ -136,7 +136,7 @@ public class PageantConnector implements AgentConnector {
     } finally {
       if (sharedMemory != null)
         kernel32.UnmapViewOfFile(sharedMemory);
-      if (sharedFile != null && sharedFile != WinBase.INVALID_HANDLE_VALUE)
+      if (sharedFile != null)
         kernel32.CloseHandle(sharedFile);
     }
   }

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -136,10 +136,15 @@ public class PageantConnector implements AgentConnector {
             "SendMessage() returned 0 with cds.dwData: " + Long.toHexString(foo));
       }
     } finally {
-      if (sharedMemory != null)
-        kernel32.UnmapViewOfFile(sharedMemory);
-      if (sharedFile != null)
-        kernel32.CloseHandle(sharedFile);
+      try {
+        if (sharedMemory != null) {
+          kernel32.UnmapViewOfFile(sharedMemory);
+        }
+      } finally {
+        if (sharedFile != null) {
+          kernel32.CloseHandle(sharedFile);
+        }
+      }
     }
   }
 

--- a/src/main/java/com/jcraft/jsch/PageantConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantConnector.java
@@ -86,8 +86,10 @@ public class PageantConnector implements AgentConnector {
       throw new AgentProxyException("Pageant is not runnning.");
     }
 
-    String mapname = String.format(Locale.ROOT, "JSchPageantRequest%08x%08x",
-        kernel32.GetCurrentProcessId(), JavaThreadId.get());
+    String threadId = JavaVersion.getVersion() >= 19
+        ? String.format(Locale.ROOT, "%08x%08x", kernel32.GetCurrentProcessId(), JavaThreadId.get())
+        : String.format(Locale.ROOT, "%08x", kernel32.GetCurrentThreadId());
+    String mapname = "JSchPageantRequest" + threadId;
 
     HANDLE sharedFile = null;
     Pointer sharedMemory = null;

--- a/src/main/java/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java/com/jcraft/jsch/PageantFFMConnector.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch;
+
+public class PageantFFMConnector implements AgentConnector {
+
+  public PageantFFMConnector() throws AgentProxyException {
+    throw new AgentProxyException("PageantFFMConnector requires Java23+.");
+  }
+
+  @Override
+  public String getName() {
+    throw new UnsupportedOperationException("PageantFFMConnector requires Java23+.");
+  }
+
+  @Override
+  public boolean isAvailable() {
+    throw new UnsupportedOperationException("PageantFFMConnector requires Java23+.");
+  }
+
+  @Override
+  public void query(Buffer buffer) throws AgentProxyException {
+    throw new UnsupportedOperationException("PageantFFMConnector requires Java23+.");
+  }
+}

--- a/src/main/java19/com/jcraft/jsch/JavaThreadId.java
+++ b/src/main/java19/com/jcraft/jsch/JavaThreadId.java
@@ -1,0 +1,8 @@
+package com.jcraft.jsch;
+
+final class JavaThreadId {
+
+  static long get() {
+    return Thread.currentThread().threadId();
+  }
+}

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -28,16 +28,31 @@ package com.jcraft.jsch;
 
 import static com.jcraft.jsch.windowsapi.windows.win32.foundation.Apis.CloseHandle;
 import static com.jcraft.jsch.windowsapi.windows.win32.foundation.Constants.INVALID_HANDLE_VALUE;
+import static com.jcraft.jsch.windowsapi.windows.win32.security.Apis.CopySid;
+import static com.jcraft.jsch.windowsapi.windows.win32.security.Apis.GetLengthSid;
+import static com.jcraft.jsch.windowsapi.windows.win32.security.Apis.GetTokenInformation;
+import static com.jcraft.jsch.windowsapi.windows.win32.security.Apis.InitializeSecurityDescriptor;
+import static com.jcraft.jsch.windowsapi.windows.win32.security.Apis.IsValidSid;
+import static com.jcraft.jsch.windowsapi.windows.win32.security.Apis.SetSecurityDescriptorOwner;
 import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.CreateFileMappingA;
 import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.MapViewOfFile;
 import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.UnmapViewOfFile;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.systemservices.Constants.MAXIMUM_ALLOWED;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.systemservices.Constants.SECURITY_DESCRIPTOR_REVISION;
 import static com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis.GetCurrentProcessId;
-import static com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis.GetCurrentThreadId;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis.OpenProcess;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis.OpenProcessToken;
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.FindWindowA;
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.SendMessageA;
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Constants.WM_COPYDATA;
 
 import com.jcraft.jsch.windowsapi.windows.win32.foundation.WIN32_ERROR;
+import com.jcraft.jsch.windowsapi.windows.win32.security.SECURITY_ATTRIBUTES;
+import com.jcraft.jsch.windowsapi.windows.win32.security.SECURITY_DESCRIPTOR;
+import com.jcraft.jsch.windowsapi.windows.win32.security.SID_AND_ATTRIBUTES;
+import com.jcraft.jsch.windowsapi.windows.win32.security.TOKEN_ACCESS_MASK;
+import com.jcraft.jsch.windowsapi.windows.win32.security.TOKEN_INFORMATION_CLASS;
+import com.jcraft.jsch.windowsapi.windows.win32.security.TOKEN_USER;
 import com.jcraft.jsch.windowsapi.windows.win32.system.dataexchange.COPYDATASTRUCT;
 import com.jcraft.jsch.windowsapi.windows.win32.system.memory.FILE_MAP;
 import com.jcraft.jsch.windowsapi.windows.win32.system.memory.PAGE_PROTECTION_FLAGS;
@@ -46,6 +61,7 @@ import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.VarHandle;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
@@ -70,6 +86,7 @@ public class PageantFFMConnector implements AgentConnector {
 
       // Force class initialization to catch UnsatisfiedLinkError
       Object foo = com.jcraft.jsch.windowsapi.windows.win32.foundation.Apis.CloseHandle$handle();
+      foo = com.jcraft.jsch.windowsapi.windows.win32.security.Apis.CopySid$handle();
       foo = com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.CreateFileMappingA$handle();
       foo = com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis
           .GetCurrentProcessId$handle();
@@ -112,16 +129,28 @@ public class PageantFFMConnector implements AgentConnector {
         throw new AgentProxyException("Pageant is not runnning.");
       }
 
-      String threadId = JavaVersion.getVersion() >= 19
-          ? String.format(Locale.ROOT, "%08x%08x", GetCurrentProcessId(), JavaThreadId.get())
-          : String.format(Locale.ROOT, "%08x", GetCurrentThreadId());
+      MemorySegment usersid = getUserSid(arena, errorState);
+      MemorySegment psd = SECURITY_DESCRIPTOR.allocate(arena);
+      if (InitializeSecurityDescriptor(errorState, psd, SECURITY_DESCRIPTOR_REVISION) == 0) {
+        throw new AgentProxyException("Unable to InitializeSecurityDescriptor(): GetLastError() = "
+            + (int) getLastErrorVarHandle.get(errorState, 0));
+      }
+      if (SetSecurityDescriptorOwner(errorState, psd, usersid, 0) == 0) {
+        throw new AgentProxyException("Unable to SetSecurityDescriptorOwner(): GetLastError() = "
+            + (int) getLastErrorVarHandle.get(errorState, 0));
+      }
+
+      MemorySegment psa = SECURITY_ATTRIBUTES.allocate(arena);
+      SECURITY_ATTRIBUTES.nLength(psa, (int) SECURITY_ATTRIBUTES.sizeof());
+      SECURITY_ATTRIBUTES.bInheritHandle(psa, 1);
+      SECURITY_ATTRIBUTES.lpSecurityDescriptor(psa, psd);
+
+      String threadId = String.format(Locale.ROOT, "%08x%08x", GetCurrentProcessId(),
+          Thread.currentThread().threadId());
       MemorySegment mapname =
           arena.allocateFrom("JSchPageantRequest" + threadId, StandardCharsets.US_ASCII);
 
       try {
-        // TODO
-        MemorySegment psa = MemorySegment.NULL;
-
         sharedFile = CreateFileMappingA(errorState, INVALID_HANDLE_VALUE, psa,
             PAGE_PROTECTION_FLAGS.PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapname);
         int lastError = (int) getLastErrorVarHandle.get(errorState, 0);
@@ -174,6 +203,75 @@ public class PageantFFMConnector implements AgentConnector {
           UnmapViewOfFile(errorState, sharedMemory);
         if (!sharedFile.equals(MemorySegment.NULL))
           CloseHandle(errorState, sharedFile);
+      }
+    }
+  }
+
+  private MemorySegment getUserSid(Arena arena, MemorySegment errorState)
+      throws AgentProxyException {
+    MemorySegment proc = MemorySegment.NULL;
+    MemorySegment tok = MemorySegment.NULL;
+
+    try {
+      proc = OpenProcess(errorState, MAXIMUM_ALLOWED, 0, GetCurrentProcessId());
+      if (proc.equals(MemorySegment.NULL)) {
+        throw new AgentProxyException("Unable to OpenProcess(): GetLastError() = "
+            + (int) getLastErrorVarHandle.get(errorState, 0));
+      }
+
+      MemorySegment ptok = arena.allocate(ValueLayout.ADDRESS);
+      if (OpenProcessToken(errorState, proc, TOKEN_ACCESS_MASK.TOKEN_QUERY, ptok) == 0) {
+        throw new AgentProxyException("Unable to OpenProcessToken(): GetLastError() = "
+            + (int) getLastErrorVarHandle.get(errorState, 0));
+      }
+
+      tok = ptok.get(ValueLayout.ADDRESS, 0);
+      if (tok.equals(MemorySegment.NULL)) {
+        throw new AgentProxyException("ProcessToken is NULL");
+      }
+
+      MemorySegment ptoklen = arena.allocate(ValueLayout.JAVA_INT);
+      if (GetTokenInformation(errorState, tok, TOKEN_INFORMATION_CLASS.TokenUser,
+          MemorySegment.NULL, 0, ptoklen) == 0) {
+        int lastError = (int) getLastErrorVarHandle.get(errorState, 0);
+        if (lastError != WIN32_ERROR.ERROR_INSUFFICIENT_BUFFER) {
+          throw new AgentProxyException(
+              "Unable to GetTokenInformation() toklen: GetLastError() = " + lastError);
+        }
+      }
+
+      long toklen = ptoklen.get(ValueLayout.JAVA_INT, 0) & 0xffffffffL;
+      if (toklen < TOKEN_USER.sizeof()) {
+        throw new AgentProxyException(String.format(Locale.ROOT,
+            "toklen (%d) < sizeof(TOKEN_USER) (%d)", toklen, TOKEN_USER.sizeof()));
+      }
+
+      MemorySegment user = arena.allocate(toklen, ValueLayout.ADDRESS.byteAlignment());
+      if (GetTokenInformation(errorState, tok, TOKEN_INFORMATION_CLASS.TokenUser, user,
+          (int) toklen, ptoklen) == 0) {
+        throw new AgentProxyException("Unable to GetTokenInformation() user: GetLastError() = "
+            + (int) getLastErrorVarHandle.get(errorState, 0));
+      }
+
+      MemorySegment psid = SID_AND_ATTRIBUTES.Sid(TOKEN_USER.User(user));
+      if (IsValidSid(psid) == 0) {
+        throw new AgentProxyException("IsValidSid() failed");
+      }
+
+      long sidlen = GetLengthSid(psid) & 0xffffffffL;
+      MemorySegment usersid = arena.allocate(sidlen, ValueLayout.ADDRESS.byteAlignment());
+      if (CopySid(errorState, (int) sidlen, usersid, psid) == 0) {
+        throw new AgentProxyException("Unable to CopySid(): GetLastError() = "
+            + (int) getLastErrorVarHandle.get(errorState, 0));
+      }
+
+      return usersid;
+    } finally {
+      if (!tok.equals(MemorySegment.NULL)) {
+        CloseHandle(errorState, tok);
+      }
+      if (!proc.equals(MemorySegment.NULL)) {
+        CloseHandle(errorState, proc);
       }
     }
   }

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -199,10 +199,15 @@ public class PageantFFMConnector implements AgentConnector {
               "SendMessage() returned 0 with cds.dwData: " + Long.toHexString(foo));
         }
       } finally {
-        if (!sharedMemory.equals(MemorySegment.NULL))
-          UnmapViewOfFile(errorState, sharedMemory);
-        if (!sharedFile.equals(MemorySegment.NULL))
-          CloseHandle(errorState, sharedFile);
+        try {
+          if (!sharedMemory.equals(MemorySegment.NULL)) {
+            UnmapViewOfFile(errorState, sharedMemory);
+          }
+        } finally {
+          if (!sharedFile.equals(MemorySegment.NULL)) {
+            CloseHandle(errorState, sharedFile);
+          }
+        }
       }
     }
   }
@@ -267,11 +272,14 @@ public class PageantFFMConnector implements AgentConnector {
 
       return usersid;
     } finally {
-      if (!tok.equals(MemorySegment.NULL)) {
-        CloseHandle(errorState, tok);
-      }
-      if (!proc.equals(MemorySegment.NULL)) {
-        CloseHandle(errorState, proc);
+      try {
+        if (!tok.equals(MemorySegment.NULL)) {
+          CloseHandle(errorState, tok);
+        }
+      } finally {
+        if (!proc.equals(MemorySegment.NULL)) {
+          CloseHandle(errorState, proc);
+        }
       }
     }
   }

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -36,6 +36,7 @@ import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Ap
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.SendMessageA;
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Constants.WM_COPYDATA;
 
+import com.jcraft.jsch.windowsapi.windows.win32.foundation.WIN32_ERROR;
 import com.jcraft.jsch.windowsapi.windows.win32.system.dataexchange.COPYDATASTRUCT;
 import com.jcraft.jsch.windowsapi.windows.win32.system.memory.FILE_MAP;
 import com.jcraft.jsch.windowsapi.windows.win32.system.memory.PAGE_PROTECTION_FLAGS;
@@ -120,9 +121,13 @@ public class PageantFFMConnector implements AgentConnector {
 
         sharedFile = CreateFileMappingA(errorState, INVALID_HANDLE_VALUE, psa,
             PAGE_PROTECTION_FLAGS.PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapname);
+        int lastError = (int) getLastErrorVarHandle.get(errorState, 0);
         if (sharedFile.equals(MemorySegment.NULL) || sharedFile.equals(INVALID_HANDLE_VALUE)) {
-          throw new AgentProxyException("Unable to create shared file mapping: GetLastError() = "
-              + (int) getLastErrorVarHandle.get(errorState, 0));
+          throw new AgentProxyException(
+              "Unable to create shared file mapping: GetLastError() = " + lastError);
+        }
+        if (lastError == WIN32_ERROR.ERROR_ALREADY_EXISTS) {
+          throw new AgentProxyException("Shared file mapping already exists");
         }
 
         sharedMemory = MapViewOfFile(errorState, sharedFile, FILE_MAP.WRITE, 0, 0, 0);

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -156,7 +156,7 @@ public class PageantFFMConnector implements AgentConnector {
         int lastError = (int) getLastErrorVarHandle.get(errorState, 0);
         if (sharedFile.equals(MemorySegment.NULL)) {
           throw new AgentProxyException(
-              "Unable to create shared file mapping: GetLastError() = " + lastError);
+              "Unable to CreateFileMapping(): GetLastError() = " + lastError);
         }
         if (lastError == WIN32_ERROR.ERROR_ALREADY_EXISTS) {
           throw new AgentProxyException("Shared file mapping already exists");
@@ -164,7 +164,7 @@ public class PageantFFMConnector implements AgentConnector {
 
         sharedMemory = MapViewOfFile(errorState, sharedFile, FILE_MAP.WRITE, 0, 0, 0);
         if (sharedMemory.equals(MemorySegment.NULL)) {
-          throw new AgentProxyException("Unable to create shared memory mapping: GetLastError() = "
+          throw new AgentProxyException("Unable to MapViewOfFile(): GetLastError() = "
               + (int) getLastErrorVarHandle.get(errorState, 0));
         }
         sharedMemory = sharedMemory.reinterpret(AGENT_MAX_MSGLEN);

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -32,6 +32,7 @@ import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.Create
 import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.MapViewOfFile;
 import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.UnmapViewOfFile;
 import static com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis.GetCurrentProcessId;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis.GetCurrentThreadId;
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.FindWindowA;
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.SendMessageA;
 import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Constants.WM_COPYDATA;
@@ -111,9 +112,11 @@ public class PageantFFMConnector implements AgentConnector {
         throw new AgentProxyException("Pageant is not runnning.");
       }
 
+      String threadId = JavaVersion.getVersion() >= 19
+          ? String.format(Locale.ROOT, "%08x%08x", GetCurrentProcessId(), JavaThreadId.get())
+          : String.format(Locale.ROOT, "%08x", GetCurrentThreadId());
       MemorySegment mapname =
-          arena.allocateFrom(String.format(Locale.ROOT, "JSchPageantRequest%08x%08x",
-              GetCurrentProcessId(), JavaThreadId.get()), StandardCharsets.US_ASCII);
+          arena.allocateFrom("JSchPageantRequest" + threadId, StandardCharsets.US_ASCII);
 
       try {
         // TODO

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -133,11 +133,11 @@ public class PageantFFMConnector implements AgentConnector {
       MemorySegment psd = SECURITY_DESCRIPTOR.allocate(arena);
       if (InitializeSecurityDescriptor(errorState, psd, SECURITY_DESCRIPTOR_REVISION) == 0) {
         throw new AgentProxyException("Unable to InitializeSecurityDescriptor(): GetLastError() = "
-            + (int) getLastErrorVarHandle.get(errorState, 0));
+            + GetLastError(errorState));
       }
       if (SetSecurityDescriptorOwner(errorState, psd, usersid, 0) == 0) {
-        throw new AgentProxyException("Unable to SetSecurityDescriptorOwner(): GetLastError() = "
-            + (int) getLastErrorVarHandle.get(errorState, 0));
+        throw new AgentProxyException(
+            "Unable to SetSecurityDescriptorOwner(): GetLastError() = " + GetLastError(errorState));
       }
 
       MemorySegment psa = SECURITY_ATTRIBUTES.allocate(arena);
@@ -153,7 +153,7 @@ public class PageantFFMConnector implements AgentConnector {
       try {
         sharedFile = CreateFileMappingA(errorState, INVALID_HANDLE_VALUE, psa,
             PAGE_PROTECTION_FLAGS.PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapname);
-        int lastError = (int) getLastErrorVarHandle.get(errorState, 0);
+        int lastError = GetLastError(errorState);
         if (sharedFile.equals(MemorySegment.NULL)) {
           throw new AgentProxyException(
               "Unable to CreateFileMapping(): GetLastError() = " + lastError);
@@ -164,8 +164,8 @@ public class PageantFFMConnector implements AgentConnector {
 
         sharedMemory = MapViewOfFile(errorState, sharedFile, FILE_MAP.WRITE, 0, 0, 0);
         if (sharedMemory.equals(MemorySegment.NULL)) {
-          throw new AgentProxyException("Unable to MapViewOfFile(): GetLastError() = "
-              + (int) getLastErrorVarHandle.get(errorState, 0));
+          throw new AgentProxyException(
+              "Unable to MapViewOfFile(): GetLastError() = " + GetLastError(errorState));
         }
         sharedMemory = sharedMemory.reinterpret(AGENT_MAX_MSGLEN);
 
@@ -215,14 +215,14 @@ public class PageantFFMConnector implements AgentConnector {
     try {
       proc = OpenProcess(errorState, MAXIMUM_ALLOWED, 0, GetCurrentProcessId());
       if (proc.equals(MemorySegment.NULL)) {
-        throw new AgentProxyException("Unable to OpenProcess(): GetLastError() = "
-            + (int) getLastErrorVarHandle.get(errorState, 0));
+        throw new AgentProxyException(
+            "Unable to OpenProcess(): GetLastError() = " + GetLastError(errorState));
       }
 
       MemorySegment ptok = arena.allocate(ValueLayout.ADDRESS);
       if (OpenProcessToken(errorState, proc, TOKEN_ACCESS_MASK.TOKEN_QUERY, ptok) == 0) {
-        throw new AgentProxyException("Unable to OpenProcessToken(): GetLastError() = "
-            + (int) getLastErrorVarHandle.get(errorState, 0));
+        throw new AgentProxyException(
+            "Unable to OpenProcessToken(): GetLastError() = " + GetLastError(errorState));
       }
 
       tok = ptok.get(ValueLayout.ADDRESS, 0);
@@ -233,7 +233,7 @@ public class PageantFFMConnector implements AgentConnector {
       MemorySegment ptoklen = arena.allocate(ValueLayout.JAVA_INT);
       if (GetTokenInformation(errorState, tok, TOKEN_INFORMATION_CLASS.TokenUser,
           MemorySegment.NULL, 0, ptoklen) == 0) {
-        int lastError = (int) getLastErrorVarHandle.get(errorState, 0);
+        int lastError = GetLastError(errorState);
         if (lastError != WIN32_ERROR.ERROR_INSUFFICIENT_BUFFER) {
           throw new AgentProxyException(
               "Unable to GetTokenInformation() toklen: GetLastError() = " + lastError);
@@ -249,8 +249,8 @@ public class PageantFFMConnector implements AgentConnector {
       MemorySegment user = arena.allocate(toklen, ValueLayout.ADDRESS.byteAlignment());
       if (GetTokenInformation(errorState, tok, TOKEN_INFORMATION_CLASS.TokenUser, user,
           (int) toklen, ptoklen) == 0) {
-        throw new AgentProxyException("Unable to GetTokenInformation() user: GetLastError() = "
-            + (int) getLastErrorVarHandle.get(errorState, 0));
+        throw new AgentProxyException(
+            "Unable to GetTokenInformation() user: GetLastError() = " + GetLastError(errorState));
       }
 
       MemorySegment psid = SID_AND_ATTRIBUTES.Sid(TOKEN_USER.User(user));
@@ -261,8 +261,8 @@ public class PageantFFMConnector implements AgentConnector {
       long sidlen = GetLengthSid(psid) & 0xffffffffL;
       MemorySegment usersid = arena.allocate(sidlen, ValueLayout.ADDRESS.byteAlignment());
       if (CopySid(errorState, (int) sidlen, usersid, psid) == 0) {
-        throw new AgentProxyException("Unable to CopySid(): GetLastError() = "
-            + (int) getLastErrorVarHandle.get(errorState, 0));
+        throw new AgentProxyException(
+            "Unable to CopySid(): GetLastError() = " + GetLastError(errorState));
       }
 
       return usersid;
@@ -274,5 +274,9 @@ public class PageantFFMConnector implements AgentConnector {
         CloseHandle(errorState, proc);
       }
     }
+  }
+
+  private int GetLastError(MemorySegment errorState) {
+    return (int) getLastErrorVarHandle.get(errorState, 0);
   }
 }

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2011 ymnk, JCraft,Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. The names of the authors may not be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcraft.jsch;
+
+import static com.jcraft.jsch.windowsapi.windows.win32.foundation.Apis.CloseHandle;
+import static com.jcraft.jsch.windowsapi.windows.win32.foundation.Constants.INVALID_HANDLE_VALUE;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.CreateFileMappingA;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.MapViewOfFile;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.UnmapViewOfFile;
+import static com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis.GetCurrentProcessId;
+import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.FindWindowA;
+import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.SendMessageA;
+import static com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Constants.WM_COPYDATA;
+
+import com.jcraft.jsch.windowsapi.windows.win32.system.dataexchange.COPYDATASTRUCT;
+import com.jcraft.jsch.windowsapi.windows.win32.system.memory.FILE_MAP;
+import com.jcraft.jsch.windowsapi.windows.win32.system.memory.PAGE_PROTECTION_FLAGS;
+import java.lang.foreign.Arena;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.invoke.VarHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+public class PageantFFMConnector implements AgentConnector {
+
+  private static final int AGENT_MAX_MSGLEN = 262144;
+  private static final long AGENT_COPYDATA_ID = 0x804e50baL;
+
+  private final StructLayout errorStateLayout;
+  private final VarHandle getLastErrorVarHandle;
+
+  public PageantFFMConnector() throws AgentProxyException {
+    if (!Util.getSystemProperty("os.name", "").startsWith("Windows")) {
+      throw new AgentProxyException("PageantFFMConnector only available on Windows.");
+    }
+
+    try {
+      errorStateLayout = Linker.Option.captureStateLayout();
+      getLastErrorVarHandle =
+          errorStateLayout.varHandle(MemoryLayout.PathElement.groupElement("GetLastError"));
+
+      // Force class initialization to catch UnsatisfiedLinkError
+      Object foo = com.jcraft.jsch.windowsapi.windows.win32.foundation.Apis.CloseHandle$handle();
+      foo = com.jcraft.jsch.windowsapi.windows.win32.system.memory.Apis.CreateFileMappingA$handle();
+      foo = com.jcraft.jsch.windowsapi.windows.win32.system.threading.Apis
+          .GetCurrentProcessId$handle();
+      foo =
+          com.jcraft.jsch.windowsapi.windows.win32.ui.windowsandmessaging.Apis.FindWindowA$handle();
+    } catch (IllegalArgumentException | LinkageError e) {
+      throw new AgentProxyException(e.toString(), e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "pageant_ffm";
+  }
+
+  @Override
+  public boolean isAvailable() {
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment errorState = arena.allocate(errorStateLayout);
+      MemorySegment pageant = arena.allocateFrom("Pageant", StandardCharsets.US_ASCII);
+      return !FindWindowA(errorState, pageant, pageant).equals(MemorySegment.NULL);
+    }
+  }
+
+  @Override
+  public void query(Buffer buffer) throws AgentProxyException {
+    if (buffer.getLength() > AGENT_MAX_MSGLEN) {
+      throw new AgentProxyException("Query too large.");
+    }
+
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment sharedFile = MemorySegment.NULL;
+      MemorySegment sharedMemory = MemorySegment.NULL;
+      MemorySegment errorState = arena.allocate(errorStateLayout);
+      MemorySegment pageant = arena.allocateFrom("Pageant", StandardCharsets.US_ASCII);
+
+      MemorySegment hwnd = FindWindowA(errorState, pageant, pageant);
+
+      if (hwnd.equals(MemorySegment.NULL)) {
+        throw new AgentProxyException("Pageant is not runnning.");
+      }
+
+      MemorySegment mapname =
+          arena.allocateFrom(String.format(Locale.ROOT, "JSchPageantRequest%08x%08x",
+              GetCurrentProcessId(), JavaThreadId.get()), StandardCharsets.US_ASCII);
+
+      try {
+        // TODO
+        MemorySegment psa = MemorySegment.NULL;
+
+        sharedFile = CreateFileMappingA(errorState, INVALID_HANDLE_VALUE, psa,
+            PAGE_PROTECTION_FLAGS.PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapname);
+        if (sharedFile.equals(MemorySegment.NULL) || sharedFile.equals(INVALID_HANDLE_VALUE)) {
+          throw new AgentProxyException("Unable to create shared file mapping: GetLastError() = "
+              + (int) getLastErrorVarHandle.get(errorState, 0));
+        }
+
+        sharedMemory = MapViewOfFile(errorState, sharedFile, FILE_MAP.WRITE, 0, 0, 0);
+        if (sharedMemory.equals(MemorySegment.NULL)) {
+          throw new AgentProxyException("Unable to create shared memory mapping: GetLastError() = "
+              + (int) getLastErrorVarHandle.get(errorState, 0));
+        }
+        sharedMemory = sharedMemory.reinterpret(AGENT_MAX_MSGLEN);
+
+        MemorySegment buf = MemorySegment.ofArray(buffer.buffer);
+        MemorySegment.copy(buf, 0, sharedMemory, 0, buffer.getLength());
+
+        MemorySegment cds = COPYDATASTRUCT.allocate(arena);
+        COPYDATASTRUCT.dwData(cds, AGENT_COPYDATA_ID);
+        COPYDATASTRUCT.cbData(cds, (int) mapname.byteSize());
+        COPYDATASTRUCT.lpData(cds, mapname);
+
+        long rcode = SendMessageA(errorState, hwnd, WM_COPYDATA, MemorySegment.NULL.address(),
+            cds.address());
+        // Dummy read to make sure COPYDATASTRUCT isn't GC'd early
+        long foo = COPYDATASTRUCT.dwData(cds);
+
+        buffer.rewind();
+        if (rcode != 0) {
+          MemorySegment.copy(sharedMemory, 0, buf, 0, 4); // length
+          int i = buffer.getInt();
+          if (i <= 0 || i > AGENT_MAX_MSGLEN - 4) {
+            throw new AgentProxyException("Illegal length: " + i);
+          }
+          buffer.rewind();
+          buffer.checkFreeSize(i);
+          // checkFreeSize may have created a new array
+          buf = MemorySegment.ofArray(buffer.buffer);
+          MemorySegment.copy(sharedMemory, 4, buf, 0, i);
+        } else {
+          throw new AgentProxyException(
+              "SendMessage() returned 0 with cds.dwData: " + Long.toHexString(foo));
+        }
+      } finally {
+        if (!sharedMemory.equals(MemorySegment.NULL))
+          UnmapViewOfFile(errorState, sharedMemory);
+        if (!sharedFile.equals(MemorySegment.NULL) && !sharedFile.equals(INVALID_HANDLE_VALUE))
+          CloseHandle(errorState, sharedFile);
+      }
+    }
+  }
+}

--- a/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
+++ b/src/main/java23/com/jcraft/jsch/PageantFFMConnector.java
@@ -122,7 +122,7 @@ public class PageantFFMConnector implements AgentConnector {
         sharedFile = CreateFileMappingA(errorState, INVALID_HANDLE_VALUE, psa,
             PAGE_PROTECTION_FLAGS.PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapname);
         int lastError = (int) getLastErrorVarHandle.get(errorState, 0);
-        if (sharedFile.equals(MemorySegment.NULL) || sharedFile.equals(INVALID_HANDLE_VALUE)) {
+        if (sharedFile.equals(MemorySegment.NULL)) {
           throw new AgentProxyException(
               "Unable to create shared file mapping: GetLastError() = " + lastError);
         }
@@ -169,7 +169,7 @@ public class PageantFFMConnector implements AgentConnector {
       } finally {
         if (!sharedMemory.equals(MemorySegment.NULL))
           UnmapViewOfFile(errorState, sharedMemory);
-        if (!sharedFile.equals(MemorySegment.NULL) && !sharedFile.equals(INVALID_HANDLE_VALUE))
+        if (!sharedFile.equals(MemorySegment.NULL))
           CloseHandle(errorState, sharedFile);
       }
     }


### PR DESCRIPTION
This adds support for using Pageant using the [JEP 454](https://openjdk.org/jeps/454) FFM API with Java 23+ as an alternative to using JNA.

Additionally, include a few minor updates & fixes to the existing JNA based `PageantConnector`.

To use the new `PageantFFMConnector`, users will need to pass an argument of `--enable-native-access=ALL-UNNAMED` (if JSch is on the classpath) or `--enable-native-access=com.jcraft.jsch` (if JSch is on the modulepath).