### PR TITLE
Fix typo in README: 'How to you use' → 'How do you use'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ Not much. Check the example code in the [examples](https://github.com/mwiede/jsc
 
 Up until `0.2.26` the versioning followed the original jsch scheme, from `2.27.0` on, we switched to [semantic versioning](https://semver.org), expressing that the library api is stable and used in production.
 
-## How to you use this library as a replacement for `com.jcraft:jsch`
+## How do you use this library as a replacement for `com.jcraft:jsch`
 
 Make sure, that you only have one jsch dependency on your classpath. For example you can check the output of `mvn dependency:tree`.
 


### PR DESCRIPTION
Fixed a small grammatical typo in the README.

Changed:
"How to you use this library..."
to
"How do you use this library..."

This improves readability and correctness of the documentation.