### PR TITLE
Fix #1045: RSA certificate auth ignores negotiated signature algorithm

### DIFF
--- a/src/main/java/com/jcraft/jsch/OpenSshCertificateAwareIdentityFile.java
+++ b/src/main/java/com/jcraft/jsch/OpenSshCertificateAwareIdentityFile.java
@@ -218,9 +218,11 @@ class OpenSshCertificateAwareIdentityFile implements Identity {
 
   @Override
   public byte[] getSignature(byte[] data, String alg) {
-    String rawKeyType = OpenSshCertificateUtil.getRawKeyType(keyType);
-    // Fall back to keyType if rawKeyType is null (defensive check)
-    return kpair.getSignature(data, rawKeyType != null ? rawKeyType : keyType);
+    String sigAlg = OpenSshCertificateUtil.getRawKeyType(alg);
+    if (sigAlg == null || sigAlg.isEmpty()) {
+      sigAlg = OpenSshCertificateUtil.getRawKeyType(keyType);
+    }
+    return kpair.getSignature(data, sigAlg != null ? sigAlg : keyType);
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/UserAuthPublicKey.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthPublicKey.java
@@ -134,6 +134,7 @@ class UserAuthPublicKey extends UserAuth {
         session.getConfig("try_additional_pubkey_algorithms").equals("yes");
 
     List<String> rsamethods = new ArrayList<>();
+    List<String> rsacertmethods = new ArrayList<>();
     List<String> nonrsamethods = new ArrayList<>();
     for (String pkmethod : pkmethods) {
       if (pkmethod.equals("ssh-rsa") || pkmethod.equals("rsa-sha2-256")
@@ -141,6 +142,10 @@ class UserAuthPublicKey extends UserAuth {
           || pkmethod.equals("ssh-rsa-sha256@ssh.com") || pkmethod.equals("ssh-rsa-sha384@ssh.com")
           || pkmethod.equals("ssh-rsa-sha512@ssh.com")) {
         rsamethods.add(pkmethod);
+      } else if (pkmethod.equals("ssh-rsa-cert-v01@openssh.com")
+          || pkmethod.equals("rsa-sha2-256-cert-v01@openssh.com")
+          || pkmethod.equals("rsa-sha2-512-cert-v01@openssh.com")) {
+        rsacertmethods.add(pkmethod);
       } else {
         nonrsamethods.add(pkmethod);
       }
@@ -164,6 +169,8 @@ class UserAuthPublicKey extends UserAuth {
       List<String> ipkmethods = null;
       if (_ipkmethod.equals("ssh-rsa")) {
         ipkmethods = new ArrayList<>(rsamethods);
+      } else if (_ipkmethod.equals("ssh-rsa-cert-v01@openssh.com")) {
+        ipkmethods = new ArrayList<>(rsacertmethods);
       } else if (nonrsamethods.contains(_ipkmethod)) {
         ipkmethods = new ArrayList<>(1);
         ipkmethods.add(_ipkmethod);

--- a/src/test/java/com/jcraft/jsch/OpenSshCertificateAwareIdentityFileTest.java
+++ b/src/test/java/com/jcraft/jsch/OpenSshCertificateAwareIdentityFileTest.java
@@ -1,6 +1,8 @@
 package com.jcraft.jsch;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -387,5 +389,67 @@ public class OpenSshCertificateAwareIdentityFileTest {
         exceptionMessage.toLowerCase(Locale.ROOT).contains("mismatch")
             || exceptionMessage.contains("does not match"),
         "Exception message should indicate key type mismatch: " + exceptionMessage);
+  }
+
+  @Test
+  public void testGetSignature_usesRsaSha2_512WhenCertAlgProvided() throws Exception {
+    Identity identity = loadRsaCertIdentity();
+    byte[] data = "test data to sign".getBytes(StandardCharsets.UTF_8);
+
+    byte[] signature = identity.getSignature(data, "rsa-sha2-512-cert-v01@openssh.com");
+
+    assertNotNull(signature, "Signature should not be null");
+    String sigAlg = extractSignatureAlgorithm(signature);
+    assertEquals("rsa-sha2-512", sigAlg, "Signature should use rsa-sha2-512, not ssh-rsa (SHA-1)");
+  }
+
+  @Test
+  public void testGetSignature_usesRsaSha2_256WhenCertAlgProvided() throws Exception {
+    Identity identity = loadRsaCertIdentity();
+    byte[] data = "test data to sign".getBytes(StandardCharsets.UTF_8);
+
+    byte[] signature = identity.getSignature(data, "rsa-sha2-256-cert-v01@openssh.com");
+
+    assertNotNull(signature, "Signature should not be null");
+    String sigAlg = extractSignatureAlgorithm(signature);
+    assertEquals("rsa-sha2-256", sigAlg, "Signature should use rsa-sha2-256, not ssh-rsa (SHA-1)");
+  }
+
+  @Test
+  public void testGetSignature_usesRsaSha2_512WhenBaseAlgProvided() throws Exception {
+    Identity identity = loadRsaCertIdentity();
+    byte[] data = "test data to sign".getBytes(StandardCharsets.UTF_8);
+
+    byte[] signature = identity.getSignature(data, "rsa-sha2-512");
+
+    assertNotNull(signature, "Signature should not be null");
+    String sigAlg = extractSignatureAlgorithm(signature);
+    assertEquals("rsa-sha2-512", sigAlg);
+  }
+
+  @Test
+  public void testGetSignature_fallsBackToSshRsaWhenAlgIsNull() throws Exception {
+    Identity identity = loadRsaCertIdentity();
+    byte[] data = "test data to sign".getBytes(StandardCharsets.UTF_8);
+
+    byte[] signature = identity.getSignature(data, null);
+
+    assertNotNull(signature, "Signature should not be null");
+    String sigAlg = extractSignatureAlgorithm(signature);
+    assertEquals("ssh-rsa", sigAlg, "Signature should fall back to ssh-rsa when alg is null");
+  }
+
+  private Identity loadRsaCertIdentity() throws JSchException {
+    JSch jsch = new JSch();
+    String privateKeyPath = "src/test/resources/certificates/rsa/root_rsa_key";
+    String certificatePath = "src/test/resources/certificates/rsa/root_rsa_key-cert.pub";
+    return OpenSshCertificateAwareIdentityFile.newInstance(privateKeyPath, certificatePath,
+        jsch.instLogger);
+  }
+
+  private String extractSignatureAlgorithm(byte[] signatureBlob) {
+    Buffer buf = new Buffer(signatureBlob);
+    byte[] algBytes = buf.getString();
+    return Util.byte2str(algBytes, StandardCharsets.UTF_8);
   }
 }

--- a/src/test/java/com/jcraft/jsch/UserCertAuthIT.java
+++ b/src/test/java/com/jcraft/jsch/UserCertAuthIT.java
@@ -172,6 +172,34 @@ public class UserCertAuthIT {
     doSftp(session);
   }
 
+  /**
+   * Tests RSA certificate authentication using the default {@code PubkeyAcceptedAlgorithms}, which
+   * excludes {@code ssh-rsa-cert-v01@openssh.com} (following OpenSSH defaults). This verifies that
+   * the RSA certificate identity is correctly mapped to SHA-2 certificate algorithm variants
+   * ({@code rsa-sha2-512-cert-v01@openssh.com}, {@code rsa-sha2-256-cert-v01@openssh.com}) and that
+   * the signature uses the negotiated algorithm instead of falling back to {@code ssh-rsa} (SHA-1).
+   *
+   * @throws Exception if any error occurs during key reading, session setup, or connection.
+   */
+  @Test
+  public void opensshCertificateRsaSha2CertTest() throws Exception {
+    HostKey hostKey = readHostKey(
+        ResourceUtil.getResourceFile(this.getClass(), "certificates/docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.addIdentity(ResourceUtil.getResourceFile(this.getClass(), "certificates/rsa/root_rsa_key"),
+        ResourceUtil.getResourceFile(this.getClass(), "certificates/rsa/root_rsa_key-cert.pub"),
+        null);
+    ssh.getHostKeyRepository().add(hostKey, null);
+
+    Session session = ssh.getSession("root", sshd.getHost(), sshd.getFirstMappedPort());
+    session.setConfig("enable_auth_none", "yes");
+    session.setConfig("StrictHostKeyChecking", "no");
+    session.setConfig("PreferredAuthentications", "publickey");
+    session.setConfig("server_host_key",
+        "ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,rsa-sha2-512,rsa-sha2-256");
+    doSftp(session);
+  }
+
   private Session createEd25519CertSession() throws Exception {
     HostKey hostKey = readHostKey(
         ResourceUtil.getResourceFile(this.getClass(), "certificates/docker/ssh_host_rsa_key.pub"));


### PR DESCRIPTION
## Summary
- Fix `OpenSshCertificateAwareIdentityFile.getSignature()` to use the
  negotiated `alg` parameter instead of always signing with `ssh-rsa` (SHA-1)
- Fix `UserAuthPublicKey._start()` to map `ssh-rsa-cert-v01@openssh.com`
  identities to SHA-2 certificate variants (`rsa-sha2-512-cert-v01@openssh.com`,
  `rsa-sha2-256-cert-v01@openssh.com`), matching the existing fan-out for
  plain RSA identities

## Test plan
- [x] Unit tests verifying `getSignature` uses correct algorithm from `alg` parameter
- [x] Integration test verifying RSA cert auth with default `PubkeyAcceptedAlgorithms`
  (no `ssh-rsa-cert-v01@openssh.com` workaround)
- [x] All existing tests pass