### PR TITLE
Make Channel and Session implement AutoClosable

### DIFF
--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -33,7 +33,7 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public abstract class Channel {
+public abstract class Channel implements AutoCloseable {
 
   static final int SSH_MSG_CHANNEL_OPEN_CONFIRMATION = 91;
   static final int SSH_MSG_CHANNEL_OPEN_FAILURE = 92;
@@ -515,7 +515,7 @@ public abstract class Channel {
    * destination, if possible.
    */
 
-  void close() {
+  public void close() {
     if (close)
       return;
     close = true;

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -46,7 +46,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.crypto.AEADBadTagException;
 
-public class Session {
+public class Session implements AutoCloseable {
 
   // http://ietf.org/internet-drafts/draft-ietf-secsh-assignednumbers-01.txt
   static final int SSH_MSG_DISCONNECT = 1;
@@ -204,6 +204,9 @@ public class Session {
     }
   }
 
+  public void close() {
+    this.disconnect();
+  }
   public void connect() throws JSchException {
     connect(timeout);
   }


### PR DESCRIPTION
I would argue that both Channel and Session should implement AutoCloseable to enable try-with-resources usage.

However, I'm not entirely sure if my suggested implementation is correct—especially for Channel. I can see a scenario where disconnect() should be the function called during the implicit close.