### PR TITLE
Fix #1091: Parse certificate-form revoked host keys

### DIFF
--- a/src/main/java/com/jcraft/jsch/KnownHosts.java
+++ b/src/main/java/com/jcraft/jsch/KnownHosts.java
@@ -252,24 +252,13 @@ class KnownHosts implements HostKeyRepository {
         // System.err.println(host);
         // System.err.println("|"+key+"|");
 
-        byte[] keyData;
         if (revokedCertificate) {
-          try {
-            OpenSshCertificate certificate = OpenSshCertificateParser.parse(jsch.instLogger,
-                Util.fromBase64(Util.str2byte(key), 0, key.length()));
-            keyData = certificate.getCertificatePublicKey();
-            type = HostKey.name2type(Util.byte2str(new Buffer(keyData).getString()));
-            if (type == HostKey.UNKNOWN || type != getCertificateBaseType(keyType)) {
-              throw new JSchException("Certificate key type does not match known_hosts key type");
-            }
-          } catch (JSchException | RuntimeException e) {
-            addInvalidLine(Util.byte2str(buf, 0, bufl));
-            continue loop;
-          }
-        } else {
-          keyData = Util.fromBase64(Util.str2byte(key), 0, key.length());
+          addRevokedCertificateHostKey(Util.byte2str(buf, 0, bufl), marker, host, keyType, key,
+              comment);
+          continue loop;
         }
 
+        byte[] keyData = Util.fromBase64(Util.str2byte(key), 0, key.length());
         pool.addElement(new HashedHostKey(marker, host, type, keyData, comment));
       }
       if (error) {
@@ -285,6 +274,28 @@ class KnownHosts implements HostKeyRepository {
   private void addInvalidLine(String line) throws JSchException {
     HostKey hk = new HostKey(line, HostKey.UNKNOWN, null);
     pool.addElement(hk);
+  }
+
+  // Unnamed catch variables require Java 22, but this source set targets Java 8.
+  @SuppressWarnings("java:S7467")
+  private void addRevokedCertificateHostKey(String line, String marker, String host, String keyType,
+      String key, String comment) throws JSchException {
+    byte[] keyData;
+    int type;
+    try {
+      OpenSshCertificate certificate = OpenSshCertificateParser.parse(jsch.instLogger,
+          Util.fromBase64(Util.str2byte(key), 0, key.length()));
+      keyData = certificate.getCertificatePublicKey();
+      type = HostKey.name2type(Util.byte2str(new Buffer(keyData).getString()));
+      if (type == HostKey.UNKNOWN || type != getCertificateBaseType(keyType)) {
+        throw new JSchException("Certificate key type does not match known_hosts key type");
+      }
+    } catch (JSchException | RuntimeException ignored) {
+      addInvalidLine(line);
+      return;
+    }
+
+    pool.addElement(new HashedHostKey(marker, host, type, keyData, comment));
   }
 
   private static int getCertificateBaseType(String keyType) {

--- a/src/main/java/com/jcraft/jsch/KnownHosts.java
+++ b/src/main/java/com/jcraft/jsch/KnownHosts.java
@@ -169,7 +169,6 @@ class KnownHosts implements HostKeyRepository {
         }
 
         sb.setLength(0);
-        type = -1;
         while (j < bufl) {
           i = buf[j++];
           if (i == 0x20 || i == '\t') {
@@ -177,10 +176,11 @@ class KnownHosts implements HostKeyRepository {
           }
           sb.append((char) i);
         }
-        String tmp = sb.toString();
-        if (HostKey.name2type(tmp) != HostKey.UNKNOWN) {
-          type = HostKey.name2type(tmp);
-        } else {
+        String keyType = sb.toString();
+        boolean revokedCertificate =
+            "@revoked".equals(marker) && OpenSshCertificateKeyTypes.isCertificateKeyType(keyType);
+        type = HostKey.name2type(keyType);
+        if (type == HostKey.UNKNOWN && !revokedCertificate) {
           j = bufl;
         }
         if (j >= bufl) {
@@ -252,10 +252,25 @@ class KnownHosts implements HostKeyRepository {
         // System.err.println(host);
         // System.err.println("|"+key+"|");
 
-        HostKey hk = null;
-        hk = new HashedHostKey(marker, host, type,
-            Util.fromBase64(Util.str2byte(key), 0, key.length()), comment);
-        pool.addElement(hk);
+        byte[] keyData;
+        if (revokedCertificate) {
+          try {
+            OpenSshCertificate certificate = OpenSshCertificateParser.parse(jsch.instLogger,
+                Util.fromBase64(Util.str2byte(key), 0, key.length()));
+            keyData = certificate.getCertificatePublicKey();
+            type = HostKey.name2type(Util.byte2str(new Buffer(keyData).getString()));
+            if (type == HostKey.UNKNOWN || type != getCertificateBaseType(keyType)) {
+              throw new JSchException("Certificate key type does not match known_hosts key type");
+            }
+          } catch (JSchException | RuntimeException e) {
+            addInvalidLine(Util.byte2str(buf, 0, bufl));
+            continue loop;
+          }
+        } else {
+          keyData = Util.fromBase64(Util.str2byte(key), 0, key.length());
+        }
+
+        pool.addElement(new HashedHostKey(marker, host, type, keyData, comment));
       }
       if (error) {
         throw new JSchException("KnownHosts: invalid format");
@@ -270,6 +285,14 @@ class KnownHosts implements HostKeyRepository {
   private void addInvalidLine(String line) throws JSchException {
     HostKey hk = new HostKey(line, HostKey.UNKNOWN, null);
     pool.addElement(hk);
+  }
+
+  private static int getCertificateBaseType(String keyType) {
+    String baseType = OpenSshCertificateKeyTypes.getBaseKeyType(keyType);
+    if ("rsa-sha2-256".equals(baseType) || "rsa-sha2-512".equals(baseType)) {
+      return HostKey.SSHRSA;
+    }
+    return HostKey.name2type(baseType);
   }
 
   String getKnownHostsFile() {

--- a/src/test/java/com/jcraft/jsch/KnownHostsTest.java
+++ b/src/test/java/com/jcraft/jsch/KnownHostsTest.java
@@ -289,6 +289,30 @@ class KnownHostsTest {
   }
 
   @Test
+  void testSetKnownHostsPreservesInvalidRevokedCertificates() throws Exception {
+    String certificateLine = new String(
+        Util.fromFile("src/test/resources/certificates/host/ssh_host_ed25519_key-cert.pub"), UTF_8)
+        .trim();
+    String mismatchedLine = "@revoked localhost ecdsa-sha2-nistp256-cert-v01@openssh.com"
+        + certificateLine.substring(certificateLine.indexOf(' '));
+    String malformedLine = "@revoked localhost ssh-ed25519-cert-v01@openssh.com AAAA";
+    String validLine = "localhost ssh-rsa " + rsaKey;
+
+    KnownHosts kh = new KnownHosts(jsch);
+    kh.setKnownHosts(new ByteArrayInputStream(
+        (mismatchedLine + "\n" + malformedLine + "\n" + validLine).getBytes(UTF_8)));
+
+    HostKey[] keys = kh.getHostKey();
+    assertEquals(1, keys.length);
+    assertEquals("ssh-rsa", keys[0].getType());
+
+    ByteArrayOutputStream dump = new ByteArrayOutputStream();
+    kh.dump(dump);
+    assertEquals(mismatchedLine + "\n" + malformedLine + "\n" + validLine + "\n",
+        dump.toString("UTF8"));
+  }
+
+  @Test
   void testkSyncDump() throws Exception {
     KnownHosts kh = new KnownHosts(jsch) {
       @Override

--- a/src/test/java/com/jcraft/jsch/OpenSshCertificateHostKeyVerifierTest.java
+++ b/src/test/java/com/jcraft/jsch/OpenSshCertificateHostKeyVerifierTest.java
@@ -3,13 +3,18 @@ package com.jcraft.jsch;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Unit tests for OpenSshCertificateHostKeyVerifier focusing on certificate validation edge cases.
@@ -182,6 +187,32 @@ public class OpenSshCertificateHostKeyVerifierTest {
         "ssh-ed25519"));
     assertFalse(OpenSshCertificateHostKeyVerifier
         .isSignatureAlgorithmCompatible("ecdsa-sha2-nistp256", "rsa-sha2-512"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"ssh_host_ed25519_key-cert.pub, ssh-ed25519-cert-v01@openssh.com",
+      "ssh_host_ecdsa_key-cert.pub, ecdsa-sha2-nistp256-cert-v01@openssh.com",
+      "ssh_host_rsa_key-cert.pub, rsa-sha2-256-cert-v01@openssh.com",
+      "ssh_host_rsa_key-cert.pub, rsa-sha2-512-cert-v01@openssh.com"})
+  public void testCheckHostCertificate_withCertificateTypeRevocation_shouldReject(
+      String certificateFile, String knownHostsKeyType) throws Exception {
+    String certificatePath = "src/test/resources/certificates/host/" + certificateFile;
+    String certificateLine =
+        new String(Util.fromFile(certificatePath), StandardCharsets.UTF_8).trim();
+    certificateLine = knownHostsKeyType + certificateLine.substring(certificateLine.indexOf(' '));
+    String knownHosts = new String(Util.fromFile("src/test/resources/certificates/known_hosts"),
+        StandardCharsets.UTF_8) + "\n@revoked localhost " + certificateLine;
+
+    JSch jsch = new JSch();
+    jsch.setKnownHosts(new ByteArrayInputStream(knownHosts.getBytes(StandardCharsets.UTF_8)));
+
+    OpenSshCertificate certificate = parseCertificate(certificatePath);
+    assertEquals(HostKeyRepository.OK,
+        jsch.getHostKeyRepository().check("localhost", certificate.getCertificatePublicKey()));
+
+    Session session = jsch.getSession("user", "localhost");
+    assertThrows(JSchRevokedHostKeyException.class,
+        () -> OpenSshCertificateHostKeyVerifier.checkHostCertificate(session, certificate));
   }
 
   // ==================== Helper methods ====================


### PR DESCRIPTION
## Summary

- parse supported certificate-form `@revoked` entries into their embedded base public keys
- validate the declared and embedded key families, including RSA SHA-2 aliases
- preserve malformed or mismatched certificate entries without interrupting later parsing
- add regression coverage for Ed25519, ECDSA, RSA SHA-2, and invalid certificate records

Fixes #1091

## Testing

- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./mvnw -B clean install`
- 478 tests passed
