### PR TITLE
Fix #1099: Respect known_hosts markers

### DIFF
--- a/src/main/java/com/jcraft/jsch/HostKey.java
+++ b/src/main/java/com/jcraft/jsch/HostKey.java
@@ -65,7 +65,7 @@ public class HostKey {
 
   public HostKey(String marker, String host, int type, byte[] key, String comment)
       throws JSchException {
-    this.marker = marker;
+    this.marker = marker == null ? "" : marker;
     this.host = host;
     if (type == GUESS) {
       if (key[8] == 'd') {

--- a/src/main/java/com/jcraft/jsch/HostKeyRepository.java
+++ b/src/main/java/com/jcraft/jsch/HostKeyRepository.java
@@ -51,15 +51,25 @@ public interface HostKeyRepository {
   void add(HostKey hostkey, UserInfo ui);
 
   /**
-   * Removes a host key if there exists mached key with <code>host</code>, <code>type</code>.
+   * Removes host keys matching <code>host</code> and <code>type</code>.
+   *
+   * <p>
+   * When both arguments are non-null, entries with a non-empty marker are preserved. A null
+   * <code>host</code> clears the repository, while a null <code>type</code> removes all keys
+   * matching <code>host</code>, including marked entries.
    *
    * @see #remove(String host, String type, byte[] key)
    */
   void remove(String host, String type);
 
   /**
-   * Removes a host key if there exists a matched key with <code>host</code>, <code>type</code> and
-   * <code>key</code>.
+   * Removes host keys matching <code>host</code>, <code>type</code> and <code>key</code>.
+   *
+   * <p>
+   * When <code>host</code> and <code>type</code> are non-null and <code>key</code> is null, entries
+   * with a non-empty marker are preserved. A non-null matching <code>key</code> also removes marked
+   * entries. A null <code>host</code> clears the repository, while a null <code>type</code> removes
+   * all keys matching <code>host</code>, including marked entries.
    */
   void remove(String host, String type, byte[] key);
 

--- a/src/main/java/com/jcraft/jsch/KnownHosts.java
+++ b/src/main/java/com/jcraft/jsch/KnownHosts.java
@@ -300,11 +300,15 @@ class KnownHosts implements HostKeyRepository {
     synchronized (pool) {
       for (int i = 0; i < pool.size(); i++) {
         HostKey _hk = pool.elementAt(i);
-        if (_hk.isMatched(host) && _hk.type == hk.type) {
+        String marker = _hk.getMarker();
+        if (_hk.isMatched(host) && _hk.type == hk.type
+            && ("".equals(marker) || "@revoked".equals(marker))) {
           if (Util.array_equals(_hk.key, key)) {
             return OK;
           }
-          result = CHANGED;
+          if ("".equals(marker)) {
+            result = CHANGED;
+          }
         }
       }
     }
@@ -428,8 +432,10 @@ class KnownHosts implements HostKeyRepository {
     synchronized (pool) {
       for (int i = 0; i < pool.size(); i++) {
         HostKey hk = pool.elementAt(i);
-        if (host == null || (hk.isMatched(host) && (type == null
-            || (hk.getType().equals(type) && (key == null || Util.array_equals(key, hk.key)))))) {
+        boolean preserveMarkedEntry =
+            host != null && type != null && key == null && !"".equals(hk.getMarker());
+        if (!preserveMarkedEntry && (host == null || (hk.isMatched(host) && (type == null
+            || (hk.getType().equals(type) && (key == null || Util.array_equals(key, hk.key))))))) {
           String hosts = hk.getHost();
           if (host == null || hosts.equals(host)
               || ((hk instanceof HashedHostKey) && ((HashedHostKey) hk).isHashed())) {

--- a/src/test/java/com/jcraft/jsch/HostKeyTest.java
+++ b/src/test/java/com/jcraft/jsch/HostKeyTest.java
@@ -1,5 +1,6 @@
 package com.jcraft.jsch;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,6 +14,12 @@ public class HostKeyTest {
     String dummyKey = "AAAAB3NzaC1yc2EAAAADAQABAAABAQ==";
     byte[] keyBytes = Util.fromBase64(Util.str2byte(dummyKey), 0, dummyKey.length());
     return new HostKey(hostPattern, HostKey.SSHRSA, keyBytes);
+  }
+
+  @Test
+  public void testNullMarkerDefaultsToEmpty() throws Exception {
+    HostKey hostKey = new HostKey(null, "example.com", HostKey.SSHRSA, new byte[0], null);
+    assertEquals("", hostKey.getMarker(), "Null marker should represent an unmarked host key");
   }
 
   // ==================== Basic wildcard tests ====================

--- a/src/test/java/com/jcraft/jsch/KnownHostsTest.java
+++ b/src/test/java/com/jcraft/jsch/KnownHostsTest.java
@@ -809,6 +809,60 @@ class KnownHostsTest {
   }
 
   @Test
+  void testCheckIgnoresCertAuthorityEntries() throws Exception {
+    KnownHosts kh = new KnownHosts(jsch);
+    kh.add(new HostKey("@cert-authority", "host.example.com", HostKey.SSHRSA, rsaKeyBytes, null),
+        null);
+
+    assertEquals(KnownHosts.NOT_INCLUDED,
+        kh.check("host.example.com", "    ssh-rsa1234".getBytes(ISO_8859_1)),
+        "cert-authority entry should not make a different plain key look changed");
+    assertEquals(KnownHosts.NOT_INCLUDED, kh.check("host.example.com", rsaKeyBytes),
+        "cert-authority key should not be accepted as a plain host key");
+
+    kh.add(new HostKey("", "host.example.com", HostKey.SSHRSA,
+        "    ssh-rsa1234".getBytes(ISO_8859_1), null), null);
+    assertEquals(KnownHosts.CHANGED, kh.check("host.example.com", rsaKeyBytes),
+        "cert-authority entry should not mask a changed ordinary key");
+  }
+
+  @Test
+  void testCheckOnlyMatchesExactRevokedKey() throws Exception {
+    KnownHosts kh = new KnownHosts(jsch);
+    kh.add(new HostKey("@revoked", "host.example.com", HostKey.SSHRSA, rsaKeyBytes, null), null);
+
+    assertEquals(KnownHosts.OK, kh.check("host.example.com", rsaKeyBytes),
+        "matching revoked key must reach Session's marker-specific revocation check");
+    assertEquals(KnownHosts.NOT_INCLUDED,
+        kh.check("host.example.com", "    ssh-rsa1234".getBytes(ISO_8859_1)),
+        "different key should not look changed because an old key was revoked");
+  }
+
+  @Test
+  void testReplacementPreservesMarkedEntries() throws Exception {
+    KnownHosts kh = new KnownHosts(jsch);
+    HostKey certAuthority =
+        new HostKey("@cert-authority", "host.example.com", HostKey.SSHRSA, rsaKeyBytes, null);
+    HostKey revoked =
+        new HostKey("@revoked", "host.example.com", HostKey.SSHRSA, rsaKeyBytes, null);
+    kh.add(certAuthority, null);
+    kh.add(revoked, null);
+    kh.add(new HostKey("", "host.example.com", HostKey.SSHRSA,
+        "    ssh-rsa1234".getBytes(ISO_8859_1), null), null);
+
+    kh.remove("host.example.com", "ssh-rsa", null);
+
+    HostKey[] hosts = kh.getHostKey("host.example.com", "ssh-rsa");
+    assertEquals(2, hosts.length, "only marked entries should remain");
+    assertSame(certAuthority, hosts[0], "cert-authority entry should be preserved");
+    assertSame(revoked, hosts[1], "revoked entry should be preserved");
+
+    kh.remove("host.example.com", "ssh-rsa", rsaKeyBytes);
+    assertEquals(0, kh.getHostKey("host.example.com", "ssh-rsa").length,
+        "explicit key removal should still remove marked entries");
+  }
+
+  @Test
   public void testAddGetRemoveHostKeys() throws Exception {
     boolean[] throwException = new boolean[1];
     Session.random = new NotSoRandomRandom();


### PR DESCRIPTION
## Summary

- exclude certificate-authority and unknown marked entries from ordinary host-key matching
- preserve exact revoked-key matches so Session can enforce revocation without false changed-key results
- retain marked entries when replacing an ordinary host key
- normalize null markers to the canonical unmarked representation
- document removal semantics and add regression coverage for marker handling

Fixes #1099

## Testing

- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./mvnw -B -Dtest=HostKeyTest,KnownHostsTest test`
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./mvnw -B clean install`
- 477 tests passed

## Notes

- based directly on `origin/master`
- independent of #1098

Generated by Codex via /oss-address-review
