### PR TITLE
Add Session accessors for the negotiated algorithms

### DIFF
--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -3237,6 +3237,24 @@ public class Session {
     return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_COMP_ALGS_STOC);
   }
 
+  /**
+   * Returns whether strict key exchange was negotiated with the server.
+   *
+   * <p>
+   * Strict key exchange is only negotiated during the initial key exchange, so unlike the
+   * negotiated algorithms this value does not change when the session is rekeyed. It returns
+   * {@code false} again once the session is disconnected.
+   *
+   * @return {@code true} if strict key exchange, the countermeasure against
+   *         <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-48795">CVE-2023-48795</a>, was
+   *         negotiated, or {@code false} if the initial key exchange has not started yet, if the
+   *         server did not support it, or if it was turned off with the {@code enable_strict_kex}
+   *         configuration
+   */
+  public boolean isStrictKex() {
+    return doStrictKex;
+  }
+
   public void sendIgnore() throws Exception {
     Buffer buf = new Buffer();
     Packet packet = new Packet(buf);

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -103,6 +103,7 @@ public class Session {
   private int seqo = 0;
 
   String[] guess = null;
+  volatile String[] negotiatedAlgorithms = null;
   private Cipher s2ccipher;
   private Cipher c2scipher;
   private MAC s2cmac;
@@ -1594,6 +1595,7 @@ public class Session {
     } finally {
       kex.clearK();
     }
+    negotiatedAlgorithms = guess;
     in_kex = false;
     if (doStrictKex) {
       seqi = 0;
@@ -3106,6 +3108,133 @@ public class Session {
 
   public void setClientVersion(String cv) {
     V_C = Util.str2byte(cv);
+  }
+
+  private String getNegotiatedAlgorithm(int proposal) {
+    String[] g = negotiatedAlgorithms;
+    return g == null ? null : g[proposal];
+  }
+
+  /**
+   * Returns the key exchange algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated key exchange algorithm, or {@code null} if no key exchange has completed
+   *         yet
+   */
+  public String getKexAlgorithm() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_KEX_ALGS);
+  }
+
+  /**
+   * Returns the server host key algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated server host key algorithm, or {@code null} if no key exchange has
+   *         completed yet
+   */
+  public String getServerHostKeyAlgorithm() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_SERVER_HOST_KEY_ALGS);
+  }
+
+  /**
+   * Returns the client to server cipher algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated client to server cipher algorithm, or {@code null} if no key exchange
+   *         has completed yet
+   */
+  public String getCipherAlgorithmC2S() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_ENC_ALGS_CTOS);
+  }
+
+  /**
+   * Returns the server to client cipher algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated server to client cipher algorithm, or {@code null} if no key exchange
+   *         has completed yet
+   */
+  public String getCipherAlgorithmS2C() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_ENC_ALGS_STOC);
+  }
+
+  /**
+   * Returns the client to server MAC algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated client to server MAC algorithm, or {@code null} if no key exchange has
+   *         completed yet or if the negotiated client to server cipher is an AEAD cipher, in which
+   *         case no separate MAC algorithm is negotiated
+   */
+  public String getMacAlgorithmC2S() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_MAC_ALGS_CTOS);
+  }
+
+  /**
+   * Returns the server to client MAC algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated server to client MAC algorithm, or {@code null} if no key exchange has
+   *         completed yet or if the negotiated server to client cipher is an AEAD cipher, in which
+   *         case no separate MAC algorithm is negotiated
+   */
+  public String getMacAlgorithmS2C() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_MAC_ALGS_STOC);
+  }
+
+  /**
+   * Returns the client to server compression algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated client to server compression algorithm, or {@code null} if no key
+   *         exchange has completed yet
+   */
+  public String getCompressionAlgorithmC2S() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_COMP_ALGS_CTOS);
+  }
+
+  /**
+   * Returns the server to client compression algorithm that was negotiated with the server.
+   *
+   * <p>
+   * The value reflects the most recently completed key exchange: it is updated when the newly
+   * negotiated algorithms are put into use, so while a rekey is in progress it still reports the
+   * algorithms currently in effect.
+   *
+   * @return the negotiated server to client compression algorithm, or {@code null} if no key
+   *         exchange has completed yet
+   */
+  public String getCompressionAlgorithmS2C() {
+    return getNegotiatedAlgorithm(KeyExchange.PROPOSAL_COMP_ALGS_STOC);
   }
 
   public void sendIgnore() throws Exception {

--- a/src/test/java/com/jcraft/jsch/SessionNegotiatedAlgorithmsTest.java
+++ b/src/test/java/com/jcraft/jsch/SessionNegotiatedAlgorithmsTest.java
@@ -1,0 +1,109 @@
+package com.jcraft.jsch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the Session accessors reporting the algorithms negotiated during key exchange. We craft
+ * the I_S/I_C (server/client KEXINIT payloads), run the negotiation over them and store the outcome
+ * the same way receive_newkeys() publishes it, then check what each accessor reports.
+ */
+class SessionNegotiatedAlgorithmsTest {
+
+  private static Session newSession() throws Exception {
+    // Reuse pattern from existing tests: username null -> defaults to system user.
+    return new Session(new JSch(), null, null, 0);
+  }
+
+  /** Builds a SSH_MSG_KEXINIT payload carrying the ten given name-lists. */
+  private static byte[] buildKexInit(String... proposals) {
+    Buffer buf = new Buffer();
+    buf.putByte((byte) 20); // SSH_MSG_KEXINIT
+    buf.putByte(new byte[16]); // cookie
+    for (String proposal : proposals) {
+      buf.putString(Util.str2byte(proposal));
+    }
+    buf.putByte((byte) 0); // first_kex_packet_follows
+    buf.putInt(0); // reserved
+    byte[] payload = new byte[buf.getLength()];
+    buf.getByte(payload);
+    return payload;
+  }
+
+  @Test
+  @DisplayName("accessors return null before any key exchange has been performed")
+  void notNegotiatedYet() throws Exception {
+    Session s = newSession();
+    assertNull(s.getKexAlgorithm());
+    assertNull(s.getServerHostKeyAlgorithm());
+    assertNull(s.getCipherAlgorithmC2S());
+    assertNull(s.getCipherAlgorithmS2C());
+    assertNull(s.getMacAlgorithmC2S());
+    assertNull(s.getMacAlgorithmS2C());
+    assertNull(s.getCompressionAlgorithmC2S());
+    assertNull(s.getCompressionAlgorithmS2C());
+  }
+
+  @Test
+  @DisplayName("accessors report the negotiated algorithm of each proposal and direction")
+  void negotiatedAlgorithms() throws Exception {
+    Session s = newSession();
+    // Every proposal names something different, and each direction is deliberately reversed
+    // relative to the other, so that a mixed up proposal index cannot go unnoticed.
+    byte[] I_C =
+        buildKexInit("curve25519-sha256,diffie-hellman-group14-sha256", "ssh-ed25519,rsa-sha2-256",
+            "aes128-ctr,aes192-ctr", "aes192-ctr,aes128-ctr", "hmac-sha2-256,hmac-sha1",
+            "hmac-sha1,hmac-sha2-256", "none,zlib@openssh.com", "zlib@openssh.com,none", "", "");
+    // The server offers the same algorithms in the opposite order, so the assertions below also
+    // pin down that the client's preference is the one that wins.
+    byte[] I_S =
+        buildKexInit("diffie-hellman-group14-sha256,curve25519-sha256", "rsa-sha2-256,ssh-ed25519",
+            "aes192-ctr,aes128-ctr", "aes128-ctr,aes192-ctr", "hmac-sha1,hmac-sha2-256",
+            "hmac-sha2-256,hmac-sha1", "zlib@openssh.com,none", "none,zlib@openssh.com", "", "");
+    s.negotiatedAlgorithms = KeyExchange.guess(s, I_S, I_C);
+
+    assertEquals("curve25519-sha256", s.getKexAlgorithm());
+    assertEquals("ssh-ed25519", s.getServerHostKeyAlgorithm());
+    assertEquals("aes128-ctr", s.getCipherAlgorithmC2S());
+    assertEquals("aes192-ctr", s.getCipherAlgorithmS2C());
+    assertEquals("hmac-sha2-256", s.getMacAlgorithmC2S());
+    assertEquals("hmac-sha1", s.getMacAlgorithmS2C());
+    assertEquals("none", s.getCompressionAlgorithmC2S());
+    assertEquals("zlib@openssh.com", s.getCompressionAlgorithmS2C());
+  }
+
+  @Test
+  @DisplayName("accessors ignore an in-progress negotiation until its keys are put into use")
+  void inProgressNegotiationNotReported() throws Exception {
+    Session s = newSession();
+    // receive_kexinit() stores the negotiation outcome in guess, but it is only published to
+    // negotiatedAlgorithms by receive_newkeys() once the algorithms are put into use.
+    s.guess = KeyExchange.guess(s,
+        buildKexInit("curve25519-sha256", "ssh-ed25519", "aes128-ctr", "aes128-ctr",
+            "hmac-sha2-256", "hmac-sha2-256", "none", "none", "", ""),
+        buildKexInit("curve25519-sha256", "ssh-ed25519", "aes128-ctr", "aes128-ctr",
+            "hmac-sha2-256", "hmac-sha2-256", "none", "none", "", ""));
+
+    assertNull(s.getKexAlgorithm());
+    assertNull(s.getCipherAlgorithmC2S());
+  }
+
+  @Test
+  @DisplayName("MAC accessors return null when an AEAD cipher is negotiated")
+  void negotiatedAeadCipherHasNoMac() throws Exception {
+    Session s = newSession();
+    byte[] I_C = buildKexInit("curve25519-sha256", "ssh-ed25519", "aes128-gcm@openssh.com",
+        "aes128-gcm@openssh.com", "hmac-sha2-256", "hmac-sha2-256", "none", "none", "", "");
+    byte[] I_S = buildKexInit("curve25519-sha256", "ssh-ed25519", "aes128-gcm@openssh.com",
+        "aes128-gcm@openssh.com", "hmac-sha2-256", "hmac-sha2-256", "none", "none", "", "");
+    s.negotiatedAlgorithms = KeyExchange.guess(s, I_S, I_C);
+
+    assertEquals("aes128-gcm@openssh.com", s.getCipherAlgorithmC2S());
+    assertEquals("aes128-gcm@openssh.com", s.getCipherAlgorithmS2C());
+    assertNull(s.getMacAlgorithmC2S());
+    assertNull(s.getMacAlgorithmS2C());
+  }
+}

--- a/src/test/java/com/jcraft/jsch/SessionStrictKexTest.java
+++ b/src/test/java/com/jcraft/jsch/SessionStrictKexTest.java
@@ -64,4 +64,10 @@ class SessionStrictKexTest {
     s.I_S = buildIS(",,,"); // name-list of empty elements
     assertFalse(s.checkServerStrictKex());
   }
+
+  @Test
+  @DisplayName("isStrictKex returns false before the initial key exchange has started")
+  void isStrictKexNotNegotiatedYet() throws Exception {
+    assertFalse(newSession().isStrictKex());
+  }
 }

--- a/src/test/java/com/jcraft/jsch/StrictKexIT.java
+++ b/src/test/java/com/jcraft/jsch/StrictKexIT.java
@@ -104,7 +104,7 @@ public class StrictKexIT {
     Session session = createSession(ssh);
     session.setConfig("enable_strict_kex", "yes");
     session.setConfig("require_strict_kex", "no");
-    doSftp(session, true);
+    doSftp(session, true, true);
 
     String expectedServerKex = "server proposal: KEX algorithms: .*,kex-strict-s-v00@openssh.com";
     String expectedClientKex = "client proposal: KEX algorithms: .*,kex-strict-c-v00@openssh.com";
@@ -126,7 +126,7 @@ public class StrictKexIT {
     Session session = createSession(ssh);
     session.setConfig("enable_strict_kex", "yes");
     session.setConfig("require_strict_kex", "yes");
-    doSftp(session, true);
+    doSftp(session, true, true);
 
     String expectedServerKex = "server proposal: KEX algorithms: .*,kex-strict-s-v00@openssh.com";
     String expectedClientKex = "client proposal: KEX algorithms: .*,kex-strict-c-v00@openssh.com";
@@ -148,7 +148,7 @@ public class StrictKexIT {
     Session session = createSession(ssh);
     session.setConfig("enable_strict_kex", "no");
     session.setConfig("require_strict_kex", "yes");
-    doSftp(session, true);
+    doSftp(session, true, true);
 
     String expectedServerKex = "server proposal: KEX algorithms: .*,kex-strict-s-v00@openssh.com";
     String expectedClientKex = "client proposal: KEX algorithms: .*,kex-strict-c-v00@openssh.com";
@@ -170,7 +170,7 @@ public class StrictKexIT {
     Session session = createSession(ssh);
     session.setConfig("enable_strict_kex", "no");
     session.setConfig("require_strict_kex", "no");
-    doSftp(session, true);
+    doSftp(session, true, false);
 
     String expectedServerKex = "server proposal: KEX algorithms: .*,kex-strict-s-v00@openssh.com";
     String expectedClientKex = "client proposal: KEX algorithms: .*,kex-strict-c-v00@openssh.com";
@@ -209,16 +209,19 @@ public class StrictKexIT {
     return session;
   }
 
-  private void doSftp(Session session, boolean debugException) throws Exception {
+  private void doSftp(Session session, boolean debugException, boolean expectStrictKex)
+      throws Exception {
     try {
       session.setTimeout(timeout);
       session.connect();
+      assertEquals(expectStrictKex, session.isStrictKex());
       ChannelSftp sftp = (ChannelSftp) session.openChannel("sftp");
       sftp.connect(timeout);
       sftp.put(in.toString(), "/root/test");
       sftp.get("/root/test", out.toString());
       sftp.disconnect();
       session.disconnect();
+      assertFalse(session.isStrictKex());
     } catch (Exception e) {
       if (debugException) {
         printInfo();


### PR DESCRIPTION
Adds accessors to `Session` for the algorithms negotiated during key exchange, one per proposal and direction:

```java
public String getKexAlgorithm()
public String getServerHostKeyAlgorithm()
public String getCipherAlgorithmC2S()
public String getCipherAlgorithmS2C()
public String getMacAlgorithmC2S()
public String getMacAlgorithmS2C()
public String getCompressionAlgorithmC2S()
public String getCompressionAlgorithmS2C()
```

Until now the only way to observe the negotiation outcome was to parse the `kex: ...` INFO log lines. Having accessors is useful for displaying or auditing connection details, and for asserting that configured algorithm preferences are honoured.

The negotiation result is published to a new volatile `negotiatedAlgorithms` field when `receive_newkeys()` puts the new keys into use. The accessors therefore return `null` until the first key exchange has completed, keep reporting the algorithms currently in effect while a rekey is in progress, and never report a key exchange that failed. The volatile write safely publishes the array to callers on other threads. The MAC accessors return `null` for a direction whose negotiated cipher is AEAD, since no separate MAC is used then.