### PR TITLE
Report a refused agent identity removal instead of always succeeding

### DIFF
--- a/src/main/java/com/jcraft/jsch/AgentIdentityRepository.java
+++ b/src/main/java/com/jcraft/jsch/AgentIdentityRepository.java
@@ -31,6 +31,7 @@ import java.util.Vector;
 public class AgentIdentityRepository implements IdentityRepository {
 
   private AgentProxy agent;
+  private boolean removeAllResult;
 
   public AgentIdentityRepository(AgentConnector connector) {
     this.agent = new AgentProxy(connector);
@@ -52,8 +53,16 @@ public class AgentIdentityRepository implements IdentityRepository {
   }
 
   @Override
-  public void removeAll() {
-    agent.removeAllIdentities();
+  public synchronized void removeAll() {
+    removeAllResult = agent.removeAllIdentities();
+  }
+
+  @Override
+  public synchronized boolean removeAllIdentities() {
+    removeAllResult = true;
+    // Preserve dispatch to removeAll() for subclasses compiled before this method was added.
+    removeAll();
+    return removeAllResult;
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/AgentProxy.java
+++ b/src/main/java/com/jcraft/jsch/AgentProxy.java
@@ -179,7 +179,7 @@ class AgentProxy {
     return rcode == SSH_AGENT_SUCCESS;
   }
 
-  synchronized void removeAllIdentities() {
+  synchronized boolean removeAllIdentities() {
     int required_size = 1 + 4;
     buffer.reset();
     buffer.checkFreeSize(required_size);
@@ -193,9 +193,8 @@ class AgentProxy {
       buffer.putByte(SSH_AGENT_FAILURE);
     }
 
-    // int rcode = buffer.getByte();
-
-    // System.out.println(rcode == SSH_AGENT_SUCCESS);
+    int rcode = buffer.getByte();
+    return rcode == SSH_AGENT_SUCCESS;
   }
 
   synchronized boolean addIdentity(byte[] identity) {

--- a/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
+++ b/src/main/java/com/jcraft/jsch/ChannelAgentForwarding.java
@@ -223,13 +223,13 @@ class ChannelAgentForwarding extends Channel {
       }
     } else if (typ == SSH2_AGENTC_REMOVE_IDENTITY) {
       byte[] blob = rbuf.getString();
-      irepo.remove(blob);
-      mbuf.putByte(SSH_AGENT_SUCCESS);
+      boolean result = irepo.remove(blob);
+      mbuf.putByte(result ? SSH_AGENT_SUCCESS : SSH_AGENT_FAILURE);
     } else if (typ == SSH_AGENTC_REMOVE_ALL_RSA_IDENTITIES) {
       mbuf.putByte(SSH_AGENT_SUCCESS);
     } else if (typ == SSH2_AGENTC_REMOVE_ALL_IDENTITIES) {
-      irepo.removeAll();
-      mbuf.putByte(SSH_AGENT_SUCCESS);
+      boolean result = irepo.removeAllIdentities();
+      mbuf.putByte(result ? SSH_AGENT_SUCCESS : SSH_AGENT_FAILURE);
     } else if (typ == SSH2_AGENTC_ADD_IDENTITY) {
       int fooo = rbuf.getLength();
       byte[] tmp = new byte[fooo];

--- a/src/main/java/com/jcraft/jsch/IdentityRepository.java
+++ b/src/main/java/com/jcraft/jsch/IdentityRepository.java
@@ -44,4 +44,21 @@ public interface IdentityRepository {
   public boolean remove(byte[] blob);
 
   public void removeAll();
+
+  /**
+   * Removes all identities and reports whether that succeeded.
+   *
+   * <p>
+   * This is {@link #removeAll()} with an outcome, which a forwarded agent needs in order to answer
+   * an {@code SSH2_AGENTC_REMOVE_ALL_IDENTITIES} request truthfully. Implementations backed by
+   * something that can refuse the removal, such as a locked or unreachable ssh-agent, should
+   * override this and return the real outcome; the default implementation delegates to
+   * {@link #removeAll()} and reports success.
+   *
+   * @return {@code true} if all identities were removed
+   */
+  public default boolean removeAllIdentities() {
+    removeAll();
+    return true;
+  }
 }

--- a/src/main/java/com/jcraft/jsch/IdentityRepositoryWrapper.java
+++ b/src/main/java/com/jcraft/jsch/IdentityRepositoryWrapper.java
@@ -64,13 +64,37 @@ class IdentityRepositoryWrapper implements IdentityRepository {
 
   @Override
   public boolean remove(byte[] blob) {
-    return ir.remove(blob);
+    // getIdentities() hands out the cached identities as well, so they have to be removable too.
+    boolean removed = removeFromCache(blob);
+    return ir.remove(blob) || removed;
+  }
+
+  private synchronized boolean removeFromCache(byte[] blob) {
+    if (blob == null)
+      return false;
+    boolean removed = false;
+    for (int i = cache.size() - 1; i >= 0; i--) {
+      Identity identity = cache.elementAt(i);
+      byte[] _blob = identity.getPublicKeyBlob();
+      if (_blob == null || !Util.array_equals(blob, _blob))
+        continue;
+      cache.removeElementAt(i);
+      identity.clear();
+      removed = true;
+    }
+    return removed;
   }
 
   @Override
   public void removeAll() {
     cache.removeAllElements();
     ir.removeAll();
+  }
+
+  @Override
+  public boolean removeAllIdentities() {
+    cache.removeAllElements();
+    return ir.removeAllIdentities();
   }
 
   @Override

--- a/src/main/java/com/jcraft/jsch/LocalIdentityRepository.java
+++ b/src/main/java/com/jcraft/jsch/LocalIdentityRepository.java
@@ -124,6 +124,12 @@ class LocalIdentityRepository implements IdentityRepository {
     identities.removeAllElements();
   }
 
+  @Override
+  public synchronized boolean removeAllIdentities() {
+    removeAll();
+    return true;
+  }
+
   private void removeDupulicates() {
     Vector<byte[]> v = new Vector<>();
     int len = identities.size();

--- a/src/test/java/com/jcraft/jsch/ChannelAgentForwardingTest.java
+++ b/src/test/java/com/jcraft/jsch/ChannelAgentForwardingTest.java
@@ -1,0 +1,303 @@
+package com.jcraft.jsch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Vector;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the agent forwarding channel reports the outcome the {@link IdentityRepository}
+ * actually produced, rather than always claiming success.
+ */
+class ChannelAgentForwardingTest {
+
+  // Mirrors the constants of ChannelAgentForwarding, which are private there.
+  private static final byte SSH_AGENT_FAILURE = 5;
+  private static final byte SSH_AGENT_SUCCESS = 6;
+  private static final byte SSH2_AGENTC_REMOVE_IDENTITY = 18;
+  private static final byte SSH2_AGENTC_REMOVE_ALL_IDENTITIES = 19;
+
+  private static final byte[] BLOB = Util.str2byte("not really a public key blob");
+
+  @Test
+  void removeIdentityReportsFailureWhenRepositoryRefuses() throws Exception {
+    StubIdentityRepository repo = new StubIdentityRepository();
+    repo.removeResult = false;
+
+    assertEquals(SSH_AGENT_FAILURE, exchange(repo, removeIdentityRequest()));
+    assertEquals(1, repo.removeCalls);
+  }
+
+  @Test
+  void removeIdentityReportsSuccessWhenRepositoryRemoves() throws Exception {
+    StubIdentityRepository repo = new StubIdentityRepository();
+    repo.removeResult = true;
+
+    assertEquals(SSH_AGENT_SUCCESS, exchange(repo, removeIdentityRequest()));
+    assertEquals(1, repo.removeCalls);
+  }
+
+  @Test
+  void removeAllIdentitiesReportsFailureWhenRepositoryRefuses() throws Exception {
+    StubIdentityRepository repo = new StubIdentityRepository();
+    repo.removeAllResult = false;
+
+    assertEquals(SSH_AGENT_FAILURE, exchange(repo, removeAllIdentitiesRequest()));
+    assertEquals(1, repo.removeAllCalls);
+  }
+
+  @Test
+  void removeAllIdentitiesReportsSuccessWhenRepositoryRemovesThem() throws Exception {
+    StubIdentityRepository repo = new StubIdentityRepository();
+    repo.removeAllResult = true;
+
+    assertEquals(SSH_AGENT_SUCCESS, exchange(repo, removeAllIdentitiesRequest()));
+    assertEquals(1, repo.removeAllCalls);
+  }
+
+  /**
+   * A repository that only implements the {@code void} {@link IdentityRepository#removeAll()} keeps
+   * the pre-existing behaviour of always reporting success.
+   */
+  @Test
+  void removeAllIdentitiesReportsSuccessForARepositoryWithoutAnOutcome() throws Exception {
+    LegacyIdentityRepository repo = new LegacyIdentityRepository();
+
+    assertEquals(SSH_AGENT_SUCCESS, exchange(repo, removeAllIdentitiesRequest()));
+    assertEquals(1, repo.removeAllCalls);
+  }
+
+  /** Existing AgentIdentityRepository subclasses must retain their remove-all policy hooks. */
+  @Test
+  void removeAllIdentitiesUsesLegacyAgentRepositorySubclassOverride() throws Exception {
+    StubAgentConnector connector = new StubAgentConnector(SSH_AGENT_SUCCESS);
+    LegacyAgentIdentityRepository repo = new LegacyAgentIdentityRepository(connector);
+
+    assertEquals(SSH_AGENT_SUCCESS, exchange(repo, removeAllIdentitiesRequest()));
+    assertEquals(1, repo.removeAllCalls);
+    assertEquals(0, connector.queries, "the overridden policy must prevent querying the agent");
+  }
+
+  /** A locked or otherwise unwilling agent answers with a failure, and so must the channel. */
+  @Test
+  void removeAllIdentitiesReportsFailureWhenTheAgentRefuses() throws Exception {
+    StubAgentConnector connector = new StubAgentConnector(SSH_AGENT_FAILURE);
+
+    assertEquals(SSH_AGENT_FAILURE,
+        exchange(new AgentIdentityRepository(connector), removeAllIdentitiesRequest()));
+    assertEquals(1, connector.queries, "the agent should be asked exactly once");
+  }
+
+  /** An unreachable agent removed nothing, so the removal must not be reported as successful. */
+  @Test
+  void removeAllIdentitiesReportsFailureWhenTheAgentIsUnreachable() throws Exception {
+    StubAgentConnector connector = new StubAgentConnector(null);
+
+    assertEquals(SSH_AGENT_FAILURE,
+        exchange(new AgentIdentityRepository(connector), removeAllIdentitiesRequest()));
+    assertEquals(1, connector.queries, "the agent should be asked exactly once");
+  }
+
+  @Test
+  void removeAllIdentitiesReportsSuccessWhenTheAgentAcknowledges() throws Exception {
+    StubAgentConnector connector = new StubAgentConnector(SSH_AGENT_SUCCESS);
+
+    assertEquals(SSH_AGENT_SUCCESS,
+        exchange(new AgentIdentityRepository(connector), removeAllIdentitiesRequest()));
+    assertEquals(1, connector.queries, "the agent should be asked exactly once");
+  }
+
+  /** byte[]: uint32 length, byte type, string blob. */
+  private static byte[] removeIdentityRequest() {
+    Buffer buf = new Buffer(4 + 1 + 4 + BLOB.length);
+    buf.putInt(1 + 4 + BLOB.length);
+    buf.putByte(SSH2_AGENTC_REMOVE_IDENTITY);
+    buf.putString(BLOB);
+    return buf.buffer;
+  }
+
+  /** byte[]: uint32 length, byte type. */
+  private static byte[] removeAllIdentitiesRequest() {
+    Buffer buf = new Buffer(4 + 1);
+    buf.putInt(1);
+    buf.putByte(SSH2_AGENTC_REMOVE_ALL_IDENTITIES);
+    return buf.buffer;
+  }
+
+  /** Feeds one agent request to the channel and returns the type byte of the reply. */
+  private static byte exchange(IdentityRepository repo, byte[] request) throws Exception {
+    RecordingSession session = new RecordingSession();
+    session.setIdentityRepository(repo);
+
+    ChannelAgentForwarding channel = new ChannelAgentForwarding();
+    channel.setSession(session);
+    channel.setRecipient(0);
+    channel.setRemotePacketSize(0x4000);
+
+    channel.write(request, 0, request.length);
+
+    assertNotNull(session.channelData, "no reply was written to the channel");
+    return agentReplyType(session.channelData);
+  }
+
+  /**
+   * Unwraps SSH_MSG_CHANNEL_DATA (byte type, uint32 recipient, string data) whose data is one
+   * length prefixed agent message, and returns that message's type byte.
+   */
+  private static byte agentReplyType(byte[] channelData) {
+    Buffer buf = new Buffer(channelData);
+    buf.index = channelData.length;
+    assertEquals(Session.SSH_MSG_CHANNEL_DATA, buf.getByte(), "not a channel data message");
+    buf.getInt(); // recipient
+    byte[] message = buf.getString(); // the length prefixed agent message
+    assertEquals(message.length - 4, new Buffer(message).getInt(), "bad agent message length");
+    return message[4];
+  }
+
+  /** A session that captures what a channel writes instead of putting it on a socket. */
+  private static final class RecordingSession extends Session {
+    byte[] channelData;
+
+    RecordingSession() throws JSchException {
+      super(new JSch(), null, null, 0);
+    }
+
+    @Override
+    void write(Packet packet, Channel c, int length) {
+      // Packet#reset() leaves five bytes of room for the packet length and padding.
+      channelData = Arrays.copyOfRange(packet.buffer.buffer, 5, packet.buffer.index);
+    }
+  }
+
+  /** Answers every query with one reply byte, or fails outright when that byte is null. */
+  private static final class StubAgentConnector implements AgentConnector {
+    private final Byte reply;
+    int queries;
+
+    StubAgentConnector(Byte reply) {
+      this.reply = reply;
+    }
+
+    @Override
+    public String getName() {
+      return "stub";
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public void query(Buffer buffer) throws AgentProxyException {
+      queries++;
+      if (reply == null) {
+        throw new AgentProxyException("the agent is unreachable");
+      }
+      // As the real connectors do: the reply replaces the request, without its length prefix.
+      buffer.rewind();
+      buffer.buffer[0] = reply.byteValue();
+    }
+  }
+
+  private static final class LegacyAgentIdentityRepository extends AgentIdentityRepository {
+    int removeAllCalls;
+
+    LegacyAgentIdentityRepository(AgentConnector connector) {
+      super(connector);
+    }
+
+    @Override
+    public void removeAll() {
+      removeAllCalls++;
+    }
+  }
+
+  private static final class StubIdentityRepository implements IdentityRepository {
+    final Vector<Identity> identities = new Vector<>();
+    boolean removeResult;
+    boolean removeAllResult = true;
+    int removeCalls;
+    int removeAllCalls;
+
+    @Override
+    public String getName() {
+      return "stub";
+    }
+
+    @Override
+    public int getStatus() {
+      return RUNNING;
+    }
+
+    @Override
+    public Vector<Identity> getIdentities() {
+      return new Vector<>(identities);
+    }
+
+    @Override
+    public boolean add(byte[] identity) {
+      return false;
+    }
+
+    @Override
+    public boolean remove(byte[] blob) {
+      removeCalls++;
+      return removeResult;
+    }
+
+    @Override
+    public void removeAll() {
+      identities.removeAllElements();
+    }
+
+    @Override
+    public boolean removeAllIdentities() {
+      removeAllCalls++;
+      if (removeAllResult) {
+        removeAll();
+      }
+      return removeAllResult;
+    }
+  }
+
+  /**
+   * A repository predating {@link IdentityRepository#removeAllIdentities()}, which therefore only
+   * implements the {@code void} {@link IdentityRepository#removeAll()}.
+   */
+  private static final class LegacyIdentityRepository implements IdentityRepository {
+    int removeAllCalls;
+
+    @Override
+    public String getName() {
+      return "legacy";
+    }
+
+    @Override
+    public int getStatus() {
+      return RUNNING;
+    }
+
+    @Override
+    public Vector<Identity> getIdentities() {
+      return new Vector<>();
+    }
+
+    @Override
+    public boolean add(byte[] identity) {
+      return false;
+    }
+
+    @Override
+    public boolean remove(byte[] blob) {
+      return false;
+    }
+
+    @Override
+    public void removeAll() {
+      removeAllCalls++;
+    }
+  }
+}

--- a/src/test/java/com/jcraft/jsch/IdentityRepositoryWrapperTest.java
+++ b/src/test/java/com/jcraft/jsch/IdentityRepositoryWrapperTest.java
@@ -1,0 +1,145 @@
+package com.jcraft.jsch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Vector;
+import org.junit.jupiter.api.Test;
+
+/** Tests that the cached identities of the wrapper are removable, and not only listable. */
+class IdentityRepositoryWrapperTest {
+
+  private static final byte[] BLOB = Util.str2byte("not really a public key blob");
+
+  @Test
+  void removeRemovesACachedIdentity() {
+    StubIdentityRepository delegate = new StubIdentityRepository();
+    IdentityRepositoryWrapper wrapper = new IdentityRepositoryWrapper(delegate);
+    StubIdentity identity = new StubIdentity();
+    wrapper.add(identity);
+
+    assertEquals(1, wrapper.getIdentities().size(), "the cached identity should be listed");
+
+    assertTrue(wrapper.remove(BLOB.clone()));
+    assertTrue(wrapper.getIdentities().isEmpty(), "the cached identity should be gone");
+    assertTrue(identity.cleared, "the removed identity should have been cleared");
+  }
+
+  @Test
+  void removeReportsFailureForAnUnknownIdentity() {
+    IdentityRepositoryWrapper wrapper = new IdentityRepositoryWrapper(new StubIdentityRepository());
+
+    assertFalse(wrapper.remove(Util.str2byte("some other blob")));
+  }
+
+  /** Removing an identity of the wrapped repository still reports what that repository says. */
+  @Test
+  void removeDelegatesForAnIdentityThatIsNotCached() {
+    StubIdentityRepository delegate = new StubIdentityRepository();
+    delegate.removeResult = true;
+    IdentityRepositoryWrapper wrapper = new IdentityRepositoryWrapper(delegate);
+
+    assertTrue(wrapper.remove(BLOB.clone()));
+    assertEquals(1, delegate.removeCalls);
+  }
+
+  @Test
+  void removeAllIdentitiesClearsTheCacheAndReportsTheDelegateResult() {
+    StubIdentityRepository delegate = new StubIdentityRepository();
+    delegate.removeAllResult = false;
+    IdentityRepositoryWrapper wrapper = new IdentityRepositoryWrapper(delegate);
+    wrapper.add(new StubIdentity());
+
+    assertFalse(wrapper.removeAllIdentities(), "the refusal of the delegate should be reported");
+    assertTrue(wrapper.getIdentities().isEmpty(), "the cache should be cleared regardless");
+    assertEquals(1, delegate.removeAllCalls);
+  }
+
+  private static final class StubIdentityRepository implements IdentityRepository {
+    boolean removeResult;
+    boolean removeAllResult = true;
+    int removeCalls;
+    int removeAllCalls;
+
+    @Override
+    public String getName() {
+      return "stub";
+    }
+
+    @Override
+    public int getStatus() {
+      return RUNNING;
+    }
+
+    @Override
+    public Vector<Identity> getIdentities() {
+      return new Vector<>();
+    }
+
+    @Override
+    public boolean add(byte[] identity) {
+      return false;
+    }
+
+    @Override
+    public boolean remove(byte[] blob) {
+      removeCalls++;
+      return removeResult;
+    }
+
+    @Override
+    public void removeAll() {}
+
+    @Override
+    public boolean removeAllIdentities() {
+      removeAllCalls++;
+      return removeAllResult;
+    }
+  }
+
+  /** Not an IdentityFile, so IdentityRepositoryWrapper keeps it in its own cache. */
+  private static final class StubIdentity implements Identity {
+    boolean cleared;
+
+    @Override
+    public boolean setPassphrase(byte[] passphrase) {
+      return true;
+    }
+
+    @Override
+    public byte[] getPublicKeyBlob() {
+      return BLOB.clone();
+    }
+
+    @Override
+    public byte[] getSignature(byte[] data) {
+      return null;
+    }
+
+    @Override
+    public byte[] getSignature(byte[] data, String alg) {
+      return null;
+    }
+
+    @Override
+    public String getAlgName() {
+      return "stub";
+    }
+
+    @Override
+    public String getName() {
+      return "stub";
+    }
+
+    @Override
+    public boolean isEncrypted() {
+      return false;
+    }
+
+    @Override
+    public void clear() {
+      cleared = true;
+    }
+  }
+}


### PR DESCRIPTION
Fix forwarded-agent removal replies so the remote caller sees the repository's actual result.

### Changes

- Reply with `SSH_AGENT_SUCCESS` or `SSH_AGENT_FAILURE` based on `IdentityRepository.remove(byte[])`.
- Add `IdentityRepository.removeAllIdentities()`, a default method that calls the existing `removeAll()` and reports success. Existing implementations keep their current behavior, while agent-backed repositories can return the agent's real response.
- Return the remove-all response already read by `AgentProxy` and propagate it through `AgentIdentityRepository`.
- Remove identities from `IdentityRepositoryWrapper`'s cache as well as its delegate.

The remove-all result is reported directly rather than inferred from `getIdentities()`: a locked or unreachable agent may also fail identity listing, making a failed removal look like an empty repository.

### Tests

Added wire-level coverage for successful, refused, and unreachable removals, plus compatibility coverage for existing `removeAll()` implementations and overrides. Added wrapper tests for cached and delegated identities.

`./mvnw verify -DskipITs=true`: 500 tests, 0 failures.

Disclaimer: Created with claude code and opus 5. Reviewed and iterated on by me.