### PR TITLE
Add Session.getDisconnectCause()

### DIFF
--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -115,11 +115,12 @@ public class Session {
   private Compression deflater;
   private Compression inflater;
 
-  private IO io;
+  IO io;
   private Socket socket;
   private int timeout = 0;
 
-  private volatile boolean isConnected = false;
+  volatile boolean isConnected = false;
+  volatile Throwable disconnectCause = null;
 
   private volatile boolean doExtInfo = false;
   private boolean enable_server_sig_algs = true;
@@ -213,6 +214,7 @@ public class Session {
     if (isConnected) {
       throw new JSchException("session is already connected");
     }
+    disconnectCause = null;
     initialKex = true;
 
     io = new IO();
@@ -2212,6 +2214,10 @@ public class Session {
       }
     } catch (Exception e) {
       in_kex = false;
+      // disconnect() clears isConnected before closing the streams.
+      if (isConnected) {
+        disconnectCause = e;
+      }
       if (getLogger().isEnabled(Logger.INFO)) {
         getLogger().log(Logger.INFO,
             "Caught an exception, leaving main loop due to " + e.getMessage(), e);
@@ -3076,6 +3082,18 @@ public class Session {
 
   public boolean isConnected() {
     return isConnected;
+  }
+
+  /**
+   * Returns the exception that ended the last connected session. Cleared by {@link #connect}.
+   *
+   * @return the exception, or {@code null} if still connected or disconnected locally
+   */
+  public Throwable getDisconnectCause() {
+    if (isConnected) {
+      return null;
+    }
+    return disconnectCause;
   }
 
   public int getTimeout() {

--- a/src/test/java/com/jcraft/jsch/SessionDisconnectCauseTest.java
+++ b/src/test/java/com/jcraft/jsch/SessionDisconnectCauseTest.java
@@ -1,0 +1,93 @@
+package com.jcraft.jsch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SessionDisconnectCauseTest {
+
+  private static Session newSession() throws Exception {
+    return new Session(new JSch(), null, null, 0);
+  }
+
+  private static Session newConnectedSession(InputStream in) throws Exception {
+    Session s = newSession();
+    IO io = new IO();
+    io.setInputStream(in);
+    s.io = io;
+    s.isConnected = true;
+    return s;
+  }
+
+  @Test
+  @DisplayName("null before the session was ever connected")
+  void nullOnFreshSession() throws Exception {
+    assertNull(newSession().getDisconnectCause());
+  }
+
+  @Test
+  @DisplayName("null while the session is still connected")
+  void nullWhileConnected() throws Exception {
+    IOException error = new IOException("connection reset");
+    Session s = newSession();
+    s.disconnectCause = error;
+    s.isConnected = true;
+
+    assertNull(s.getDisconnectCause());
+
+    s.isConnected = false;
+    assertSame(error, s.getDisconnectCause());
+  }
+
+  @Test
+  @DisplayName("records the exception that made the read loop exit")
+  void readLoopFailureIsRecorded() throws Exception {
+    IOException error = new IOException("connection reset");
+    Session s = newConnectedSession(new InputStream() {
+      @Override
+      public int read() throws IOException {
+        throw error;
+      }
+    });
+
+    s.run();
+
+    assertSame(error, s.getDisconnectCause());
+    assertFalse(s.isConnected());
+  }
+
+  @Test
+  @DisplayName("a local disconnect() is not recorded as a cause")
+  void localDisconnectIsNotRecorded() throws Exception {
+    Session[] holder = new Session[1];
+    Session s = newConnectedSession(new InputStream() {
+      @Override
+      public int read() throws IOException {
+        // Mimic disconnect() closing a blocked read.
+        holder[0].disconnect();
+        throw new IOException("stream closed");
+      }
+    });
+    holder[0] = s;
+
+    s.run();
+
+    assertNull(s.getDisconnectCause());
+    assertFalse(s.isConnected());
+  }
+
+  @Test
+  @DisplayName("cleared again by connect()")
+  void clearedByConnect() throws Exception {
+    Session s = newSession();
+    s.disconnectCause = new IOException("previous session died");
+    assertThrows(JSchException.class, () -> s.connect(1));
+    assertNull(s.getDisconnectCause());
+  }
+}


### PR DESCRIPTION
Adds `Session.getDisconnectCause()` so callers can inspect why a session ended unexpectedly.

Exceptions that stop the read loop are retained after teardown. Local disconnects are ignored, `connect()` clears the previous cause, and the getter returns `null` while connected.