### PR TITLE
Expose verified host certificates through Session

### DIFF
--- a/src/main/java/com/jcraft/jsch/OpenSshCertificate.java
+++ b/src/main/java/com/jcraft/jsch/OpenSshCertificate.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * @see <a href="https://datatracker.ietf.org/doc/html/draft-miller-ssh-cert-03">OpenSSH Certificate
  *      Protocol</a>
  */
-class OpenSshCertificate {
+public final class OpenSshCertificate {
 
   /**
    * Certificate type constant for user certificates
@@ -140,19 +140,19 @@ class OpenSshCertificate {
     this.message = builder.message;
   }
 
-  String getKeyType() {
+  public String getKeyType() {
     return keyType;
   }
 
-  byte[] getNonce() {
+  public byte[] getNonce() {
     return nonce == null ? null : nonce.clone();
   }
 
-  byte[] getCertificatePublicKey() {
+  public byte[] getCertificatePublicKey() {
     return certificatePublicKey == null ? null : certificatePublicKey.clone();
   }
 
-  long getSerial() {
+  public long getSerial() {
     return serial;
   }
 
@@ -160,55 +160,55 @@ class OpenSshCertificate {
     return type;
   }
 
-  String getId() {
+  public String getId() {
     return id;
   }
 
-  Collection<String> getPrincipals() {
+  public Collection<String> getPrincipals() {
     return principals == null ? null : Collections.unmodifiableCollection(principals);
   }
 
-  long getValidAfter() {
+  public long getValidAfter() {
     return validAfter;
   }
 
-  long getValidBefore() {
+  public long getValidBefore() {
     return validBefore;
   }
 
-  Map<String, String> getCriticalOptions() {
+  public Map<String, String> getCriticalOptions() {
     return criticalOptions == null ? null : Collections.unmodifiableMap(criticalOptions);
   }
 
-  Map<String, String> getExtensions() {
+  public Map<String, String> getExtensions() {
     return extensions == null ? null : Collections.unmodifiableMap(extensions);
   }
 
-  String getReserved() {
+  public String getReserved() {
     return reserved;
   }
 
-  byte[] getSignatureKey() {
+  public byte[] getSignatureKey() {
     return signatureKey == null ? null : signatureKey.clone();
   }
 
-  byte[] getSignature() {
+  public byte[] getSignature() {
     return signature == null ? null : signature.clone();
   }
 
-  boolean isUserCertificate() {
+  public boolean isUserCertificate() {
     return SSH2_CERT_TYPE_USER == type;
   }
 
-  boolean isHostCertificate() {
+  public boolean isHostCertificate() {
     return SSH2_CERT_TYPE_HOST == type;
   }
 
-  boolean isValidNow() {
+  public boolean isValidNow() {
     return OpenSshCertificateUtil.isValidNow(this);
   }
 
-  byte[] getMessage() {
+  public byte[] getMessage() {
     return message == null ? null : message.clone();
   }
 

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -214,6 +214,9 @@ public class Session {
       throw new JSchException("session is already connected");
     }
     initialKex = true;
+    // Retain these values after disconnect, but not across connection attempts.
+    hostkey = null;
+    hostCertificate = null;
 
     io = new IO();
     if (random == null) {
@@ -972,6 +975,9 @@ public class Session {
           getLogger().log(Logger.INFO, "Host '" + chost + "' is known and matches the "
               + kex.getKeyType() + " host certificate");
         }
+        // This path does not reach doCheckHostKey, which normally records the host key.
+        hostkey = new HostKey(chost, certificate.getCertificatePublicKey());
+        hostCertificate = certificate;
         return;
       } catch (JSchRevokedHostKeyException e) {
         // Revoked key is a hard failure — never fall back to plain key checking
@@ -3289,8 +3295,26 @@ public class Session {
 
   private HostKey hostkey = null;
 
+  private OpenSshCertificate hostCertificate = null;
+
   public HostKey getHostKey() {
     return hostkey;
+  }
+
+  /**
+   * Returns the verified OpenSSH host certificate used by this session.
+   *
+   * <p>
+   * This is {@code null} when the server used a plain host key or when certificate verification
+   * failed and {@code host_certificate_to_key_fallback} accepted its plain key instead. The value
+   * is retained after disconnect and cleared when a new connection attempt begins.
+   * </p>
+   *
+   * @return the verified host certificate, or {@code null} if none was used
+   * @see #getHostKey()
+   */
+  public OpenSshCertificate getHostKeyCertificate() {
+    return hostCertificate;
   }
 
   public String getHost() {

--- a/src/test/java/com/jcraft/jsch/HostCertificateIT.java
+++ b/src/test/java/com/jcraft/jsch/HostCertificateIT.java
@@ -1,7 +1,11 @@
 package com.jcraft.jsch;
 
 import static com.jcraft.jsch.ResourceUtil.getResourceFile;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.JRE.JAVA_15;
@@ -118,9 +122,38 @@ public class HostCertificateIT {
     session.setConfig("StrictHostKeyChecking", "yes");
     session.setConfig("PreferredAuthentications", "publickey");
     session.setConfig("server_host_key", algorithm);
+    assertNull(session.getHostKeyCertificate());
     assertDoesNotThrow(() -> {
       connectSftp(session);
     });
+
+    HostKey hostKey = session.getHostKey();
+    assertNotNull(hostKey);
+
+    OpenSshCertificate certificate = session.getHostKeyCertificate();
+    assertNotNull(certificate);
+    assertTrue(certificate.isHostCertificate());
+    assertTrue(certificate.isValidNow());
+    assertFalse(certificate.getPrincipals().isEmpty());
+    assertNotNull(certificate.getSignatureKey());
+    assertArrayEquals(certificate.getCertificatePublicKey(), hostKey.key);
+  }
+
+  @Test
+  public void noCertificateIsReportedForAPlainHostKey() throws Exception {
+    JSch ssh = new JSch();
+    ssh.addIdentity(
+        getResourceFile(this.getClass(), CERTIFICATES_BASE_FOLDER + "/user_keys/id_ecdsa_nistp521"),
+        getResourceFile(this.getClass(),
+            CERTIFICATES_BASE_FOLDER + "/user_keys/id_ecdsa_nistp521.pub"),
+        null);
+    Session session = setup(ssh, "ssh-ed25519");
+    session.setConfig("StrictHostKeyChecking", "no");
+
+    connectSftp(session);
+
+    assertNotNull(session.getHostKey());
+    assertNull(session.getHostKeyCertificate());
   }
 
   /**


### PR DESCRIPTION
## Summary

Expose the verified OpenSSH host certificate through `Session#getHostKeyCertificate()`.

Successful certificate verification currently returns from `Session#checkHost` before `doCheckHostKey`, leaving `Session#getHostKey()` unset and the certificate inaccessible to callers. This change:

- records the underlying public key in `Session#getHostKey()`;
- retains the verified certificate in `Session#getHostKeyCertificate()`;
- makes `OpenSshCertificate` and its read accessors public.

`getHostKeyCertificate()` remains `null` for plain host-key authentication and when certificate verification fails but `host_certificate_to_key_fallback` accepts the underlying key.

## Tests

`./mvnw -B -DskipITs=false -Dit.test=HostCertificateIT verify`

- 487 unit tests passed
- 11 `HostCertificateIT` tests passed
- formatting, import sorting, and forbidden-API checks passed

Disclaimar: Created with claude code and opus 5, reviewed by me.