### PR TITLE
2.28.7 changes

### DIFF
--- a/src/main/java/com/jcraft/jsch/OpenSshCertificate.java
+++ b/src/main/java/com/jcraft/jsch/OpenSshCertificate.java
@@ -102,7 +102,7 @@ class OpenSshCertificate {
   /**
    * Reserved field for future use
    */
-  private final String reserved;
+  private final byte[] reserved;
 
   /**
    * The CA's key that signed this certificate
@@ -184,8 +184,8 @@ class OpenSshCertificate {
     return extensions == null ? null : Collections.unmodifiableMap(extensions);
   }
 
-  String getReserved() {
-    return reserved;
+  byte[] getReserved() {
+    return reserved == null ? null : reserved.clone();
   }
 
   byte[] getSignatureKey() {
@@ -227,7 +227,7 @@ class OpenSshCertificate {
     private long validBefore = MAX_VALIDITY;
     private Map<String, String> criticalOptions;
     private Map<String, String> extensions;
-    private String reserved;
+    private byte[] reserved;
     private byte[] signatureKey;
     private byte[] signature;
     private byte[] message;
@@ -289,7 +289,7 @@ class OpenSshCertificate {
       return this;
     }
 
-    Builder reserved(String reserved) {
+    Builder reserved(byte[] reserved) {
       this.reserved = reserved;
       return this;
     }

--- a/src/main/java/com/jcraft/jsch/OpenSshCertificateParser.java
+++ b/src/main/java/com/jcraft/jsch/OpenSshCertificateParser.java
@@ -79,8 +79,7 @@ class OpenSshCertificateParser {
     Collection<String> principals = principalsBuffer.getStrings();
     openSshCertificateBuilder.principals(principals).validAfter(buffer.getLong())
         .validBefore(buffer.getLong()).criticalOptions(buffer.getCriticalOptions())
-        .extensions(buffer.getExtensions())
-        .reserved(Util.byte2str(buffer.getString(), StandardCharsets.UTF_8))
+        .extensions(buffer.getExtensions()).reserved(buffer.getString())
         .signatureKey(buffer.getString());
 
     int messageEndIndex = buffer.s;

--- a/src/main/java/com/jcraft/jsch/SftpATTRS.java
+++ b/src/main/java/com/jcraft/jsch/SftpATTRS.java
@@ -62,6 +62,8 @@ public class SftpATTRS {
   static final int S_IWOTH = 00002; // write by others
   static final int S_IXOTH = 00001; // execute/search by others
 
+  static final int MAX_EXTENDED_COUNT = 0x100000;
+
   private static final int pmask = 0xFFF;
 
   public String getPermissionsString() {
@@ -168,7 +170,7 @@ public class SftpATTRS {
 
   public SftpATTRS() {}
 
-  static SftpATTRS getATTR(Buffer buf) {
+  static SftpATTRS getATTR(Buffer buf) throws SftpException {
     SftpATTRS attr = new SftpATTRS();
     attr.flags = buf.getInt();
     if ((attr.flags & SSH_FILEXFER_ATTR_SIZE) != 0) {
@@ -189,6 +191,11 @@ public class SftpATTRS {
     }
     if ((attr.flags & SSH_FILEXFER_ATTR_EXTENDED) != 0) {
       int count = buf.getInt();
+      // OpenSSH restricts count to a max of 0x100000.
+      // Min length of two strings is 8 bytes.
+      if (count < 0 || count > MAX_EXTENDED_COUNT || count * 8 > buf.getLength()) {
+        throw new SftpException(ChannelSftp.SSH_FX_BAD_MESSAGE, "invalid extended attr count");
+      }
       if (count > 0) {
         attr.extended = new String[count * 2];
         for (int i = 0; i < count; i++) {

--- a/src/test/java/com/jcraft/jsch/SftpATTRSTest.java
+++ b/src/test/java/com/jcraft/jsch/SftpATTRSTest.java
@@ -1,6 +1,11 @@
 package com.jcraft.jsch;
 
+import static com.jcraft.jsch.SftpATTRS.MAX_EXTENDED_COUNT;
+import static com.jcraft.jsch.SftpATTRS.SSH_FILEXFER_ATTR_EXTENDED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -50,5 +55,54 @@ public class SftpATTRSTest {
       String actual = SftpATTRS.toDateString(l);
       assertEquals(expected, actual);
     }
+  }
+
+  @Test
+  public void testGetATTRNegativeExtendedCount() {
+    Buffer buf = new Buffer(8);
+    buf.putInt(SSH_FILEXFER_ATTR_EXTENDED);
+    buf.putInt(-1);
+    assertThrows(SftpException.class, () -> SftpATTRS.getATTR(buf));
+  }
+
+  @Test
+  public void testGetATTRMaxExtendedCount() {
+    Buffer buf = new Buffer(8);
+    buf.putInt(SSH_FILEXFER_ATTR_EXTENDED);
+    buf.putInt(MAX_EXTENDED_COUNT + 1);
+    assertThrows(SftpException.class, () -> SftpATTRS.getATTR(buf));
+  }
+
+  @Test
+  public void testGetATTRInvalidExtendedCount() {
+    Buffer buf = new Buffer(8);
+    buf.putInt(SSH_FILEXFER_ATTR_EXTENDED);
+    buf.putInt(1);
+    assertThrows(SftpException.class, () -> SftpATTRS.getATTR(buf));
+  }
+
+  @Test
+  public void testGetATTREmptyExtendedCount() throws Exception {
+    Buffer buf = new Buffer(8);
+    buf.putInt(SSH_FILEXFER_ATTR_EXTENDED);
+    buf.putInt(0);
+    SftpATTRS attrs = SftpATTRS.getATTR(buf);
+    String[] extended = attrs.getExtended();
+    assertNull(extended);
+  }
+
+  @Test
+  public void testGetATTRValidExtendedCount() throws Exception {
+    Buffer buf = new Buffer(16);
+    buf.putInt(SSH_FILEXFER_ATTR_EXTENDED);
+    buf.putInt(1);
+    buf.putString(Util.str2byte(""));
+    buf.putString(Util.str2byte(""));
+    SftpATTRS attrs = SftpATTRS.getATTR(buf);
+    String[] extended = attrs.getExtended();
+    assertNotNull(extended);
+    assertEquals(2, extended.length);
+    assertEquals("", extended[0]);
+    assertEquals("", extended[1]);
   }
 }


### PR DESCRIPTION
- #1127: add bounds checks when parsing SFTP vendor-specific extensions.
- Treat the reserved field in certs as an opaque byte array instead of a String.