### PR TITLE
2.28.8 changes

### DIFF
--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -1016,6 +1016,7 @@ public class ChannelSftp extends ChannelSession {
         request_len = 1024;
       }
 
+      SftpException invalid_len = null;
       loop: while (true) {
 
         while (rq.count() < request_max) {
@@ -1054,6 +1055,10 @@ public class ChannelSftp extends ChannelSession {
         fill(buf.buffer, 0, 4);
         length -= 4;
         int length_of_data = buf.getInt(); // length of data
+        if (length_of_data < 0 || length_of_data > rr.length) {
+          invalid_len = new SftpException(SSH_FX_BAD_MESSAGE, "invalid length");
+          break loop;
+        }
 
         /*
          * Since sftp protocol version 6, "end-of-file" has been defined, byte SSH_FXP_DATA uint32
@@ -1104,14 +1109,26 @@ public class ChannelSftp extends ChannelSession {
           request_max++;
         }
       }
-      dst.flush();
+      try {
+        dst.flush();
 
-      if (monitor != null)
-        monitor.end();
+        if (monitor != null)
+          monitor.end();
 
-      rq.cancel(header, buf);
+        rq.cancel(header, buf);
 
-      _sendCLOSE(handle, header);
+        _sendCLOSE(handle, header);
+      } catch (Exception e) {
+        if (invalid_len != null) {
+          invalid_len.addSuppressed(e);
+          throw invalid_len;
+        } else {
+          throw e;
+        }
+      }
+      if (invalid_len != null) {
+        throw invalid_len;
+      }
     } catch (Exception e) {
       if (e instanceof SftpException)
         throw (SftpException) e;
@@ -1409,6 +1426,9 @@ public class ChannelSftp extends ChannelSession {
           fill(buf.buffer, 0, 4);
           int length_of_data = buf.getInt();
           rest_length -= 4;
+          if (length_of_data < 0 || length_of_data > rr.length) {
+            throw new IOException("invalid length");
+          }
 
           /*
            * Since sftp protocol version 6, "end-of-file" has been defined, byte SSH_FXP_DATA uint32

--- a/src/main/java/com/jcraft/jsch/ChannelSftp.java
+++ b/src/main/java/com/jcraft/jsch/ChannelSftp.java
@@ -1609,7 +1609,8 @@ public class ChannelSftp extends ChannelSession {
       int cancel = LsEntrySelector.CONTINUE;
       byte[] handle = buf.getString(); // handle
 
-      while (cancel == LsEntrySelector.CONTINUE) {
+      SftpException invalid_attrs = null;
+      loop: while (cancel == LsEntrySelector.CONTINUE) {
 
         sendREADDIR(handle);
 
@@ -1650,7 +1651,13 @@ public class ChannelSftp extends ChannelSession {
           if (server_version <= 3) {
             longname = buf.getString();
           }
-          SftpATTRS attrs = SftpATTRS.getATTR(buf);
+          SftpATTRS attrs;
+          try {
+            attrs = SftpATTRS.getATTR(buf);
+          } catch (SftpException e) {
+            invalid_attrs = e;
+            break loop;
+          }
 
           if (cancel == LsEntrySelector.BREAK) {
             count--;
@@ -1691,7 +1698,19 @@ public class ChannelSftp extends ChannelSession {
           count--;
         }
       }
-      _sendCLOSE(handle, header);
+      try {
+        _sendCLOSE(handle, header);
+      } catch (Exception e) {
+        if (invalid_attrs != null) {
+          invalid_attrs.addSuppressed(e);
+          throw invalid_attrs;
+        } else {
+          throw e;
+        }
+      }
+      if (invalid_attrs != null) {
+        throw invalid_attrs;
+      }
 
       /*
        * if(v.size()==1 && pattern_has_wildcard){ LsEntry le=(LsEntry)v.elementAt(0);
@@ -2670,7 +2689,8 @@ public class ChannelSftp extends ChannelSession {
     byte[] handle = buf.getString(); // filename
     String pdir = null; // parent directory
 
-    while (true) {
+    SftpException invalid_attrs = null;
+    loop: while (true) {
       sendREADDIR(handle);
       header = header(buf, header);
       length = header.length;
@@ -2710,7 +2730,13 @@ public class ChannelSftp extends ChannelSession {
         if (server_version <= 3) {
           str = buf.getString(); // longname
         }
-        SftpATTRS attrs = SftpATTRS.getATTR(buf);
+        SftpATTRS attrs;
+        try {
+          attrs = SftpATTRS.getATTR(buf);
+        } catch (SftpException e) {
+          invalid_attrs = e;
+          break loop;
+        }
 
         byte[] _filename = filename;
         String f = null;
@@ -2737,9 +2763,23 @@ public class ChannelSftp extends ChannelSession {
         count--;
       }
     }
-    if (_sendCLOSE(handle, header))
-      return v;
-    return null;
+    try {
+      if (_sendCLOSE(handle, header) && invalid_attrs == null) {
+        return v;
+      }
+    } catch (Exception e) {
+      if (invalid_attrs != null) {
+        invalid_attrs.addSuppressed(e);
+        throw invalid_attrs;
+      } else {
+        throw e;
+      }
+    }
+    if (invalid_attrs != null) {
+      throw invalid_attrs;
+    } else {
+      return null;
+    }
   }
 
   private boolean isPattern(byte[] path) {

--- a/src/main/java/com/jcraft/jsch/ProxyHTTP.java
+++ b/src/main/java/com/jcraft/jsch/ProxyHTTP.java
@@ -33,6 +33,7 @@ import java.net.Socket;
 
 public class ProxyHTTP implements Proxy {
   private static int DEFAULTPORT = 80;
+  static int MAX_STATUS_LEN = 1024;
   private String proxy_host;
   private int proxy_port;
   private InputStream in;
@@ -99,24 +100,7 @@ public class ProxyHTTP implements Proxy {
 
       int foo = 0;
 
-      StringBuilder sb = new StringBuilder();
-      while (foo >= 0) {
-        foo = in.read();
-        if (foo != 13) {
-          sb.append((char) foo);
-          continue;
-        }
-        foo = in.read();
-        if (foo != 10) {
-          continue;
-        }
-        break;
-      }
-      if (foo < 0) {
-        throw new IOException();
-      }
-
-      String response = sb.toString();
+      String response = readStatus(in);
       String reason = "Unknow reason";
       int code = -1;
       try {
@@ -202,5 +186,30 @@ public class ProxyHTTP implements Proxy {
 
   public static int getDefaultPort() {
     return DEFAULTPORT;
+  }
+
+  static String readStatus(InputStream in) throws IOException {
+    int foo = 0;
+    int i = 0;
+    StringBuilder sb = new StringBuilder();
+    while (foo >= 0 && i < MAX_STATUS_LEN) {
+      foo = in.read();
+      i++;
+      if (foo != 13) {
+        sb.append((char) foo);
+        continue;
+      }
+      foo = in.read();
+      i++;
+      if (foo != 10) {
+        continue;
+      }
+      break;
+    }
+    if (foo < 0) {
+      throw new IOException();
+    }
+
+    return sb.toString();
   }
 }

--- a/src/main/java/com/jcraft/jsch/SftpATTRS.java
+++ b/src/main/java/com/jcraft/jsch/SftpATTRS.java
@@ -191,9 +191,14 @@ public class SftpATTRS {
     }
     if ((attr.flags & SSH_FILEXFER_ATTR_EXTENDED) != 0) {
       int count = buf.getInt();
-      // OpenSSH restricts count to a max of 0x100000.
-      // Min length of two strings is 8 bytes.
-      if (count < 0 || count > MAX_EXTENDED_COUNT || count * 8 > buf.getLength()) {
+      try {
+        // OpenSSH restricts count to a max of 0x100000.
+        // Min length of two strings is 8 bytes.
+        if (count < 0 || count > MAX_EXTENDED_COUNT
+            || Math.multiplyExact(count, 8) > buf.getLength()) {
+          throw new SftpException(ChannelSftp.SSH_FX_BAD_MESSAGE, "invalid extended attr count");
+        }
+      } catch (ArithmeticException e) {
         throw new SftpException(ChannelSftp.SSH_FX_BAD_MESSAGE, "invalid extended attr count");
       }
       if (count > 0) {

--- a/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
@@ -121,8 +121,12 @@ class UserAuthKeyboardInteractive extends UserAuth {
           String instruction = Util.byte2str(buf.getString());
           String languate_tag = Util.byte2str(buf.getString());
           int num = buf.getInt();
-          // Min length of one string plus one byte is 5 bytes.
-          if (num < 0 || num * 5 > buf.getLength()) {
+          try {
+            // Min length of one string plus one byte is 5 bytes.
+            if (num < 0 || Math.multiplyExact(num, 5) > buf.getLength()) {
+              throw new JSchException("invalid prompt count");
+            }
+          } catch (ArithmeticException e) {
             throw new JSchException("invalid prompt count");
           }
           String[] prompt = new String[num];

--- a/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
+++ b/src/main/java/com/jcraft/jsch/UserAuthKeyboardInteractive.java
@@ -121,6 +121,10 @@ class UserAuthKeyboardInteractive extends UserAuth {
           String instruction = Util.byte2str(buf.getString());
           String languate_tag = Util.byte2str(buf.getString());
           int num = buf.getInt();
+          // Min length of one string plus one byte is 5 bytes.
+          if (num < 0 || num * 5 > buf.getLength()) {
+            throw new JSchException("invalid prompt count");
+          }
           String[] prompt = new String[num];
           boolean[] echo = new boolean[num];
           for (int i = 0; i < num; i++) {

--- a/src/test/java/com/jcraft/jsch/ChannelSftpIT.java
+++ b/src/test/java/com/jcraft/jsch/ChannelSftpIT.java
@@ -1,0 +1,207 @@
+package com.jcraft.jsch;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class ChannelSftpIT {
+
+  private static final int timeout = 2000;
+  private static final DigestUtils sha256sum = new DigestUtils(DigestUtils.getSha256Digest());
+  private static final TestLogger jschLogger = TestLoggerFactory.getTestLogger(JSch.class);
+  private static final TestLogger sshdLogger = TestLoggerFactory.getTestLogger(AlgorithmsIT.class);
+
+  @TempDir
+  public Path tmpDir;
+  private Path in;
+  private Path out;
+  private String hash;
+  private Slf4jLogConsumer sshdLogConsumer;
+
+  @Container
+  public GenericContainer<?> sshd = new GenericContainer<>(
+      new ImageFromDockerfile().withFileFromClasspath("ssh_host_rsa_key", "docker/ssh_host_rsa_key")
+          .withFileFromClasspath("ssh_host_rsa_key.pub", "docker/ssh_host_rsa_key.pub")
+          .withFileFromClasspath("ssh_host_ecdsa256_key", "docker/ssh_host_ecdsa256_key")
+          .withFileFromClasspath("ssh_host_ecdsa256_key.pub", "docker/ssh_host_ecdsa256_key.pub")
+          .withFileFromClasspath("ssh_host_ecdsa384_key", "docker/ssh_host_ecdsa384_key")
+          .withFileFromClasspath("ssh_host_ecdsa384_key.pub", "docker/ssh_host_ecdsa384_key.pub")
+          .withFileFromClasspath("ssh_host_ecdsa521_key", "docker/ssh_host_ecdsa521_key")
+          .withFileFromClasspath("ssh_host_ecdsa521_key.pub", "docker/ssh_host_ecdsa521_key.pub")
+          .withFileFromClasspath("ssh_host_ed25519_key", "docker/ssh_host_ed25519_key")
+          .withFileFromClasspath("ssh_host_ed25519_key.pub", "docker/ssh_host_ed25519_key.pub")
+          .withFileFromClasspath("ssh_host_dsa_key", "docker/ssh_host_dsa_key")
+          .withFileFromClasspath("ssh_host_dsa_key.pub", "docker/ssh_host_dsa_key.pub")
+          .withFileFromClasspath("sshd_config", "docker/sshd_config")
+          .withFileFromClasspath("authorized_keys", "docker/authorized_keys")
+          .withFileFromClasspath("Dockerfile", "docker/Dockerfile"))
+      .withExposedPorts(22);
+
+  @BeforeAll
+  public static void beforeAll() {
+    JSch.setLogger(new Slf4jLogger());
+  }
+
+  @BeforeEach
+  public void beforeEach() throws IOException {
+    if (sshdLogConsumer == null) {
+      sshdLogConsumer = new Slf4jLogConsumer(sshdLogger);
+      sshd.followOutput(sshdLogConsumer);
+    }
+
+    in = tmpDir.resolve("in");
+    out = tmpDir.resolve("out");
+    Files.createFile(in);
+    try (OutputStream os = Files.newOutputStream(in)) {
+      byte[] data = new byte[1024];
+      for (int i = 0; i < 1024 * 100; i += 1024) {
+        new Random().nextBytes(data);
+        os.write(data);
+      }
+    }
+    hash = sha256sum.digestAsHex(in);
+
+    jschLogger.clearAll();
+    sshdLogger.clearAll();
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    JSch.setLogger(null);
+    jschLogger.clearAll();
+    sshdLogger.clearAll();
+  }
+
+  @Test
+  public void testGetPutString() throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+
+    try {
+      session.setTimeout(timeout);
+      session.connect();
+      ChannelSftp sftp = (ChannelSftp) session.openChannel("sftp");
+      sftp.connect(timeout);
+      sftp.put(in.toString(), "/root/test");
+      sftp.get("/root/test", out.toString());
+      sftp.disconnect();
+      session.disconnect();
+    } catch (Exception e) {
+      printInfo();
+      throw e;
+    }
+
+    assertEquals(1024L * 100L, Files.size(out));
+    assertEquals(hash, sha256sum.digestAsHex(out));
+  }
+
+  @Test
+  public void testGetPutStream() throws Exception {
+    JSch ssh = createRSAIdentity();
+    Session session = createSession(ssh);
+
+    try {
+      session.setTimeout(timeout);
+      session.connect();
+      ChannelSftp sftp = (ChannelSftp) session.openChannel("sftp");
+      sftp.connect(timeout);
+      try (OutputStream os = sftp.put("/root/test")) {
+        Files.copy(in, os);
+      }
+      try (InputStream is = sftp.get("/root/test")) {
+        Files.copy(is, out);
+      }
+      sftp.disconnect();
+      session.disconnect();
+    } catch (Exception e) {
+      printInfo();
+      throw e;
+    }
+
+    assertEquals(1024L * 100L, Files.size(out));
+    assertEquals(hash, sha256sum.digestAsHex(out));
+  }
+
+  private JSch createRSAIdentity() throws Exception {
+    HostKey hostKey = readHostKey(getResourceFile("docker/ssh_host_rsa_key.pub"));
+    JSch ssh = new JSch();
+    ssh.addIdentity(getResourceFile("docker/id_rsa"), getResourceFile("docker/id_rsa.pub"), null);
+    ssh.getHostKeyRepository().add(hostKey, null);
+    return ssh;
+  }
+
+  private HostKey readHostKey(String fileName) throws Exception {
+    List<String> lines = Files.readAllLines(Paths.get(fileName), UTF_8);
+    String[] split = lines.get(0).split("\\s+");
+    String hostname =
+        String.format(Locale.ROOT, "[%s]:%d", sshd.getHost(), sshd.getFirstMappedPort());
+    return new HostKey(hostname, Base64.getDecoder().decode(split[1]));
+  }
+
+  private Session createSession(JSch ssh) throws Exception {
+    Session session = ssh.getSession("root", sshd.getHost(), sshd.getFirstMappedPort());
+    session.setConfig("StrictHostKeyChecking", "yes");
+    session.setConfig("PreferredAuthentications", "publickey");
+    return session;
+  }
+
+  private void doSftp(Session session, boolean debugException) throws Exception {
+    try {
+      session.setTimeout(timeout);
+      session.connect();
+      ChannelSftp sftp = (ChannelSftp) session.openChannel("sftp");
+      sftp.connect(timeout);
+      sftp.put(in.toString(), "/root/test");
+      sftp.get("/root/test", out.toString());
+      sftp.disconnect();
+      session.disconnect();
+    } catch (Exception e) {
+      if (debugException) {
+        printInfo();
+      }
+      throw e;
+    }
+
+    assertEquals(1024L * 100L, Files.size(out));
+    assertEquals(hash, sha256sum.digestAsHex(out));
+  }
+
+  private void printInfo() {
+    jschLogger.getAllLoggingEvents().stream().map(LoggingEvent::getFormattedMessage)
+        .forEach(System.out::println);
+    sshdLogger.getAllLoggingEvents().stream().map(LoggingEvent::getFormattedMessage)
+        .forEach(System.out::println);
+    System.out.println("");
+    System.out.println("");
+    System.out.println("");
+  }
+
+  private String getResourceFile(String fileName) {
+    return ResourceUtil.getResourceFile(getClass(), fileName);
+  }
+}

--- a/src/test/java/com/jcraft/jsch/ProxyHTTPTest.java
+++ b/src/test/java/com/jcraft/jsch/ProxyHTTPTest.java
@@ -1,0 +1,43 @@
+package com.jcraft.jsch;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
+public class ProxyHTTPTest {
+
+  @Test
+  public void testReadStatus() throws IOException {
+    String expected = "HTTP/1.0 Connection Established\r\n";
+    InputStream is = new ByteArrayInputStream(expected.getBytes(UTF_8));
+    String actual = ProxyHTTP.readStatus(is);
+    assertEquals(expected.length() - 2, actual.length());
+    assertTrue(expected.startsWith(actual));
+  }
+
+  @Test
+  public void testReadStatusLong() throws IOException {
+    String expected = "HTTP/1.0 ";
+    for (int i = 0; i < ProxyHTTP.MAX_STATUS_LEN; i++) {
+      expected += "a";
+    }
+    expected += "\r\n";
+    InputStream is = new ByteArrayInputStream(expected.getBytes(UTF_8));
+    String actual = ProxyHTTP.readStatus(is);
+    assertEquals(ProxyHTTP.MAX_STATUS_LEN, actual.length());
+    assertTrue(expected.length() > actual.length());
+    assertTrue(expected.startsWith(actual));
+  }
+
+  @Test
+  public void testReadStatusEmpty() {
+    InputStream is = new ByteArrayInputStream(new byte[0]);
+    assertThrows(IOException.class, () -> ProxyHTTP.readStatus(is));
+  }
+}


### PR DESCRIPTION
- #1133: bounds check incoming SSH_FXP_DATA responses.
- #1133: cap length of incoming HTTP status response lines.
- #1127: expand on previous SftpATTRS bounds checks to properly close SSH_FX_READDIR handles.
- #1139: add bounds checks when parsing prompts from SSH_MSG_USERAUTH_INFO_REQUEST messages.
- #1127 & #1139: expand upon previous bounds checks to account for arithmetic overflow.