### PR TITLE
Expose local SFTP window/packet size setters as public

### DIFF
--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -46,9 +46,13 @@ public abstract class Channel {
 
   private static final AtomicInteger index = new AtomicInteger();
 
-  // sanity cap for setLocalPacketSize: lmpsize is used to allocate a Buffer of that size
-  // (e.g. ChannelSftp.start()), so an unbounded value could trigger an excessive allocation
-  private static final int MAX_LOCAL_PACKET_SIZE = 16 * 1024 * 1024;
+  // sanity cap for setLocalPacketSize: lmpsize is both used to allocate a Buffer of that size
+  // (e.g. ChannelSftp.start()) and advertised to the server as the max size of a single
+  // CHANNEL_DATA payload it may send us. That payload is wrapped in an SSH packet together with
+  // ~9 bytes of channel-data framing plus padding, so it must stay comfortably under
+  // Session.PACKET_MAX_SIZE (RFC 4253 6.1 Maximum Packet Length) or the resulting packet gets
+  // discarded by the transport layer, killing the connection.
+  private static final int MAX_LOCAL_PACKET_SIZE = Session.PACKET_MAX_SIZE - 4096;
 
   int id;
   volatile int recipient = -1;

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -406,16 +406,35 @@ public abstract class Channel {
     }
   }
 
-  public void setLocalWindowSizeMax(int foo) {
-    this.lwsize_max = foo;
+  public void setLocalWindowSizeMax(int size) {
+    if (isConnected()) {
+      throw new IllegalStateException("local window size max cannot be changed after channel is connected");
+    }
+    if (size <= 0) {
+      throw new IllegalArgumentException("local window size max must be positive: " + size);
+    }
+    this.lwsize_max = size;
   }
 
-  public void setLocalWindowSize(int foo) {
-    this.lwsize = foo;
+  public void setLocalWindowSize(int size) {
+    if (isConnected()) {
+      throw new IllegalStateException("local window size cannot be changed after channel is connected");
+    }
+    if (size <= 0 || size > lwsize_max) {
+      throw new IllegalArgumentException(
+          "local window size must be positive and not exceed local window size max (" + lwsize_max + "): " + size);
+    }
+    this.lwsize = size;
   }
 
-  public void setLocalPacketSize(int foo) {
-    this.lmpsize = foo;
+  public void setLocalPacketSize(int size) {
+    if (isConnected()) {
+      throw new IllegalStateException("local packet size cannot be changed after channel is connected");
+    }
+    if (size <= 0) {
+      throw new IllegalArgumentException("local packet size must be positive: " + size);
+    }
+    this.lmpsize = size;
   }
 
   synchronized void setRemoteWindowSize(long foo) {

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -46,6 +46,10 @@ public abstract class Channel {
 
   private static final AtomicInteger index = new AtomicInteger();
 
+  // sanity cap for setLocalPacketSize: lmpsize is used to allocate a Buffer of that size
+  // (e.g. ChannelSftp.start()), so an unbounded value could trigger an excessive allocation
+  private static final int MAX_LOCAL_PACKET_SIZE = 16 * 1024 * 1024;
+
   int id;
   volatile int recipient = -1;
   protected byte[] type = Util.str2byte("foo");
@@ -431,8 +435,9 @@ public abstract class Channel {
     if (isConnected()) {
       throw new IllegalStateException("local packet size cannot be changed after channel is connected");
     }
-    if (size <= 0) {
-      throw new IllegalArgumentException("local packet size must be positive: " + size);
+    if (size <= 0 || size > MAX_LOCAL_PACKET_SIZE) {
+      throw new IllegalArgumentException(
+          "local packet size must be positive and not exceed " + MAX_LOCAL_PACKET_SIZE + ": " + size);
     }
     this.lmpsize = size;
   }

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -406,15 +406,15 @@ public abstract class Channel {
     }
   }
 
-  void setLocalWindowSizeMax(int foo) {
+  public void setLocalWindowSizeMax(int foo) {
     this.lwsize_max = foo;
   }
 
-  void setLocalWindowSize(int foo) {
+  public void setLocalWindowSize(int foo) {
     this.lwsize = foo;
   }
 
-  void setLocalPacketSize(int foo) {
+  public void setLocalPacketSize(int foo) {
     this.lmpsize = foo;
   }
 

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -438,6 +438,21 @@ public abstract class Channel {
     this.lwsize = size;
   }
 
+  // Session's own flow-control bookkeeping (see SSH_MSG_CHANNEL_DATA/SSH_MSG_CHANNEL_EXTENDED_DATA
+  // handling) needs to update the local window continuously while the channel is connected, and can
+  // legitimately drive it down to 0 before resetting it to lwsize_max. That is a different contract
+  // than the public setLocalWindowSize, which is meant for pre-connect configuration by consumers,
+  // so keep this bookkeeping update package-private and unrestricted (besides the lwsize_max
+  // bound).
+  void updateLocalWindowSize(int size) {
+    if (size < 0 || size > lwsize_max) {
+      throw new IllegalArgumentException(
+          "local window size must not be negative and must not exceed local window size max ("
+              + lwsize_max + "): " + size);
+    }
+    this.lwsize = size;
+  }
+
   public void setLocalPacketSize(int size) {
     if (isConnected()) {
       throw new IllegalStateException(

--- a/src/main/java/com/jcraft/jsch/Channel.java
+++ b/src/main/java/com/jcraft/jsch/Channel.java
@@ -416,7 +416,8 @@ public abstract class Channel {
 
   public void setLocalWindowSizeMax(int size) {
     if (isConnected()) {
-      throw new IllegalStateException("local window size max cannot be changed after channel is connected");
+      throw new IllegalStateException(
+          "local window size max cannot be changed after channel is connected");
     }
     if (size <= 0) {
       throw new IllegalArgumentException("local window size max must be positive: " + size);
@@ -426,22 +427,25 @@ public abstract class Channel {
 
   public void setLocalWindowSize(int size) {
     if (isConnected()) {
-      throw new IllegalStateException("local window size cannot be changed after channel is connected");
+      throw new IllegalStateException(
+          "local window size cannot be changed after channel is connected");
     }
     if (size <= 0 || size > lwsize_max) {
       throw new IllegalArgumentException(
-          "local window size must be positive and not exceed local window size max (" + lwsize_max + "): " + size);
+          "local window size must be positive and not exceed local window size max (" + lwsize_max
+              + "): " + size);
     }
     this.lwsize = size;
   }
 
   public void setLocalPacketSize(int size) {
     if (isConnected()) {
-      throw new IllegalStateException("local packet size cannot be changed after channel is connected");
+      throw new IllegalStateException(
+          "local packet size cannot be changed after channel is connected");
     }
     if (size <= 0 || size > MAX_LOCAL_PACKET_SIZE) {
-      throw new IllegalArgumentException(
-          "local packet size must be positive and not exceed " + MAX_LOCAL_PACKET_SIZE + ": " + size);
+      throw new IllegalArgumentException("local packet size must be positive and not exceed "
+          + MAX_LOCAL_PACKET_SIZE + ": " + size);
     }
     this.lmpsize = size;
   }

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -1978,7 +1978,7 @@ public class Session {
               break;
             }
             int len = length[0];
-            channel.setLocalWindowSize(channel.lwsize - len);
+            channel.updateLocalWindowSize(channel.lwsize - len);
             if (channel.lwsize < channel.lwsize_max / 2) {
               packet.reset();
               buf.putByte((byte) SSH_MSG_CHANNEL_WINDOW_ADJUST);
@@ -1988,7 +1988,7 @@ public class Session {
                 if (!channel.close)
                   write(packet);
               }
-              channel.setLocalWindowSize(channel.lwsize_max);
+              channel.updateLocalWindowSize(channel.lwsize_max);
             }
             break;
 
@@ -2011,7 +2011,7 @@ public class Session {
             channel.write_ext(foo, start[0], length[0]);
 
             len = length[0];
-            channel.setLocalWindowSize(channel.lwsize - len);
+            channel.updateLocalWindowSize(channel.lwsize - len);
             if (channel.lwsize < channel.lwsize_max / 2) {
               packet.reset();
               buf.putByte((byte) SSH_MSG_CHANNEL_WINDOW_ADJUST);
@@ -2021,7 +2021,7 @@ public class Session {
                 if (!channel.close)
                   write(packet);
               }
-              channel.setLocalWindowSize(channel.lwsize_max);
+              channel.updateLocalWindowSize(channel.lwsize_max);
             }
             break;
 

--- a/src/main/java/com/jcraft/jsch/Session.java
+++ b/src/main/java/com/jcraft/jsch/Session.java
@@ -79,7 +79,10 @@ public class Session {
   static final int SSH_MSG_CHANNEL_SUCCESS = 99;
   static final int SSH_MSG_CHANNEL_FAILURE = 100;
 
-  private static final int PACKET_MAX_SIZE = 256 * 1024;
+  // RFC 4253 6.1. Maximum Packet Length: hard ceiling enforced on any incoming decrypted SSH
+  // packet (see read(Buffer) below); package-visible so Channel can bound its local packet size
+  // against it.
+  static final int PACKET_MAX_SIZE = 256 * 1024;
 
   private byte[] V_S; // server version
   private byte[] V_C = Util.str2byte("SSH-2.0-JSCH_" + JSch.VERSION); // client version


### PR DESCRIPTION
ChannelSftp caps every pipelined SFTP READ request at a fixed 32KB local packet size (LOCAL_MAXIMUM_PACKET_SIZE), which limits transfer throughput even with multiple requests in flight. Channel already had setLocalWindowSizeMax/setLocalWindowSize/setLocalPacketSize setters that could raise these values per-channel before connecting, but they were package-private, so callers had no way to tune them.

Making them public lets consumers configure a larger packet/window size from their own code without having to fork the library default.

This enable to catch up throughput penalty and beat sshj implementation in my application nova video player cf. https://github.com/nova-video-player/aos-AVP/issues/1943